### PR TITLE
Instrument link

### DIFF
--- a/GUI/coregui/Models/ComboProperty.cpp
+++ b/GUI/coregui/Models/ComboProperty.cpp
@@ -82,5 +82,5 @@ bool ComboProperty::operator==(const ComboProperty &other) const {
 
 bool ComboProperty::operator<(const ComboProperty &other) const
 {
-    return m_current_value < other.m_current_value && m_values < other.m_values;
+    return m_current_value < other.m_current_value && m_values.size() < other.m_values.size();
 }

--- a/GUI/coregui/Models/ComboProperty.cpp
+++ b/GUI/coregui/Models/ComboProperty.cpp
@@ -15,6 +15,7 @@
 // ************************************************************************** //
 
 #include "ComboProperty.h"
+#include "GUIHelpers.h"
 
 
 ComboProperty::ComboProperty(const QStringList &values, const QString &current_value)
@@ -69,4 +70,18 @@ QString ComboProperty::toString(int index) const
 void ComboProperty::setCachedValue(const QString &name)
 {
     m_cached_value = name;
+}
+
+bool ComboProperty::operator==(const ComboProperty &other) const {
+    if(m_current_value != other.m_current_value) return false;
+    if(m_values != other.m_values) return false;
+//    if(!GUIHelpers::isTheSame(m_values, other.m_values)) return false;
+//    if(m_cached_value != other.m_cached_value) return false;
+//    if(m_cache_contains_GUI_value != other.m_cache_contains_GUI_value) return false;
+    return true;
+}
+
+bool ComboProperty::operator<(const ComboProperty &other) const
+{
+    return m_current_value < other.m_current_value && m_values < other.m_values;
 }

--- a/GUI/coregui/Models/ComboProperty.cpp
+++ b/GUI/coregui/Models/ComboProperty.cpp
@@ -74,8 +74,7 @@ void ComboProperty::setCachedValue(const QString &name)
 
 bool ComboProperty::operator==(const ComboProperty &other) const {
     if(m_current_value != other.m_current_value) return false;
-    if(m_values != other.m_values) return false;
-//    if(!GUIHelpers::isTheSame(m_values, other.m_values)) return false;
+    if(!GUIHelpers::isTheSame(m_values, other.m_values)) return false;
 //    if(m_cached_value != other.m_cached_value) return false;
 //    if(m_cache_contains_GUI_value != other.m_cache_contains_GUI_value) return false;
     return true;

--- a/GUI/coregui/Models/ComboProperty.h
+++ b/GUI/coregui/Models/ComboProperty.h
@@ -35,7 +35,6 @@ public:
     QString getValue() const;
 
     void setValue(const QString &name);
-    bool operator!=(const ComboProperty &other);
     bool isDefined();
 
     QStringList getValues() const;
@@ -61,6 +60,10 @@ public:
     bool cacheContainsGUIValue() const;
     void setCacheContainsGUIFlag(bool flag=true);
 
+    bool operator==(const ComboProperty &other) const;
+    bool operator!=(const ComboProperty &other) const { return !(*this == other); }
+    bool operator<(const ComboProperty &other) const;
+
 private:
     QStringList m_values;
     QStringList m_values_tooltips;
@@ -72,11 +75,6 @@ private:
 inline QString ComboProperty::getValue() const
 {
     return m_current_value;
-}
-
-inline bool ComboProperty::operator!=(const ComboProperty &other)
-{
-    return (getValue() != other.getValue());
 }
 
 inline bool ComboProperty::isDefined()

--- a/GUI/coregui/Models/IntensityDataItem.cpp
+++ b/GUI/coregui/Models/IntensityDataItem.cpp
@@ -38,8 +38,7 @@ IntensityDataItem::IntensityDataItem()
 {
 //    setItemName(Constants::IntensityDataType);
 
-    ComboProperty units;
-//    addProperty(P_AXES_UNITS, units.getVariant())->setVisible(false);
+    ComboProperty units = ComboProperty() << Constants::UnitsNbins;
     addProperty(P_AXES_UNITS, units.getVariant());
 
     addProperty(P_TITLE, QString())->setVisible(false);
@@ -68,6 +67,9 @@ IntensityDataItem::IntensityDataItem()
 
     item = addGroupProperty(P_ZAXIS, Constants::AmplitudeAxisType);
     item->getItem(BasicAxisItem::P_NBINS)->setVisible(false);
+
+    setXaxisTitle("X [nbins]");
+    setYaxisTitle("Y [nbins]");
 
     // name of the file used to serialize given IntensityDataItem
     addProperty(P_FILE_NAME, QStringLiteral("undefined"))->setVisible(false);

--- a/GUI/coregui/Models/ItemFactory.cpp
+++ b/GUI/coregui/Models/ItemFactory.cpp
@@ -53,6 +53,7 @@
 #include "SimulationOptionsItem.h"
 #include "TransformationItem.h"
 #include "VectorItem.h"
+#include "LinkInstrumentItem.h"
 #include <QDebug>
 
 namespace {
@@ -192,6 +193,7 @@ ItemFactory::ItemMap_t initializeItemMap() {
     result[Constants::SimulationOptionsType] = &createInstance<SimulationOptionsItem>;
 
     result[Constants::RealDataType] = &createInstance<RealDataItem>;
+    result[Constants::LinkInstrumentType] = &createInstance<LinkInstrumentItem>;
 
     result[Constants::MinimizerContainerType] = &createInstance<MinimizerContainerItem>;
     result[Constants::MinuitMinimizerType] = &createInstance<MinuitMinimizerItem>;

--- a/GUI/coregui/Models/ItemFactory.cpp
+++ b/GUI/coregui/Models/ItemFactory.cpp
@@ -225,7 +225,7 @@ ItemFactory::ItemMap_t ItemFactory::m_item_map = initializeItemMap();
 SessionItem *ItemFactory::createItem(const QString &model_name,
                                            SessionItem *parent)
 {
-    qDebug() << "ItemFactory::createItem" << model_name;
+    //qDebug() << "ItemFactory::createItem" << model_name;
 
     if(!m_item_map.contains(model_name))
         throw GUIHelpers::Error("ItemFactory::createItem() -> Error: Model name does not exist: "+model_name);
@@ -234,7 +234,7 @@ SessionItem *ItemFactory::createItem(const QString &model_name,
     if(parent) {
         parent->insertItem(-1, result);
     }
-    qDebug() << "       result:" << result;
+    //qDebug() << "       result:" << result;
     return result;
 }
 

--- a/GUI/coregui/Models/JobItemHelper.cpp
+++ b/GUI/coregui/Models/JobItemHelper.cpp
@@ -120,11 +120,11 @@ void JobItemHelper::adjustIntensityDataToInstrument(IntensityDataItem *intensity
         instrument->getDetector()->createDetectorMap(instrument->getBeam(),
                                                      preferrable_units));
 
-    newData->setRawDataVector(intensityDataItem->getOutputData()->getRawDataVector());
-
     if(!newData->hasSameDimensions(*intensityDataItem->getOutputData()))
         throw GUIHelpers::Error("JobItemHelper::adjustIntensityDataToInstrument() -> Error. "
                                 "Dimension of detector doesn't match IntensityData.");
+
+    newData->setRawDataVector(intensityDataItem->getOutputData()->getRawDataVector());
 
     ComboProperty unitsCombo;
     foreach (auto units, instrument->getDetector()->getValidAxesUnits())

--- a/GUI/coregui/Models/JobItemHelper.cpp
+++ b/GUI/coregui/Models/JobItemHelper.cpp
@@ -221,16 +221,17 @@ void JobItemHelper::setIntensityItemAxesUnits(IntensityDataItem *intensityItem,
 void JobItemHelper::setIntensityItemAxesUnits(IntensityDataItem *intensityItem,
                                               const IDetector2D *detector)
 {
-    ComboProperty combo = intensityItem->getItemValue(IntensityDataItem::P_AXES_UNITS)
+    ComboProperty orig = intensityItem->getItemValue(IntensityDataItem::P_AXES_UNITS)
                               .value<ComboProperty>();
 
-    if(!combo.getValues().isEmpty())
-        return;
+//    if(!combo.getValues().isEmpty())
+//        return;
 
-    QString cachedUnits = combo.getCachedValue();
+    QString cachedUnits = orig.getCachedValue();
 
     intensityItem->getItem(IntensityDataItem::P_AXES_UNITS)->setVisible(true);
 
+    ComboProperty combo;
     foreach (auto units, detector->getValidAxesUnits()) {
         combo << getNameFromAxesUnits(units);
     }

--- a/GUI/coregui/Models/LinkInstrumentItem.cpp
+++ b/GUI/coregui/Models/LinkInstrumentItem.cpp
@@ -1,0 +1,34 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Models/LinkInstrumentItem.cpp
+//! @brief     Defines class LinkInstrumentItem
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
+//! @authors   Walter Van Herck, Joachim Wuttke
+//
+// ************************************************************************** //
+
+#include "LinkInstrumentItem.h"
+#include "ComboProperty.h"
+
+const QString LinkInstrumentItem::P_REALDATA_NAME = "RealDataName";
+const QString LinkInstrumentItem::P_INSTRUMENT_ID = "Instrument Id";
+const QString LinkInstrumentItem::P_INSTRUMENT_NAME = "Instrument";
+const QString LinkInstrumentItem::P_INSTRUMENT_COMBO = "Combo";
+
+
+LinkInstrumentItem::LinkInstrumentItem()
+    : SessionItem(Constants::LinkInstrumentType)
+{
+    addProperty(P_REALDATA_NAME, QString());
+    addProperty(P_INSTRUMENT_ID, QString());
+    addProperty(P_INSTRUMENT_NAME, QString());
+    ComboProperty instruments = ComboProperty() << "Undefined";
+    addProperty(P_INSTRUMENT_COMBO, instruments.getVariant());
+}

--- a/GUI/coregui/Models/LinkInstrumentItem.h
+++ b/GUI/coregui/Models/LinkInstrumentItem.h
@@ -1,0 +1,37 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Models/LinkInstrumentItem.h
+//! @brief     Defines class LinkInstrumentItem
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
+//! @authors   Walter Van Herck, Joachim Wuttke
+//
+// ************************************************************************** //
+
+#ifndef LINKINSTRUMENTITEM_H
+#define LINKINSTRUMENTITEM_H
+
+#include "SessionItem.h"
+
+//! The LinkInstrumentItem class is a helper item to link RealDataItem to InstrumentItem.
+//! Contains dynamic ComboProperty with list of all instrument names, which is updated on
+//! every change of instrument name, and on add/remove InstrumentItem.
+//! Handled by temporary (not serializable) model from LinkInstrumentManager.
+
+class BA_CORE_API_ LinkInstrumentItem : public SessionItem
+{
+public:
+    static const QString P_REALDATA_NAME;
+    static const QString P_INSTRUMENT_ID;
+    static const QString P_INSTRUMENT_NAME;
+    static const QString P_INSTRUMENT_COMBO;
+    LinkInstrumentItem();
+};
+
+#endif

--- a/GUI/coregui/Models/ModelMapper.cpp
+++ b/GUI/coregui/Models/ModelMapper.cpp
@@ -15,8 +15,6 @@
 // ************************************************************************** //
 
 #include "SessionModel.h"
-#include <QDebug>
-
 
 ModelMapper::ModelMapper(QObject *parent)
     : QObject(parent)
@@ -258,12 +256,9 @@ void ModelMapper::onDataChanged(const QModelIndex &topLeft, const QModelIndex &b
 
 void ModelMapper::onRowsInserted(const QModelIndex &parent, int first, int /*last*/)
 {
-    qDebug() << "OOO-> ModelMapper::onRowsInserted -> begin()";
     Q_ASSERT(m_item);
 
     SessionItem *newChild = m_model->itemForIndex(parent.child(first, 0));
-    qDebug() << "AAA 1.1" << m_item << m_item->displayName();
-    qDebug() << "AAA 1.2" << newChild << newChild->displayName();
 
     int nestling = nestlingDepth(newChild);
 
@@ -298,17 +293,12 @@ void ModelMapper::onRowsInserted(const QModelIndex &parent, int first, int /*las
     if (nestling > 0) {
         callOnAnyChildChange(newChild);
     }
-
-    qDebug() << "OOO-> ModelMapper::onRowsInserted -> end()";
 }
 
 void ModelMapper::onBeginRemoveRows(const QModelIndex &parent, int first, int /*last*/)
 {
-    qDebug() << "OOO-> ModelMapper::onBeginRemoveRows -> begin()";
     Q_ASSERT(m_item);
     SessionItem *oldChild = m_model->itemForIndex(parent.child(first, 0));
-//    qDebug() << "AAA 1.1" << m_item << m_item->displayName();
-//    qDebug() << "AAA 1.2" << oldChild << oldChild->displayName();
 
     int nestling = nestlingDepth(m_model->itemForIndex(parent));
 
@@ -342,17 +332,11 @@ void ModelMapper::onBeginRemoveRows(const QModelIndex &parent, int first, int /*
 
     if (m_item == oldChild) {
         m_aboutToDelete = parent.child(first, 0);
-        qDebug() << "---------------------------->>>";
-        qDebug() << "ModelMapper::onBeginRemoveRows() -> preparing m_aboutToDelete" << m_aboutToDelete;
     }
-
-    qDebug() << "OOO-> ModelMapper::onBeginRemoveRows -> end()";
 }
 
 void ModelMapper::onRowRemoved(const QModelIndex &parent, int first, int /*last*/)
 {
-    qDebug() << "OOO-> ModelMapper::onRowRemoved -> begin()";
-
     int nestling = nestlingDepth(m_model->itemForIndex(parent));
 
     if (nestling >= 0 || m_model->itemForIndex(parent) == m_item->parent()) {
@@ -362,11 +346,7 @@ void ModelMapper::onRowRemoved(const QModelIndex &parent, int first, int /*last*
     }
 
     if(m_aboutToDelete.isValid() && m_aboutToDelete == parent.child(first, 0)) {
-        qDebug() << "ModelMapper::onRowRemoved() -> clearingMapper";
         clearMapper();
-        qDebug() << "<<<- done ---------------------------";
 
     }
-    qDebug() << "OOO-> ModelMapper::onRowRemoved -> end()";
-
 }

--- a/GUI/coregui/Models/RealDataItem.cpp
+++ b/GUI/coregui/Models/RealDataItem.cpp
@@ -46,9 +46,27 @@ RealDataItem::RealDataItem()
 
     mapper()->setOnPropertyChange(
         [this](const QString &name){
-        if(name == P_NAME && isTag(T_INTENSITY_DATA))
+        if(name == P_NAME && isTag(T_INTENSITY_DATA)) {
             updateIntensityDataFileName();
         }
+
+        else if(name == P_INSTRUMENT_ID) {
+            QString id = getItemValue(P_INSTRUMENT_ID).toString();
+            if(id.isEmpty()) {
+                mapper()->setActive(false);
+                ComboProperty combo;
+                combo << Constants::UnitsNbins;
+                IntensityDataItem *item = intensityDataItem();
+                item->setItemValue(IntensityDataItem::P_AXES_UNITS, combo.getVariant());
+                item->getItem(IntensityDataItem::P_AXES_UNITS)->setVisible(true);
+                item->setXaxisTitle("X [nbins]");
+                item->setYaxisTitle("Y [nbins]");
+                item->setOutputData(ImportDataAssistant::createSimlifiedOutputData(*item->getOutputData()));
+                item->setAxesRangeToData();
+                mapper()->setActive(true);
+            }
+        }
+    }
     );
 
     mapper()->setOnChildrenChange(

--- a/GUI/coregui/Models/RealDataItem.cpp
+++ b/GUI/coregui/Models/RealDataItem.cpp
@@ -25,7 +25,6 @@
 
 const QString RealDataItem::P_INSTRUMENT_ID = "Instrument Id";
 const QString RealDataItem::P_INSTRUMENT_NAME = "Instrument";
-const QString RealDataItem::P_INSTRUMENT_COMBO = "Combo";
 const QString RealDataItem::T_INTENSITY_DATA = "Intensity data";
 
 RealDataItem::RealDataItem()
@@ -34,12 +33,8 @@ RealDataItem::RealDataItem()
 {
     setItemName(QStringLiteral("undefined"));
 
-//    addProperty(P_INSTRUMENT_ID, QString())->setVisible(false);
     addProperty(P_INSTRUMENT_ID, QString());
     addProperty(P_INSTRUMENT_NAME, QString());
-
-    ComboProperty instruments = ComboProperty() << "Undefined";
-    addProperty(P_INSTRUMENT_COMBO, instruments.getVariant());
 
     registerTag(T_INTENSITY_DATA, 1, 1, QStringList() << Constants::IntensityDataType);
     setDefaultTag(T_INTENSITY_DATA);
@@ -51,20 +46,20 @@ RealDataItem::RealDataItem()
         }
 
         else if(name == P_INSTRUMENT_ID) {
-            QString id = getItemValue(P_INSTRUMENT_ID).toString();
-            if(id.isEmpty()) {
-                mapper()->setActive(false);
-                ComboProperty combo;
-                combo << Constants::UnitsNbins;
-                IntensityDataItem *item = intensityDataItem();
-                item->setItemValue(IntensityDataItem::P_AXES_UNITS, combo.getVariant());
-                item->getItem(IntensityDataItem::P_AXES_UNITS)->setVisible(true);
-                item->setXaxisTitle("X [nbins]");
-                item->setYaxisTitle("Y [nbins]");
-                item->setOutputData(ImportDataAssistant::createSimlifiedOutputData(*item->getOutputData()));
-                item->setAxesRangeToData();
-                mapper()->setActive(true);
-            }
+//            QString id = getItemValue(P_INSTRUMENT_ID).toString();
+//            if(id.isEmpty()) {
+//                mapper()->setActive(false);
+//                ComboProperty combo;
+//                combo << Constants::UnitsNbins;
+//                IntensityDataItem *item = intensityDataItem();
+//                item->setItemValue(IntensityDataItem::P_AXES_UNITS, combo.getVariant());
+//                item->getItem(IntensityDataItem::P_AXES_UNITS)->setVisible(true);
+//                item->setXaxisTitle("X [nbins]");
+//                item->setYaxisTitle("Y [nbins]");
+//                item->setOutputData(ImportDataAssistant::createSimlifiedOutputData(*item->getOutputData()));
+//                item->setAxesRangeToData();
+//                mapper()->setActive(true);
+//            }
         }
     }
     );

--- a/GUI/coregui/Models/RealDataItem.cpp
+++ b/GUI/coregui/Models/RealDataItem.cpp
@@ -91,6 +91,9 @@ RealDataItem::RealDataItem()
     });
 
 
+//    registerTag(T_INTENSITY_DATA, 1, 1, QStringList() << Constants::IntensityDataType);
+//    insertItem(0, new IntensityDataItem(), T_INTENSITY_DATA);
+
 
 }
 

--- a/GUI/coregui/Models/RealDataItem.cpp
+++ b/GUI/coregui/Models/RealDataItem.cpp
@@ -110,8 +110,8 @@ void RealDataItem::setOutputData(OutputData<double> *data)
 
 void RealDataItem::linkToInstrument(const InstrumentItem *instrument)
 {
-    if(m_linkedInstrument == instrument)
-        return;
+//    if(m_linkedInstrument == instrument)
+//        return;
 
     m_linkedInstrument = instrument;
     updateToInstrument();

--- a/GUI/coregui/Models/RealDataItem.cpp
+++ b/GUI/coregui/Models/RealDataItem.cpp
@@ -136,6 +136,7 @@ void RealDataItem::updateToInstrument()
     }
 
     else {
+
         JobItemHelper::adjustIntensityDataToInstrument(item, m_linkedInstrument);
 
     }

--- a/GUI/coregui/Models/RealDataItem.cpp
+++ b/GUI/coregui/Models/RealDataItem.cpp
@@ -46,22 +46,6 @@ RealDataItem::RealDataItem()
             updateIntensityDataFileName();
         }
 
-        else if(name == P_INSTRUMENT_ID) {
-//            QString id = getItemValue(P_INSTRUMENT_ID).toString();
-//            if(id.isEmpty()) {
-//                mapper()->setActive(false);
-//                ComboProperty combo;
-//                combo << Constants::UnitsNbins;
-//                IntensityDataItem *item = intensityDataItem();
-//                item->setItemValue(IntensityDataItem::P_AXES_UNITS, combo.getVariant());
-//                item->getItem(IntensityDataItem::P_AXES_UNITS)->setVisible(true);
-//                item->setXaxisTitle("X [nbins]");
-//                item->setYaxisTitle("Y [nbins]");
-//                item->setOutputData(ImportDataAssistant::createSimlifiedOutputData(*item->getOutputData()));
-//                item->setAxesRangeToData();
-//                mapper()->setActive(true);
-//            }
-        }
     }
     );
 
@@ -90,12 +74,14 @@ RealDataItem::RealDataItem()
 
 IntensityDataItem *RealDataItem::intensityDataItem()
 {
-    return const_cast<IntensityDataItem *>(static_cast<const RealDataItem*>(this)->intensityDataItem());
+    return const_cast<IntensityDataItem *>(
+                static_cast<const RealDataItem*>(this)->intensityDataItem());
 }
 
 const IntensityDataItem *RealDataItem::intensityDataItem() const
 {
-    const IntensityDataItem *result = dynamic_cast<const IntensityDataItem *>(getItem(T_INTENSITY_DATA));
+    const IntensityDataItem *result = dynamic_cast<const IntensityDataItem *>(
+                getItem(T_INTENSITY_DATA));
     return result;
 }
 

--- a/GUI/coregui/Models/RealDataItem.cpp
+++ b/GUI/coregui/Models/RealDataItem.cpp
@@ -38,6 +38,7 @@ RealDataItem::RealDataItem()
 
     registerTag(T_INTENSITY_DATA, 1, 1, QStringList() << Constants::IntensityDataType);
     setDefaultTag(T_INTENSITY_DATA);
+    insertItem(0, new IntensityDataItem(), T_INTENSITY_DATA);
 
     mapper()->setOnPropertyChange(
         [this](const QString &name){
@@ -85,11 +86,6 @@ RealDataItem::RealDataItem()
         }
     });
 
-
-//    registerTag(T_INTENSITY_DATA, 1, 1, QStringList() << Constants::IntensityDataType);
-//    insertItem(0, new IntensityDataItem(), T_INTENSITY_DATA);
-
-
 }
 
 IntensityDataItem *RealDataItem::intensityDataItem()
@@ -108,22 +104,15 @@ const IntensityDataItem *RealDataItem::intensityDataItem() const
 void RealDataItem::setOutputData(OutputData<double> *data)
 {
     IntensityDataItem *item = intensityDataItem();
-    if(!item) {
-        item = dynamic_cast<IntensityDataItem *>(
-            this->model()->insertNewItem(Constants::IntensityDataType, this->index()));
-        ComboProperty combo;
-        combo << Constants::UnitsNbins;
-        item->setItemValue(IntensityDataItem::P_AXES_UNITS, combo.getVariant());
-        item->getItem(IntensityDataItem::P_AXES_UNITS)->setVisible(true);
-        item->setXaxisTitle("X [nbins]");
-        item->setYaxisTitle("Y [nbins]");
-    }
-
+    Q_ASSERT(item);
     item->setOutputData(data);
 }
 
 void RealDataItem::linkToInstrument(const InstrumentItem *instrument)
 {
+    if(m_linkedInstrument == instrument)
+        return;
+
     m_linkedInstrument = instrument;
     updateToInstrument();
 }

--- a/GUI/coregui/Models/RealDataItem.h
+++ b/GUI/coregui/Models/RealDataItem.h
@@ -32,7 +32,7 @@ public:
     static const QString P_INSTRUMENT_NAME;
     static const QString P_INSTRUMENT_COMBO;
     static const QString T_INTENSITY_DATA;
-    explicit RealDataItem();
+    RealDataItem();
 
     IntensityDataItem *intensityDataItem();
     const IntensityDataItem *intensityDataItem() const;

--- a/GUI/coregui/Models/RealDataItem.h
+++ b/GUI/coregui/Models/RealDataItem.h
@@ -30,7 +30,6 @@ class BA_CORE_API_ RealDataItem : public SessionItem
 public:
     static const QString P_INSTRUMENT_ID;
     static const QString P_INSTRUMENT_NAME;
-    static const QString P_INSTRUMENT_COMBO;
     static const QString T_INTENSITY_DATA;
     RealDataItem();
 

--- a/GUI/coregui/Models/RealDataModel.cpp
+++ b/GUI/coregui/Models/RealDataModel.cpp
@@ -41,6 +41,7 @@ void RealDataModel::loadNonXMLData(const QString &projectDir)
             = dynamic_cast<RealDataItem *>(itemForIndex(index(i, 0, QModelIndex())));
         ImportDataAssistant::loadIntensityData(realDataItem, projectDir);
     }
+    emit modelLoaded();
 }
 
 //! Saves JobItem's OutputData to the projectDir

--- a/GUI/coregui/Models/RealDataModel.h
+++ b/GUI/coregui/Models/RealDataModel.h
@@ -32,6 +32,9 @@ public:
     void loadNonXMLData(const QString &projectDir);
     void saveNonXMLData(const QString &projectDir);
 
+signals:
+    void modelLoaded();
+
 };
 
 #endif // REALDATAMODEL_H

--- a/GUI/coregui/Models/item_constants.h
+++ b/GUI/coregui/Models/item_constants.h
@@ -157,6 +157,7 @@ const ModelType RegionOfInterestType = "RegionOfInterest";
 const ModelType SimulationOptionsType = "SimulationOptions";
 
 const ModelType RealDataType = "RealData";
+const ModelType LinkInstrumentType = "LinkInstrument";
 
 const ModelType MinimizerContainerType = "MinimizerContainer";
 const ModelType MinuitMinimizerType = "Minuit2";

--- a/GUI/coregui/Views/ImportDataWidgets/ImportDataAssistant.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/ImportDataAssistant.cpp
@@ -113,16 +113,23 @@ OutputData<double> *ImportDataAssistant::createSimlifiedOutputData(const OutputD
     return result;
 }
 
+bool ImportDataAssistant::hasSameDimensions(const InstrumentItem *instrumentItem,
+                                            const RealDataItem *realDataItem)
+{
+    QString message;
+    return hasSameDimensions(instrumentItem, realDataItem, message);
+}
+
 //! Returns trues if [nxbin X nybin] of the detector is the same as in realData.
 
 bool ImportDataAssistant::hasSameDimensions(const InstrumentItem *instrumentItem,
-                              const RealDataItem *realDataItemItem, QString &message)
+                              const RealDataItem *realDataItem, QString &message)
 {
     bool isSame(true);
     message.clear();
 
     int nxData(0), nyData(0);
-    realDataShape(realDataItemItem, nxData, nyData);
+    realDataShape(realDataItem, nxData, nyData);
 
     int nxDetector(0), nyDetector(0);
     detectorShape(instrumentItem, nxDetector, nyDetector);

--- a/GUI/coregui/Views/ImportDataWidgets/ImportDataAssistant.h
+++ b/GUI/coregui/Views/ImportDataWidgets/ImportDataAssistant.h
@@ -18,11 +18,11 @@
 #define IMPORTDATAASSISTANT_H
 
 #include "WinDllMacros.h"
+#include <QString>
 
 template <class T> class OutputData;
 class RealDataItem;
 class InstrumentItem;
-class QString;
 
 //! The ImportDataAssistant class provides utility methods to import data files.
 
@@ -37,7 +37,11 @@ public:
     static OutputData<double> *createSimlifiedOutputData(const OutputData<double> &data);
 
     static bool hasSameDimensions(const InstrumentItem *instrumentItem,
-                                  const RealDataItem *realDataItemItem, QString &message);
+                                  const RealDataItem *realDataItem);
+
+    static bool hasSameDimensions(const InstrumentItem *instrumentItem,
+                                  const RealDataItem *realDataItem,
+                                  QString &message);
 
     static void realDataShape(const RealDataItem *realData, int &nx, int &ny);
 

--- a/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.cpp
@@ -96,7 +96,7 @@ void LinkInstrumentManager::setOnRealDataPropertyChange(SessionItem *dataItem, c
         } else {
             QString prevName = instrumentNameFromIdentifier(currentIdentifier);
             qDebug() << "AAAAA 1.3" << prevName;
-            dataItem->setItemValue(RealDataItem::P_INSTRUMENT_NAME, prevName);
+//            dataItem->setItemValue(RealDataItem::P_INSTRUMENT_NAME, prevName);
             qDebug() << "AAAAA 1.4";
             combo.setValue(prevName);
 //            realDataItem->mapper()->setActive(false);

--- a/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.cpp
@@ -102,7 +102,7 @@ void LinkInstrumentManager::setOnRealDataPropertyChange(SessionItem *dataItem, c
 //            realDataItem->mapper()->setActive(false);
 
             dataItem->setItemValue(RealDataItem::P_INSTRUMENT_COMBO, combo.getVariant());
-            //dataItem->getItem(RealDataItem::P_INSTRUMENT_COMBO)->emitDataChanged();
+            dataItem->getItem(RealDataItem::P_INSTRUMENT_COMBO)->emitDataChanged(Qt::DisplayRole);
 //            realDataItem->mapper()->setActive(true);
 
             qDebug() << "AAAAA 1.5";

--- a/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.cpp
@@ -27,12 +27,13 @@
 #include "IntensityDataItem.h"
 #include "DomainObjectBuilder.h"
 #include "Instrument.h"
+#include "LinkInstrumentItem.h"
 #include <QMessageBox>
 #include <QPushButton>
 #include <QDebug>
 
 namespace {
-const QString undefinedInstrument = "Undefined";
+const QString undefinedInstrumentName = "Undefined";
 }
 
 LinkInstrumentManager::LinkInstrumentManager(QObject *parent)
@@ -47,16 +48,16 @@ void LinkInstrumentManager::setModels(InstrumentModel *instrumentModel, RealData
 {
     setInstrumentModel(instrumentModel);
     setRealDataModel(realDataModel);
-    updateInstrumentMap();
+    updateLinks();
 }
+
 
 void LinkInstrumentManager::setOnInstrumentPropertyChange(SessionItem *instrument, const QString &property)
 {
     Q_ASSERT(instrument);
     qDebug() << "LinkInstrumentManager::setOnInstrumentPropertyChange" << instrument->itemName() << property;
-    if(property == SessionItem::P_NAME) {
-//        InstrumentInfo& info = getInstrumentInfo(instrument);
-//        info.m_name = instrument->itemName();
+    if(property == SessionItem::P_NAME) {        
+        updateLinks();
     }
 }
 
@@ -64,23 +65,56 @@ void LinkInstrumentManager::setOnRealDataPropertyChange(SessionItem *dataItem, c
 {
     qDebug() << "AAAAA" << dataItem << property;
     if(property == RealDataItem::P_INSTRUMENT_COMBO) {
+        QString currentIdentifier = dataItem->getItemValue(RealDataItem::P_INSTRUMENT_ID).toString();
         ComboProperty combo = dataItem->getItemValue(RealDataItem::P_INSTRUMENT_COMBO).value<ComboProperty>();
+
+        qDebug() << " AAAA";
+        qDebug() << " AAAA";
+        qDebug() << " AAAA 0.1" << combo.getValue();
+
         QString instrName = combo.getValue();
 
+        QString identifier = instrumentIdentifierFromName(instrName);
 
-        int index = m_instrumentNames.indexOf(instrName);
-        QString identifier;
-        if(index >= 0)
-            identifier = m_instrumentVec[index].m_identifier;
+        if(identifier == currentIdentifier)
+            return;
+
+        qDebug() << " AAAA 0.2";
 
         RealDataItem *realDataItem = dynamic_cast<RealDataItem *>(dataItem);
         Q_ASSERT(realDataItem);
 
+
+        qDebug() << " AAAAAAA" << combo.getValue() << combo.getCachedValue() << currentIdentifier << identifier;
+
         if(canLinkDataToInstrument(realDataItem, getInstrument(identifier))) {
+            qDebug() << "AAAAA 1.1";
             dataItem->setItemValue(RealDataItem::P_INSTRUMENT_ID, identifier);
             dataItem->setItemValue(RealDataItem::P_INSTRUMENT_NAME, instrName);
-            realDataItem->linkToInstrument(getInstrument(identifier));
+            qDebug() << "AAAAA 1.2";
+//            realDataItem->linkToInstrument(getInstrument(identifier));
+        } else {
+            QString prevName = instrumentNameFromIdentifier(currentIdentifier);
+            qDebug() << "AAAAA 1.3" << prevName;
+            dataItem->setItemValue(RealDataItem::P_INSTRUMENT_NAME, prevName);
+            qDebug() << "AAAAA 1.4";
+            combo.setValue(prevName);
+//            realDataItem->mapper()->setActive(false);
+
+            dataItem->setItemValue(RealDataItem::P_INSTRUMENT_COMBO, combo.getVariant());
+            //dataItem->getItem(RealDataItem::P_INSTRUMENT_COMBO)->emitDataChanged();
+//            realDataItem->mapper()->setActive(true);
+
+            qDebug() << "AAAAA 1.5";
         }
+    }
+
+    else if(property == RealDataItem::P_INSTRUMENT_ID) {
+        qDebug() << "AAAAA 2.1";
+        RealDataItem *realDataItem = dynamic_cast<RealDataItem *>(dataItem);
+        QString identifier = dataItem->getItemValue(RealDataItem::P_INSTRUMENT_ID).toString();
+        realDataItem->linkToInstrument(getInstrument(identifier));
+        qDebug() << "AAAAA 2.2";
     }
 
 }
@@ -89,18 +123,18 @@ void LinkInstrumentManager::setInstrumentModel(InstrumentModel *model)
 {
     if (m_instrumentModel) {
         disconnect(m_instrumentModel, SIGNAL(rowsInserted(QModelIndex, int, int)),
-                   this, SLOT(updateInstrumentMap()));
+                   this, SLOT(updateLinks()));
         disconnect(m_instrumentModel, SIGNAL(rowsRemoved(QModelIndex, int, int)),
-                   this, SLOT(updateInstrumentMap()));
+                   this, SLOT(updateLinks()));
     }
 
     m_instrumentModel = model;
 
     if (m_instrumentModel) {
         connect(m_instrumentModel, SIGNAL(rowsInserted(QModelIndex, int, int)),
-                   this, SLOT(updateInstrumentMap()));
+                   this, SLOT(updateLinks()));
         connect(m_instrumentModel, SIGNAL(rowsRemoved(QModelIndex, int, int)),
-                   this, SLOT(updateInstrumentMap()));
+                   this, SLOT(updateLinks()));
     }
 
 }
@@ -109,29 +143,19 @@ void LinkInstrumentManager::setRealDataModel(RealDataModel *model)
 {
     if (m_realDataModel) {
         disconnect(m_realDataModel, SIGNAL(rowsInserted(QModelIndex, int, int)),
-                   this, SLOT(updateInstrumentMap()));
+                   this, SLOT(updateRealDataMap()));
         disconnect(m_realDataModel, SIGNAL(rowsRemoved(QModelIndex, int, int)),
-                   this, SLOT(updateInstrumentMap()));
+                   this, SLOT(updateRealDataMap()));
     }
 
     m_realDataModel = model;
 
     if (m_realDataModel) {
         connect(m_realDataModel, SIGNAL(rowsInserted(QModelIndex, int, int)),
-                   this, SLOT(updateInstrumentMap()));
+                   this, SLOT(updateRealDataMap()));
         connect(m_realDataModel, SIGNAL(rowsRemoved(QModelIndex, int, int)),
-                   this, SLOT(updateInstrumentMap()));
+                   this, SLOT(updateRealDataMap()));
     }
-}
-
-LinkInstrumentManager::InstrumentInfo &LinkInstrumentManager::getInstrumentInfo(SessionItem *item)
-{
-    auto it = m_instrumentInfo.find(item);
-    if(it == m_instrumentInfo.end())
-        throw GUIHelpers::Error("LinkInstrumentManager::getInstrumentInfo() -> Error. No such "
-                                "instrument");
-
-    return it.value();
 }
 
 //! Returns name of the instrument from identifier
@@ -142,7 +166,18 @@ QString LinkInstrumentManager::instrumentNameFromIdentifier(const QString &ident
         if(m_instrumentVec[i].m_identifier == identifier)
             return m_instrumentVec[i].m_name;
 
-    return undefinedInstrument;
+    return undefinedInstrumentName;
+}
+
+//! Returns instrument's identifier from its name
+
+QString LinkInstrumentManager::instrumentIdentifierFromName(const QString &name)
+{
+    for(int i=0; i<m_instrumentVec.size(); ++i)
+        if(m_instrumentVec[i].m_name == name)
+            return m_instrumentVec[i].m_identifier;
+
+    return QString();
 }
 
 InstrumentItem *LinkInstrumentManager::getInstrument(const QString &identifier)
@@ -152,6 +187,14 @@ InstrumentItem *LinkInstrumentManager::getInstrument(const QString &identifier)
             return m_instrumentVec[i].m_instrument;
 
     return nullptr;
+}
+
+QStringList LinkInstrumentManager::instrumentNames() const
+{
+    QStringList result = QStringList() << undefinedInstrumentName;
+    for(int i=0; i<m_instrumentVec.size(); ++i)
+        result.append(m_instrumentVec[i].m_name);
+    return result;
 }
 
 bool LinkInstrumentManager::canLinkDataToInstrument(RealDataItem *realDataItem,
@@ -193,13 +236,18 @@ bool LinkInstrumentManager::canLinkDataToInstrument(RealDataItem *realDataItem,
     return canLink;
 }
 
+void LinkInstrumentManager::updateLinks()
+{
+    updateInstrumentMap();
+    updateRealDataMap();
+}
+
 
 void LinkInstrumentManager::updateInstrumentMap()
 {
     Q_ASSERT(m_realDataModel);
 
-    m_instrumentNames.clear();
-    m_instrumentInfo.clear();
+//    m_instrumentInfo.clear();
     m_instrumentVec.clear();
     foreach(SessionItem *item, m_instrumentModel->topItems(Constants::InstrumentType)) {
         item->mapper()->unsubscribe(this);
@@ -213,26 +261,23 @@ void LinkInstrumentManager::updateInstrumentMap()
         info.m_name = item->itemName();
         info.m_identifier = item->getItemValue(InstrumentItem::P_IDENTIFIER).toString();
         info.m_instrument = dynamic_cast<InstrumentItem *>(item);
-        m_instrumentInfo[item] = info;
-        m_instrumentNames.push_back(item->itemName());
+//        m_instrumentInfo[item] = info;
         m_instrumentVec.append(info);
     }
+}
 
-    qDebug() << "XXXX LinkInstrumentManager::updateInstrumentMap()" << m_instrumentNames;
-
+void LinkInstrumentManager::updateRealDataMap()
+{
     foreach(SessionItem *dataItem, m_realDataModel->topItems(Constants::RealDataType)) {
         dataItem->mapper()->unsubscribe(this);
 
-//        ComboProperty combo = dataItem->getItemValue(RealDataItem::P_INSTRUMENT_COMBO).value<ComboProperty>();
-
         QString identifier = dataItem->getItemValue(RealDataItem::P_INSTRUMENT_ID).toString();
         QString instrName = instrumentNameFromIdentifier(identifier);
-        if(instrName == undefinedInstrument) {
+        if(instrName == undefinedInstrumentName) {
             dataItem->setItemValue(RealDataItem::P_INSTRUMENT_ID, QString());
         }
 
-        ComboProperty combo;
-        combo << undefinedInstrument << m_instrumentNames;
+        ComboProperty combo = ComboProperty() << instrumentNames();
         combo.setValue(instrName);
 
         dataItem->setItemValue(RealDataItem::P_INSTRUMENT_COMBO, combo.getVariant());
@@ -245,5 +290,6 @@ void LinkInstrumentManager::updateInstrumentMap()
         }, this);
 
     }
+
 }
 

--- a/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.cpp
@@ -21,6 +21,7 @@
 #include "RealDataItem.h"
 #include "ImportDataAssistant.h"
 #include "AxesItems.h"
+#include "DetectorItems.h"
 #include <QMessageBox>
 #include <QPushButton>
 #include <QDebug>
@@ -167,7 +168,12 @@ void LinkInstrumentManager::onInstrumentChildChange(InstrumentItem *instrument, 
     if(child == nullptr)
         return;
 
-    if(child->itemName() == BasicAxisItem::P_NBINS) {
+    qDebug() << "SSS 1.1" << child->modelType() << child->itemName();
+    qDebug() << "SSS 1.1" << child->parent()->modelType() << child->parent()->itemName();
+
+
+    if(child->itemName() == BasicAxisItem::P_NBINS ||
+       child->parent()->itemName() == DetectorItem::P_DETECTOR) {
         onInstrumentBinningChange(instrument);
     } else {
         onInstrumentLayoutChange(instrument);

--- a/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.cpp
@@ -19,20 +19,11 @@
 #include "RealDataModel.h"
 #include "InstrumentItem.h"
 #include "RealDataItem.h"
-#include "ComboProperty.h"
-#include "SessionItem.h"
-#include "GUIHelpers.h"
-#include "JobItemHelper.h"
 #include "ImportDataAssistant.h"
-#include "IntensityDataItem.h"
-#include "DomainObjectBuilder.h"
-#include "Instrument.h"
-#include "LinkInstrumentItem.h"
 #include "AxesItems.h"
 #include <QMessageBox>
 #include <QPushButton>
 #include <QDebug>
-
 
 namespace {
 const QString undefinedInstrumentName = "Undefined";
@@ -51,6 +42,8 @@ LinkInstrumentManager::LinkInstrumentManager(QObject *parent)
 {
 }
 
+//! Sets models and builds initial links.
+
 void LinkInstrumentManager::setModels(InstrumentModel *instrumentModel,
                                       RealDataModel *realDataModel)
 {
@@ -61,81 +54,7 @@ void LinkInstrumentManager::setModels(InstrumentModel *instrumentModel,
     updateLinks();
 }
 
-void LinkInstrumentManager::setOnInstrumentPropertyChange(SessionItem *instrument, const QString &property)
-{
-    Q_ASSERT(instrument);
-    qDebug() << "LinkInstrumentManager::setOnInstrumentPropertyChange" << instrument->itemName() << property;
-    if(property == SessionItem::P_NAME || property == InstrumentItem::P_IDENTIFIER) {
-        updateInstrumentMap();
-    }
-}
-
-void LinkInstrumentManager::setOnRealDataPropertyChange(SessionItem *dataItem, const QString &property)
-{
-    qDebug() << "AAAAA setOnRealDataPropertyChange" << dataItem << property;
-    if(property == RealDataItem::P_INSTRUMENT_ID) {
-        qDebug() << "AAAAA 2.1";
-        RealDataItem *realDataItem = dynamic_cast<RealDataItem *>(dataItem);
-        QString identifier = dataItem->getItemValue(RealDataItem::P_INSTRUMENT_ID).toString();
-        realDataItem->linkToInstrument(getInstrument(identifier));
-        qDebug() << "AAAAA 2.2";
-    }
-}
-
-void LinkInstrumentManager::onInstrumentChildChange(SessionItem *instrument, SessionItem *child)
-{
-    qDebug() << "onInstrumentChildChange" << instrument->modelType() << child->modelType() << child->itemName();
-    if(child->itemName() == BasicAxisItem::P_NBINS)
-        onInstrumentBinningChange(instrument);
-}
-
-//! Updates map of instruments on insert/remove instrument.
-
-void LinkInstrumentManager::onInstrumentRowsChange(const QModelIndex &parent, int, int)
-{
-    // valid parent means not an instrument (which is top level item) but something below
-    if(parent.isValid())
-        return;
-
-    updateInstrumentMap();
-    updateLinks();
-}
-
-//! Updates map of data on insert/remove event.
-
-void LinkInstrumentManager::onRealDataRowsChange(const QModelIndex &parent, int, int)
-{
-    // valid parent means not a data (which is top level item) but something below
-    if(parent.isValid())
-        return;
-
-    updateRealDataMap();
-    updateLinks();
-}
-
-
-//! Returns name of the instrument from identifier
-
-QString LinkInstrumentManager::instrumentNameFromIdentifier(const QString &identifier)
-{
-    for(int i=0; i<m_instrumentVec.size(); ++i)
-        if(m_instrumentVec[i].m_identifier == identifier)
-            return m_instrumentVec[i].m_name;
-
-    throw GUIHelpers::Error("LinkInstrumentManager::instrumentNameFromIdentifier() -> Error. "
-                            "Unknown instrument identifier.");
-}
-
-//! Returns instrument's identifier from its name
-
-//QString LinkInstrumentManager::instrumentIdentifierFromName(const QString &name)
-//{
-//    for(int i=0; i<m_instrumentVec.size(); ++i)
-//        if(m_instrumentVec[i].m_name == name)
-//            return m_instrumentVec[i].m_identifier;
-
-//    return QString();
-//}
+//! Returns InstrumentItem for given identifier.
 
 InstrumentItem *LinkInstrumentManager::getInstrument(const QString &identifier)
 {
@@ -146,6 +65,8 @@ InstrumentItem *LinkInstrumentManager::getInstrument(const QString &identifier)
     return nullptr;
 }
 
+//! Returns list of instrument names including artificial name "Undefined".
+
 QStringList LinkInstrumentManager::instrumentNames() const
 {
     QStringList result;
@@ -153,6 +74,8 @@ QStringList LinkInstrumentManager::instrumentNames() const
         result.append(m_instrumentVec[i].m_name);
     return result;
 }
+
+//! Returns combo index for instrument selector from given identifier.
 
 int LinkInstrumentManager::instrumentComboIndex(const QString &identifier)
 {
@@ -163,16 +86,16 @@ int LinkInstrumentManager::instrumentComboIndex(const QString &identifier)
     return -1; // no such identifier exists
 }
 
+//! Returns instrument identifier from given index in combo instrument selector.
+
 QString LinkInstrumentManager::instrumentIdentifier(int comboIndex)
 {
     Q_ASSERT(comboIndex >= 0 && comboIndex < m_instrumentVec.size());
     return m_instrumentVec[comboIndex].m_identifier;
 }
 
-//bool LinkInstrumentManager::canLinkDataToInstrument(RealDataItem *realDataItem,
-//                                                    InstrumentItem *instrumentItem)
-//{
-//}
+//! Returns true if RealDataItem can be linked to the instrument (same number of bins).
+//! Also offers dialog to adjust instrument to match shape of real data.
 
 bool LinkInstrumentManager::canLinkDataToInstrument(const RealDataItem *realDataItem,
                                                     const QString &identifier)
@@ -214,6 +137,69 @@ bool LinkInstrumentManager::canLinkDataToInstrument(const RealDataItem *realData
     return canLink;
 }
 
+//! Calls rebuild of instrument map if the name or identifier of the instrument have changed.
+
+void LinkInstrumentManager::setOnInstrumentPropertyChange(SessionItem *instrument,
+                                                          const QString &property)
+{
+    Q_ASSERT(instrument);
+    if(property == SessionItem::P_NAME || property == InstrumentItem::P_IDENTIFIER) {
+        updateInstrumentMap();
+    }
+}
+
+//! Link or re-link RealDataItem to the instrument on identifier change.
+
+void LinkInstrumentManager::setOnRealDataPropertyChange(SessionItem *dataItem,
+                                                        const QString &property)
+{
+    if(property == RealDataItem::P_INSTRUMENT_ID) {
+        RealDataItem *realDataItem = dynamic_cast<RealDataItem *>(dataItem);
+        QString identifier = dataItem->getItemValue(RealDataItem::P_INSTRUMENT_ID).toString();
+        realDataItem->linkToInstrument(getInstrument(identifier));
+    }
+}
+
+//! Perform actions on instrument children change.
+
+void LinkInstrumentManager::onInstrumentChildChange(InstrumentItem *instrument, SessionItem *child)
+{
+    if(child == nullptr)
+        return;
+
+    if(child->itemName() == BasicAxisItem::P_NBINS) {
+        onInstrumentBinningChange(instrument);
+    } else {
+        onInstrumentLayoutChange(instrument);
+    }
+}
+
+//! Updates map of instruments on insert/remove InstrumentItem event.
+
+void LinkInstrumentManager::onInstrumentRowsChange(const QModelIndex &parent, int, int)
+{
+    // valid parent means not an instrument (which is top level item) but something below
+    if(parent.isValid())
+        return;
+
+    updateInstrumentMap();
+    updateLinks();
+}
+
+//! Updates map of data on insert/remove RealDataItem event.
+
+void LinkInstrumentManager::onRealDataRowsChange(const QModelIndex &parent, int, int)
+{
+    // valid parent means not a data (which is top level item) but something below
+    if(parent.isValid())
+        return;
+
+    updateRealDataMap();
+    updateLinks();
+}
+
+//! Runs through all RealDataItem and check all links.
+
 void LinkInstrumentManager::updateLinks()
 {
     foreach(SessionItem *item, m_realDataModel->topItems(Constants::RealDataType)) {
@@ -224,44 +210,48 @@ void LinkInstrumentManager::updateLinks()
         InstrumentItem *instrumentItem = getInstrument(identifier);
 
         if(!instrumentItem) {
+            // if no instrument with P_INSTRUMENT_ID exists, break the link
             realDataItem->setItemValue(RealDataItem::P_INSTRUMENT_ID, QString());
         } else {
+            // refresh the link to update axes
             realDataItem->linkToInstrument(instrumentItem);
         }
-
     }
 }
 
+//! Builds the map of existing instruments, their names, identifiers and sets up callbacks.
 
 void LinkInstrumentManager::updateInstrumentMap()
 {
     m_instrumentVec.clear();
     m_instrumentVec.append(InstrumentInfo()); // undefined instrument
     foreach(SessionItem *item, m_instrumentModel->topItems(Constants::InstrumentType)) {
-        item->mapper()->unsubscribe(this);
+        InstrumentItem *instrumentItem = dynamic_cast<InstrumentItem *>(item);
+        instrumentItem->mapper()->unsubscribe(this);
 
-        item->mapper()->setOnPropertyChange(
+        instrumentItem->mapper()->setOnPropertyChange(
                     [this, item](const QString &name)
         {
             setOnInstrumentPropertyChange(item, name);
         }, this);
 
-        item->mapper()->setOnAnyChildChange(
-            [this, item] (SessionItem* child)
+        instrumentItem->mapper()->setOnAnyChildChange(
+            [this, instrumentItem] (SessionItem* child)
         {
-            onInstrumentChildChange(item, child);
+            onInstrumentChildChange(instrumentItem, child);
         }, this);
-
 
         InstrumentInfo info;
         info.m_name = item->itemName();
         info.m_identifier = item->getItemValue(InstrumentItem::P_IDENTIFIER).toString();
-        info.m_instrument = dynamic_cast<InstrumentItem *>(item);
+        info.m_instrument = instrumentItem;
         m_instrumentVec.append(info);
     }
 
     emit instrumentMapUpdated();
 }
+
+//! Sets callbacks for all RealDataItem.
 
 void LinkInstrumentManager::updateRealDataMap()
 {
@@ -275,28 +265,48 @@ void LinkInstrumentManager::updateRealDataMap()
         }, this);
 
     }
-
 }
 
 //! Runs through all RealDataItem and break the link, if instrument binning doesn't match the data.
 
-void LinkInstrumentManager::onInstrumentBinningChange(SessionItem *changedInstrument)
+void LinkInstrumentManager::onInstrumentBinningChange(InstrumentItem *changedInstrument)
 {
-    Q_ASSERT(changedInstrument);
+    foreach(RealDataItem *realDataItem, linkedItems(changedInstrument)) {
+        if(!ImportDataAssistant::hasSameDimensions(changedInstrument, realDataItem)) {
+            qDebug() << "Breaking the link ";
+            realDataItem->setItemValue(RealDataItem::P_INSTRUMENT_ID, QString());
+        }
+    }
+}
 
+//! Runs through all RealDataItem and refresh linking to match possible change in detector
+//! axes definition.
+
+void LinkInstrumentManager::onInstrumentLayoutChange(InstrumentItem *changedInstrument)
+{
+    foreach(RealDataItem *realDataItem, linkedItems(changedInstrument)) {
+        qDebug() << "Changing layout";
+        realDataItem->linkToInstrument(changedInstrument);
+    }
+}
+
+//! Returns list of RealDataItem's linked to given instrument.
+
+QList<RealDataItem *> LinkInstrumentManager::linkedItems(InstrumentItem *instrumentItem)
+{
+    QList<RealDataItem *> result;
     foreach(SessionItem *item, m_realDataModel->topItems(Constants::RealDataType)) {
         RealDataItem *realDataItem = dynamic_cast<RealDataItem *>(item);
 
-        QString identifier = realDataItem->getItemValue(RealDataItem::P_INSTRUMENT_ID).toString();
-        InstrumentItem *instrumentItem = getInstrument(identifier);
-        if(instrumentItem == changedInstrument) {
-            QString message;
-            if(!ImportDataAssistant::hasSameDimensions(instrumentItem, realDataItem, message)) {
-                qDebug() << "Breaking the link " << identifier;
-                realDataItem->setItemValue(RealDataItem::P_INSTRUMENT_ID, QString());
-            }
-        }
+        QString linkedIdentifier
+            = realDataItem->getItemValue(RealDataItem::P_INSTRUMENT_ID).toString();
+        QString instrumentIdentifier
+            = instrumentItem->getItemValue(InstrumentItem::P_IDENTIFIER).toString();
+
+        if(linkedIdentifier == instrumentIdentifier)
+            result.append(realDataItem);
     }
+    return result;
 }
 
 //! Sets connections for instrument model.

--- a/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.cpp
@@ -134,6 +134,8 @@ void LinkInstrumentManager::setRealDataModel(RealDataModel *model)
                    this, SLOT(onRealDataRowsChange(QModelIndex, int, int)));
         disconnect(m_realDataModel, SIGNAL(rowsRemoved(QModelIndex, int, int)),
                    this, SLOT(onRealDataRowsChange(QModelIndex, int, int)));
+        disconnect(m_realDataModel, SIGNAL(modelLoaded()),
+                   this, SLOT(updateLinks()));
     }
 
     m_realDataModel = model;
@@ -143,6 +145,8 @@ void LinkInstrumentManager::setRealDataModel(RealDataModel *model)
                    this, SLOT(onRealDataRowsChange(QModelIndex, int, int)));
         connect(m_realDataModel, SIGNAL(rowsRemoved(QModelIndex, int, int)),
                    this, SLOT(onRealDataRowsChange(QModelIndex, int, int)));
+        connect(m_realDataModel, SIGNAL(modelLoaded()),
+                   this, SLOT(updateLinks()));
     }
 }
 

--- a/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.h
+++ b/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.h
@@ -40,7 +40,7 @@ public:
     class InstrumentInfo
     {
     public:
-        InstrumentInfo() : m_instrument(0){}
+        InstrumentInfo();
         QString m_identifier;
         QString m_name;
         InstrumentItem *m_instrument;
@@ -49,6 +49,9 @@ public:
     explicit LinkInstrumentManager(QObject *parent =  0);
 
     void setModels(InstrumentModel *instrumentModel, RealDataModel *realDataModel);
+
+signals:
+    void instrumentMapUpdated();
 
 public slots:
     void setOnInstrumentPropertyChange(SessionItem *instrument, const QString &property);
@@ -59,15 +62,18 @@ private slots:
     void updateInstrumentMap();
     void updateRealDataMap();
 
+public:
+    QString instrumentNameFromIdentifier(const QString &identifier);
+//    QString instrumentIdentifierFromName(const QString &name);
+    InstrumentItem *getInstrument(const QString &identifier);
+    QStringList instrumentNames() const;
+    int instrumentComboIndex(const QString &identifier);
+    QString instrumentIdentifier(int comboIndex);
+    bool canLinkDataToInstrument(const RealDataItem *realDataItem, const QString &identifier);
+
 private:
     void setInstrumentModel(InstrumentModel *model);
     void setRealDataModel(RealDataModel *model);
-    QString instrumentNameFromIdentifier(const QString &identifier);
-    QString instrumentIdentifierFromName(const QString &name);
-    InstrumentItem *getInstrument(const QString &identifier);
-    QStringList instrumentNames() const;
-
-    bool canLinkDataToInstrument(RealDataItem *realDataItem, InstrumentItem *instrumentItem);
 
     InstrumentModel *m_instrumentModel;
     RealDataModel *m_realDataModel;

--- a/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.h
+++ b/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.h
@@ -58,6 +58,8 @@ public slots:
     void setOnInstrumentPropertyChange(SessionItem *instrument, const QString &property);
     void setOnRealDataPropertyChange(SessionItem *dataItem, const QString &property);
 
+    void onInstrumentChildChange(SessionItem *instrument, SessionItem *child);
+
     void onInstrumentRowsChange(const QModelIndex & parent, int, int);
     void onRealDataRowsChange(const QModelIndex & parent, int, int);
 
@@ -65,10 +67,10 @@ private slots:
     void updateLinks();
     void updateInstrumentMap();
     void updateRealDataMap();
+    void onInstrumentBinningChange(SessionItem *changedInstrument);
 
 public:
     QString instrumentNameFromIdentifier(const QString &identifier);
-//    QString instrumentIdentifierFromName(const QString &name);
     InstrumentItem *getInstrument(const QString &identifier);
     QStringList instrumentNames() const;
     int instrumentComboIndex(const QString &identifier);

--- a/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.h
+++ b/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.h
@@ -19,20 +19,20 @@
 
 #include "WinDllMacros.h"
 #include <QObject>
-#include <QMap>
 #include <QVector>
+#include <QList>
 #include <QStringList>
 
 class InstrumentModel;
 class RealDataModel;
 class SessionItem;
 class InstrumentItem;
-class IntensityDataItem;
 class RealDataItem;
 class SessionModel;
 
 //! The LinkInstrumentManager class provides communication between InstrumentModel and
-//! RealDataModel. Particularly, it notifies RealDataItem about changes in linked instruments.
+//! RealDataModel. Particularly, it notifies RealDataItem about changes in linked instruments
+//! to adjust axes of IntensityDataItem.
 
 class BA_CORE_API_ LinkInstrumentManager : public QObject {
     Q_OBJECT
@@ -51,31 +51,28 @@ public:
 
     void setModels(InstrumentModel *instrumentModel, RealDataModel *realDataModel);
 
-signals:
-    void instrumentMapUpdated();
-
-public slots:
-    void setOnInstrumentPropertyChange(SessionItem *instrument, const QString &property);
-    void setOnRealDataPropertyChange(SessionItem *dataItem, const QString &property);
-
-    void onInstrumentChildChange(SessionItem *instrument, SessionItem *child);
-
-    void onInstrumentRowsChange(const QModelIndex & parent, int, int);
-    void onRealDataRowsChange(const QModelIndex & parent, int, int);
-
-private slots:
-    void updateLinks();
-    void updateInstrumentMap();
-    void updateRealDataMap();
-    void onInstrumentBinningChange(SessionItem *changedInstrument);
-
-public:
-    QString instrumentNameFromIdentifier(const QString &identifier);
     InstrumentItem *getInstrument(const QString &identifier);
     QStringList instrumentNames() const;
     int instrumentComboIndex(const QString &identifier);
     QString instrumentIdentifier(int comboIndex);
     bool canLinkDataToInstrument(const RealDataItem *realDataItem, const QString &identifier);
+
+signals:
+    void instrumentMapUpdated();
+
+private slots:
+    void setOnInstrumentPropertyChange(SessionItem *instrument, const QString &property);
+    void setOnRealDataPropertyChange(SessionItem *dataItem, const QString &property);
+    void onInstrumentChildChange(InstrumentItem *instrument, SessionItem *child);
+    void onInstrumentRowsChange(const QModelIndex & parent, int, int);
+    void onRealDataRowsChange(const QModelIndex & parent, int, int);
+
+    void updateLinks();
+    void updateInstrumentMap();
+    void updateRealDataMap();
+    void onInstrumentBinningChange(InstrumentItem *changedInstrument);
+    void onInstrumentLayoutChange(InstrumentItem *changedInstrument);
+    QList<RealDataItem *> linkedItems(InstrumentItem *instrumentItem);
 
 private:
     void setInstrumentModel(InstrumentModel *model);

--- a/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.h
+++ b/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.h
@@ -57,6 +57,9 @@ public slots:
     void setOnInstrumentPropertyChange(SessionItem *instrument, const QString &property);
     void setOnRealDataPropertyChange(SessionItem *dataItem, const QString &property);
 
+    void onInstrumentRowsChange(const QModelIndex & parent, int, int);
+    void onRealDataRowsChange(const QModelIndex & parent, int, int);
+
 private slots:
     void updateLinks();
     void updateInstrumentMap();

--- a/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.h
+++ b/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.h
@@ -21,6 +21,7 @@
 #include <QObject>
 #include <QMap>
 #include <QVector>
+#include <QStringList>
 
 class InstrumentModel;
 class RealDataModel;

--- a/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.h
+++ b/GUI/coregui/Views/ImportDataWidgets/LinkInstrumentManager.h
@@ -28,6 +28,7 @@ class SessionItem;
 class InstrumentItem;
 class IntensityDataItem;
 class RealDataItem;
+class SessionModel;
 
 //! The LinkInstrumentManager class provides communication between InstrumentModel and
 //! RealDataModel. Particularly, it notifies RealDataItem about changes in linked instruments.
@@ -54,21 +55,22 @@ public slots:
     void setOnRealDataPropertyChange(SessionItem *dataItem, const QString &property);
 
 private slots:
+    void updateLinks();
     void updateInstrumentMap();
+    void updateRealDataMap();
 
 private:
     void setInstrumentModel(InstrumentModel *model);
     void setRealDataModel(RealDataModel *model);
-    InstrumentInfo& getInstrumentInfo(SessionItem *item);
     QString instrumentNameFromIdentifier(const QString &identifier);
+    QString instrumentIdentifierFromName(const QString &name);
     InstrumentItem *getInstrument(const QString &identifier);
+    QStringList instrumentNames() const;
 
     bool canLinkDataToInstrument(RealDataItem *realDataItem, InstrumentItem *instrumentItem);
 
     InstrumentModel *m_instrumentModel;
     RealDataModel *m_realDataModel;
-    QStringList m_instrumentNames;
-    QMap<SessionItem *, InstrumentInfo> m_instrumentInfo;
     QVector<InstrumentInfo> m_instrumentVec;
 };
 

--- a/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.cpp
@@ -22,6 +22,7 @@
 RealDataPropertiesWidget::RealDataPropertiesWidget(QWidget *parent)
     : QWidget(parent)
     , m_propertyEditor(new ComponentEditor)
+    , m_propertyEditor2(new ComponentEditor)
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     setWindowTitle("RealDataPropertiesWidget");
@@ -31,6 +32,7 @@ RealDataPropertiesWidget::RealDataPropertiesWidget(QWidget *parent)
     mainLayout->setSpacing(0);
     mainLayout->setContentsMargins(0,0,0,0);
     mainLayout->addWidget(m_propertyEditor);
+    mainLayout->addWidget(m_propertyEditor2);
 
     setLayout(mainLayout);
 }
@@ -38,6 +40,7 @@ RealDataPropertiesWidget::RealDataPropertiesWidget(QWidget *parent)
 void RealDataPropertiesWidget::setItem(SessionItem *item)
 {
     m_propertyEditor->setItem(item);
+    m_propertyEditor2->setItem(item);
 }
 
 

--- a/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.cpp
@@ -206,4 +206,8 @@ void RealDataPropertiesWidget::setPropertiesEnabled(bool enabled)
     m_dataNameEdit->setEnabled(enabled);
     m_instrumentLabel->setEnabled(enabled);
     m_instrumentCombo->setEnabled(enabled);
+    if(enabled == false) {
+        m_dataNameEdit->clear();
+        m_instrumentCombo->setCurrentIndex(0);
+    }
 }

--- a/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.cpp
@@ -35,7 +35,9 @@ RealDataPropertiesWidget::RealDataPropertiesWidget(QWidget *parent)
     : QWidget(parent)
     , m_linkManager(new LinkInstrumentManager(this))
     , m_dataNameMapper(new QDataWidgetMapper)
+    , m_dataNameLabel(new QLabel("Dataset"))
     , m_dataNameEdit(new QLineEdit)
+    , m_instrumentLabel(new QLabel("Linked instrument"))
     , m_instrumentCombo(new QComboBox)
     , m_currentDataItem(0)
 {
@@ -46,18 +48,15 @@ RealDataPropertiesWidget::RealDataPropertiesWidget(QWidget *parent)
     mainLayout->setMargin(5);
     mainLayout->setSpacing(2);
 
-    QLabel *nameLabel = new QLabel("Dataset");
-    nameLabel->setToolTip(instrumentNameTooltip);
+    m_dataNameLabel->setToolTip(instrumentNameTooltip);
     m_dataNameEdit->setToolTip(instrumentNameTooltip);
-
-    QLabel *selectorLabel = new QLabel("Linked instrument");
-    selectorLabel->setToolTip(selectorTooltip);
+    m_instrumentLabel->setToolTip(selectorTooltip);
     m_instrumentCombo->setToolTip(selectorTooltip);
 
-    mainLayout->addWidget(nameLabel);
+    mainLayout->addWidget(m_dataNameLabel);
     mainLayout->addWidget(m_dataNameEdit);
     mainLayout->addSpacing(5);
-    mainLayout->addWidget(selectorLabel);
+    mainLayout->addWidget(m_instrumentLabel);
     mainLayout->addWidget(m_instrumentCombo);
 
     mainLayout->addStretch();
@@ -66,6 +65,8 @@ RealDataPropertiesWidget::RealDataPropertiesWidget(QWidget *parent)
     setComboConnected(true);
     connect(m_linkManager, SIGNAL(instrumentMapUpdated()),
             this, SLOT(onInstrumentMapUpdate()));
+
+    setPropertiesEnabled(false);
 }
 
 //! Sets models to underlying link manager.
@@ -90,8 +91,12 @@ void RealDataPropertiesWidget::setItem(SessionItem *item)
 
     m_currentDataItem = dynamic_cast<RealDataItem *>(item);
 
-    if(!m_currentDataItem)
+    if(!m_currentDataItem) {
+        setPropertiesEnabled(false);
         return;
+    }
+
+    setPropertiesEnabled(true);
 
     m_currentDataItem->mapper()->setOnPropertyChange(
                 [this](const QString &name)
@@ -120,7 +125,6 @@ void RealDataPropertiesWidget::setItem(SessionItem *item)
 
 void RealDataPropertiesWidget::onInstrumentComboIndexChanged(int index)
 {
-    qDebug() << "AAA" << index;
     m_current_id = m_linkManager->instrumentIdentifier(index);
 
     if(!m_currentDataItem)
@@ -191,4 +195,15 @@ void RealDataPropertiesWidget::setComboConnected(bool isConnected)
         disconnect(m_instrumentCombo, SIGNAL(currentIndexChanged(int)),
                 this, SLOT(onInstrumentComboIndexChanged(int)));
     }
+}
+
+//! Sets all widget's children enabled/disabled. When no RealDataItem selected all
+//! will appear in gray.
+
+void RealDataPropertiesWidget::setPropertiesEnabled(bool enabled)
+{
+    m_dataNameLabel->setEnabled(enabled);
+    m_dataNameEdit->setEnabled(enabled);
+    m_instrumentLabel->setEnabled(enabled);
+    m_instrumentCombo->setEnabled(enabled);
 }

--- a/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.cpp
@@ -17,22 +17,29 @@
 #include "RealDataPropertiesWidget.h"
 #include "ComponentEditor.h"
 #include "RealDataItem.h"
+#include "SessionModel.h"
 #include <QVBoxLayout>
+#include <QLineEdit>
+#include <QDataWidgetMapper>
 
 RealDataPropertiesWidget::RealDataPropertiesWidget(QWidget *parent)
     : QWidget(parent)
     , m_propertyEditor(new ComponentEditor)
-    , m_propertyEditor2(new ComponentEditor)
+//    , m_propertyEditor2(new ComponentEditor)
+    , m_dataNameMapper(new QDataWidgetMapper)
+    , m_dataNameEdit(new QLineEdit)
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     setWindowTitle("RealDataPropertiesWidget");
+
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->setMargin(0);
     mainLayout->setSpacing(0);
     mainLayout->setContentsMargins(0,0,0,0);
     mainLayout->addWidget(m_propertyEditor);
-    mainLayout->addWidget(m_propertyEditor2);
+//    mainLayout->addWidget(m_propertyEditor2);
+    mainLayout->addWidget(m_dataNameEdit);
 
     setLayout(mainLayout);
 }
@@ -40,7 +47,23 @@ RealDataPropertiesWidget::RealDataPropertiesWidget(QWidget *parent)
 void RealDataPropertiesWidget::setItem(SessionItem *item)
 {
     m_propertyEditor->setItem(item);
-    m_propertyEditor2->setItem(item);
+//    m_propertyEditor2->setItem(item);
+    m_dataNameMapper->clearMapping();
+    if(!item)
+        return;
+
+
+    m_dataNameMapper->setModel(item->model());
+    m_dataNameMapper->setRootIndex(item->index());
+    m_dataNameMapper->setCurrentModelIndex(item->getItem(SessionItem::P_NAME)->index());
+//    m_dataNameMapper->addMapping(m_dataNameEdit, 1, "plainText");
+    m_dataNameMapper->addMapping(m_dataNameEdit, 1);
+    m_dataNameMapper->toFirst();
 }
+
+
+//m_textEditMapper->setRootIndex(m_fitModel->rootItem()->getItem("", m_row)->index());
+//m_textEditMapper->setCurrentModelIndex(m_fitModel->rootItem()->getItem("", m_row)->getItem(FittingWorkspace::P_PARAMETERS)->index());
+//m_textEditMapper->addMapping(m_textEdit, 1, "plainText");
 
 

--- a/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.cpp
@@ -18,16 +18,23 @@
 #include "ComponentEditor.h"
 #include "RealDataItem.h"
 #include "SessionModel.h"
+#include "LinkInstrumentManager.h"
+#include "GUIHelpers.h"
 #include <QVBoxLayout>
 #include <QLineEdit>
+#include <QComboBox>
 #include <QDataWidgetMapper>
+#include <QDebug>
+
 
 RealDataPropertiesWidget::RealDataPropertiesWidget(QWidget *parent)
     : QWidget(parent)
+    , m_linkManager(new LinkInstrumentManager(this))
     , m_propertyEditor(new ComponentEditor)
-//    , m_propertyEditor2(new ComponentEditor)
     , m_dataNameMapper(new QDataWidgetMapper)
     , m_dataNameEdit(new QLineEdit)
+    , m_instrumentCombo(new QComboBox)
+    , m_currentDataItem(0)
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     setWindowTitle("RealDataPropertiesWidget");
@@ -38,32 +45,109 @@ RealDataPropertiesWidget::RealDataPropertiesWidget(QWidget *parent)
     mainLayout->setSpacing(0);
     mainLayout->setContentsMargins(0,0,0,0);
     mainLayout->addWidget(m_propertyEditor);
-//    mainLayout->addWidget(m_propertyEditor2);
     mainLayout->addWidget(m_dataNameEdit);
+    mainLayout->addWidget(m_instrumentCombo);
 
     setLayout(mainLayout);
+
+    setComboConnected(true);
+    connect(m_linkManager, SIGNAL(instrumentMapUpdated()),
+            this, SLOT(onInstrumentMapUpdate()));
 }
+
+void RealDataPropertiesWidget::setModels(InstrumentModel *instrumentModel,
+                                         RealDataModel *realDataModel)
+{
+    m_linkManager->setModels(instrumentModel, realDataModel);
+}
+
 
 void RealDataPropertiesWidget::setItem(SessionItem *item)
 {
     m_propertyEditor->setItem(item);
-//    m_propertyEditor2->setItem(item);
     m_dataNameMapper->clearMapping();
     if(!item)
         return;
 
+    m_currentDataItem = dynamic_cast<RealDataItem *>(item);
+    Q_ASSERT(m_currentDataItem);
 
     m_dataNameMapper->setModel(item->model());
     m_dataNameMapper->setRootIndex(item->index());
     m_dataNameMapper->setCurrentModelIndex(item->getItem(SessionItem::P_NAME)->index());
-//    m_dataNameMapper->addMapping(m_dataNameEdit, 1, "plainText");
     m_dataNameMapper->addMapping(m_dataNameEdit, 1);
     m_dataNameMapper->toFirst();
+
+
+    setComboToIdentifier(item->getItemValue(RealDataItem::P_INSTRUMENT_ID).toString());
 }
 
+//! Processes user interaction with instrument selector combo. If there is realDataItem,
+//! it will be linked with selected instrument.
 
-//m_textEditMapper->setRootIndex(m_fitModel->rootItem()->getItem("", m_row)->index());
-//m_textEditMapper->setCurrentModelIndex(m_fitModel->rootItem()->getItem("", m_row)->getItem(FittingWorkspace::P_PARAMETERS)->index());
-//m_textEditMapper->addMapping(m_textEdit, 1, "plainText");
+void RealDataPropertiesWidget::onInstrumentComboIndexChanged(int index)
+{
+    qDebug() << "AAA" << index;
+    m_current_id = m_linkManager->instrumentIdentifier(index);
 
+    if(!m_currentDataItem)
+        return;
+
+    QString dataLink = m_currentDataItem->getItemValue(RealDataItem::P_INSTRUMENT_ID).toString();
+    if(m_current_id == dataLink)
+        return;
+
+    if(m_linkManager->canLinkDataToInstrument(m_currentDataItem, m_current_id)) {
+        m_currentDataItem->setItemValue(RealDataItem::P_INSTRUMENT_ID, m_current_id);
+
+    } else {
+        // LinkManager doesn't allow to link data to instrument.
+        setComboToIdentifier(dataLink); // Returning Combo selector to previous state
+    }
+
+}
+
+//! Updates instrument selector for new instrument names, and add/remove instrument events.
+//! Current selection will be preserved.
+
+void RealDataPropertiesWidget::onInstrumentMapUpdate()
+{
+    setComboConnected(false);
+    m_instrumentCombo->clear();
+    m_instrumentCombo->addItems(m_linkManager->instrumentNames());
+    int index = m_linkManager->instrumentComboIndex(m_current_id);
+    if(index >= 0) {
+        m_instrumentCombo->setCurrentIndex(index);
+    } else {
+        // instrument corresponding to m_current_id was deleted
+        m_current_id = QString();
+        m_instrumentCombo->setCurrentIndex(0);
+    }
+    setComboConnected(true);
+}
+
+//! Sets instrument combo selector to the state corresponding to given instrument identifier.
+
+void RealDataPropertiesWidget::setComboToIdentifier(const QString &identifier)
+{
+    setComboConnected(false);
+    m_current_id = identifier;
+    int index = m_linkManager->instrumentComboIndex(identifier);
+    Q_ASSERT(index >=0);
+    m_instrumentCombo->setCurrentIndex(index);
+    setComboConnected(true);
+}
+
+//! Sets connected/disconnected for instrument combo selector.
+
+void RealDataPropertiesWidget::setComboConnected(bool isConnected)
+{
+    if(isConnected) {
+        connect(m_instrumentCombo, SIGNAL(currentIndexChanged(int)),
+                this, SLOT(onInstrumentComboIndexChanged(int)));
+    } else {
+        disconnect(m_instrumentCombo, SIGNAL(currentIndexChanged(int)),
+                this, SLOT(onInstrumentComboIndexChanged(int)));
+    }
+}
 

--- a/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.h
+++ b/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.h
@@ -20,10 +20,15 @@
 #include "WinDllMacros.h"
 #include <QWidget>
 
+class LinkInstrumentManager;
 class ComponentEditor;
 class SessionItem;
+class InstrumentModel;
+class RealDataModel;
+class RealDataItem;
 class QDataWidgetMapper;
 class QLineEdit;
+class QComboBox;
 
 //! The RealDataPropertiesWidget class holds component editor for RealDataItem.
 //! Part of RealDataSelectorWidget, resides at lower left corner of ImportDataView.
@@ -39,13 +44,23 @@ public:
 
     void setItem(SessionItem *item);
 
-    void setModels();
+    void setModels(InstrumentModel *instrumentModel, RealDataModel *realDataModel);
+
+public slots:
+    void onInstrumentComboIndexChanged(int index);
+    void onInstrumentMapUpdate();
 
 private:
+    void setComboToIdentifier(const QString &identifier);
+    void setComboConnected(bool isConnected);
+
+    LinkInstrumentManager *m_linkManager;
     ComponentEditor *m_propertyEditor;
-//    ComponentEditor *m_propertyEditor2;
     QDataWidgetMapper *m_dataNameMapper;
     QLineEdit *m_dataNameEdit;
+    QComboBox *m_instrumentCombo;
+    QString m_current_id;
+    RealDataItem *m_currentDataItem;
 };
 
 #endif

--- a/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.h
+++ b/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.h
@@ -49,6 +49,7 @@ public:
 public slots:
     void onInstrumentComboIndexChanged(int index);
     void onInstrumentMapUpdate();
+    void onRealDataPropertyChanged(const QString &name);
 
 private:
     void setComboToIdentifier(const QString &identifier);

--- a/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.h
+++ b/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.h
@@ -28,6 +28,7 @@ class RealDataItem;
 class QDataWidgetMapper;
 class QLineEdit;
 class QComboBox;
+class QLabel;
 
 //! The RealDataPropertiesWidget class holds instrument selector to link with RealDataItem.
 //! Part of RealDataSelectorWidget, resides at lower left corner of ImportDataView.
@@ -52,10 +53,13 @@ public slots:
 private:
     void setComboToIdentifier(const QString &identifier);
     void setComboConnected(bool isConnected);
+    void setPropertiesEnabled(bool enabled);
 
     LinkInstrumentManager *m_linkManager;
     QDataWidgetMapper *m_dataNameMapper;
+    QLabel *m_dataNameLabel;
     QLineEdit *m_dataNameEdit;
+    QLabel *m_instrumentLabel;
     QComboBox *m_instrumentCombo;
     QString m_current_id;
     RealDataItem *m_currentDataItem;

--- a/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.h
+++ b/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.h
@@ -39,6 +39,7 @@ public:
 
 private:
     ComponentEditor *m_propertyEditor;
+    ComponentEditor *m_propertyEditor2;
 };
 
 #endif

--- a/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.h
+++ b/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.h
@@ -21,7 +21,6 @@
 #include <QWidget>
 
 class LinkInstrumentManager;
-class ComponentEditor;
 class SessionItem;
 class InstrumentModel;
 class RealDataModel;
@@ -30,7 +29,7 @@ class QDataWidgetMapper;
 class QLineEdit;
 class QComboBox;
 
-//! The RealDataPropertiesWidget class holds component editor for RealDataItem.
+//! The RealDataPropertiesWidget class holds instrument selector to link with RealDataItem.
 //! Part of RealDataSelectorWidget, resides at lower left corner of ImportDataView.
 
 class BA_CORE_API_ RealDataPropertiesWidget : public QWidget
@@ -39,12 +38,11 @@ class BA_CORE_API_ RealDataPropertiesWidget : public QWidget
 public:
     explicit RealDataPropertiesWidget(QWidget *parent = 0);
 
-    QSize sizeHint() const { return QSize(64, 256); }
-    QSize minimumSizeHint() const { return QSize(64, 64); }
-
-    void setItem(SessionItem *item);
+    QSize sizeHint() const { return QSize(64, 135); }
+    QSize minimumSizeHint() const { return QSize(64, 128); }
 
     void setModels(InstrumentModel *instrumentModel, RealDataModel *realDataModel);
+    void setItem(SessionItem *item);
 
 public slots:
     void onInstrumentComboIndexChanged(int index);
@@ -56,7 +54,6 @@ private:
     void setComboConnected(bool isConnected);
 
     LinkInstrumentManager *m_linkManager;
-    ComponentEditor *m_propertyEditor;
     QDataWidgetMapper *m_dataNameMapper;
     QLineEdit *m_dataNameEdit;
     QComboBox *m_instrumentCombo;

--- a/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.h
+++ b/GUI/coregui/Views/ImportDataWidgets/RealDataPropertiesWidget.h
@@ -22,6 +22,8 @@
 
 class ComponentEditor;
 class SessionItem;
+class QDataWidgetMapper;
+class QLineEdit;
 
 //! The RealDataPropertiesWidget class holds component editor for RealDataItem.
 //! Part of RealDataSelectorWidget, resides at lower left corner of ImportDataView.
@@ -37,9 +39,13 @@ public:
 
     void setItem(SessionItem *item);
 
+    void setModels();
+
 private:
     ComponentEditor *m_propertyEditor;
-    ComponentEditor *m_propertyEditor2;
+//    ComponentEditor *m_propertyEditor2;
+    QDataWidgetMapper *m_dataNameMapper;
+    QLineEdit *m_dataNameEdit;
 };
 
 #endif

--- a/GUI/coregui/Views/ImportDataWidgets/RealDataSelectorWidget.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/RealDataSelectorWidget.cpp
@@ -48,6 +48,8 @@ RealDataSelectorWidget::RealDataSelectorWidget(QWidget *parent)
 
     connect(m_selectorWidget, SIGNAL(selectionChanged(SessionItem *)),
         this, SLOT(onSelectionChanged(SessionItem *)));
+
+//    m_propertiesWidget->setItem(m_linkManager->getLinkInstrumentItem());
 }
 
 void RealDataSelectorWidget::setModels(InstrumentModel *instrumentModel, RealDataModel *realDataModel)
@@ -64,5 +66,6 @@ QItemSelectionModel *RealDataSelectorWidget::selectionModel()
 void RealDataSelectorWidget::onSelectionChanged(SessionItem *item)
 {
    m_propertiesWidget->setItem(item);
+//   m_linkManager->setRealDataItem(item);
    emit selectionChanged(item);
 }

--- a/GUI/coregui/Views/ImportDataWidgets/RealDataSelectorWidget.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/RealDataSelectorWidget.cpp
@@ -28,7 +28,6 @@ RealDataSelectorWidget::RealDataSelectorWidget(QWidget *parent)
     , m_splitter(new Manhattan::MiniSplitter)
     , m_selectorWidget(new ItemSelectorWidget)
     , m_propertiesWidget(new RealDataPropertiesWidget)
-    , m_linkManager(new LinkInstrumentManager(this))
 {
     setMinimumSize(128, 600);
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
@@ -49,13 +48,13 @@ RealDataSelectorWidget::RealDataSelectorWidget(QWidget *parent)
     connect(m_selectorWidget, SIGNAL(selectionChanged(SessionItem *)),
         this, SLOT(onSelectionChanged(SessionItem *)));
 
-//    m_propertiesWidget->setItem(m_linkManager->getLinkInstrumentItem());
 }
 
-void RealDataSelectorWidget::setModels(InstrumentModel *instrumentModel, RealDataModel *realDataModel)
+void RealDataSelectorWidget::setModels(InstrumentModel *instrumentModel,
+                                       RealDataModel *realDataModel)
 {
     m_selectorWidget->setModel(realDataModel);
-    m_linkManager->setModels(instrumentModel, realDataModel);
+    m_propertiesWidget->setModels(instrumentModel, realDataModel);
 }
 
 QItemSelectionModel *RealDataSelectorWidget::selectionModel()
@@ -66,6 +65,5 @@ QItemSelectionModel *RealDataSelectorWidget::selectionModel()
 void RealDataSelectorWidget::onSelectionChanged(SessionItem *item)
 {
    m_propertiesWidget->setItem(item);
-//   m_linkManager->setRealDataItem(item);
    emit selectionChanged(item);
 }

--- a/GUI/coregui/Views/ImportDataWidgets/RealDataSelectorWidget.h
+++ b/GUI/coregui/Views/ImportDataWidgets/RealDataSelectorWidget.h
@@ -27,7 +27,6 @@ class InstrumentModel;
 class RealDataModel;
 class SessionItem;
 class QItemSelectionModel;
-class LinkInstrumentManager;
 namespace Manhattan { class MiniSplitter;}
 
 //! The RealDataSelectorWidget represents left panel of ImportDataView. Contains a widget to
@@ -58,7 +57,6 @@ private:
     Manhattan::MiniSplitter *m_splitter;
     ItemSelectorWidget *m_selectorWidget;
     RealDataPropertiesWidget *m_propertiesWidget;
-    LinkInstrumentManager *m_linkManager;
 };
 
 #endif // REALDATASELECTORWIDGET_H

--- a/GUI/coregui/Views/PropertyEditor/PropertyVariantFactory.cpp
+++ b/GUI/coregui/Views/PropertyEditor/PropertyVariantFactory.cpp
@@ -22,7 +22,7 @@
 
 PropertyVariantFactory::~PropertyVariantFactory()
 {
-    qDebug() << "PropertyVariantFactory::~PropertyVariantFactory()";
+//    qDebug() << "PropertyVariantFactory::~PropertyVariantFactory()";
     QList<MaterialPropertyEdit *> mat_editors =
             m_material_editor_to_property.keys();
     QListIterator<MaterialPropertyEdit *> mat_it(mat_editors);
@@ -71,7 +71,7 @@ void PropertyVariantFactory::connectPropertyManager(
 QWidget *PropertyVariantFactory::createEditor(QtVariantPropertyManager *manager,
         QtProperty *property, QWidget *parent)
 {
-    qDebug() << "PropertyVariantFactory::createEditor()" << property->propertyName();
+//    qDebug() << "PropertyVariantFactory::createEditor()" << property->propertyName();
     if (manager->propertyType(property) ==
             PropertyVariantManager::materialTypeId()) {
         MaterialPropertyEdit *editor = new MaterialPropertyEdit(parent);
@@ -146,7 +146,7 @@ QWidget *PropertyVariantFactory::createEditor(QtVariantPropertyManager *manager,
     if (manager->propertyType(property) ==
             PropertyVariantManager::comboPropertyTypeId()) {
         ComboPropertyEdit *editor = new ComboPropertyEdit(parent);
-        qDebug() << "       PropertyVariantFactory::createEditor() -> created ComboEditor" << editor;
+//        qDebug() << "       PropertyVariantFactory::createEditor() -> created ComboEditor" << editor;
 
         QVariant var = manager->value(property);
         ComboProperty combo = var.value<ComboProperty>();
@@ -182,7 +182,7 @@ void PropertyVariantFactory::disconnectPropertyManager(
 void PropertyVariantFactory::slotPropertyChanged(QtProperty *property,
                 const QVariant &value)
 {
-    qDebug() << "PropertyVariantFactory::slotPropertyChanged()" << property->propertyName() << value;
+//    qDebug() << "PropertyVariantFactory::slotPropertyChanged()" << property->propertyName() << value;
     if (m_property_to_material_editors.contains(property)) {
         QList<MaterialPropertyEdit *> editors =
                 m_property_to_material_editors[property];
@@ -216,7 +216,7 @@ void PropertyVariantFactory::slotPropertyChanged(QtProperty *property,
         QListIterator<GroupPropertyEdit *> itEditor(editors);
         while (itEditor.hasNext()) {
             GroupProperty_t mat = value.value<GroupProperty_t>();
-            qDebug() << "       PropertyVariantFactory::slotPropertyChanged() -> Setting editor";
+//            qDebug() << "       PropertyVariantFactory::slotPropertyChanged() -> Setting editor";
             itEditor.next()->setGroupProperty(mat);
         }
     }
@@ -225,7 +225,7 @@ void PropertyVariantFactory::slotPropertyChanged(QtProperty *property,
                 m_property_to_combo_editors[property];
         QListIterator<ComboPropertyEdit *> itEditor(editors);
         while (itEditor.hasNext()) {
-            qDebug() << "       PropertyVariantFactory::slotPropertyChanged() -> Setting editor";
+//            qDebug() << "       PropertyVariantFactory::slotPropertyChanged() -> Setting editor";
             ComboProperty combo = value.value<ComboProperty>();
             itEditor.next()->setComboProperty(combo);
         }
@@ -235,7 +235,7 @@ void PropertyVariantFactory::slotPropertyChanged(QtProperty *property,
 
 void PropertyVariantFactory::slotSetValue(const MaterialProperty &value)
 {
-    qDebug() << "PropertyVariantFactory::slotSetValue(const MaterialProperty &value)";
+//    qDebug() << "PropertyVariantFactory::slotSetValue(const MaterialProperty &value)";
     QObject *object = sender();
     QMap<MaterialPropertyEdit *, QtProperty *>::ConstIterator itEditor =
                 m_material_editor_to_property.constBegin();
@@ -297,7 +297,7 @@ void PropertyVariantFactory::slotSetValue(const ScientificDoubleProperty &value)
 
 void PropertyVariantFactory::slotSetValue(const GroupProperty_t &value)
 {
-    qDebug() << "PropertyVariantFactory::slotSetValue(const GroupProperty_t &value)";
+//    qDebug() << "PropertyVariantFactory::slotSetValue(const GroupProperty_t &value)";
     QObject *object = sender();
     QMap<GroupPropertyEdit *, QtProperty *>::ConstIterator itEditor =
                 m_fancygroup_editor_to_property.constBegin();
@@ -317,7 +317,7 @@ void PropertyVariantFactory::slotSetValue(const GroupProperty_t &value)
 
 void PropertyVariantFactory::slotSetValue(const ComboProperty &value)
 {
-    qDebug() << "PropertyVariantFactory::slotSetValue(const ComboProperty &value)";
+//    qDebug() << "PropertyVariantFactory::slotSetValue(const ComboProperty &value)";
     QObject *object = sender();
     QMap<ComboPropertyEdit *, QtProperty *>::ConstIterator itEditor =
                 m_combo_editor_to_property.constBegin();
@@ -339,7 +339,7 @@ void PropertyVariantFactory::slotSetValue(const ComboProperty &value)
 
 void PropertyVariantFactory::slotEditorDestroyed(QObject *object)
 {
-    qDebug() << "PropertyVariantFactory::slotEditorDestroyed(QObject *object)";
+//    qDebug() << "PropertyVariantFactory::slotEditorDestroyed(QObject *object)";
     QMap<MaterialPropertyEdit *, QtProperty *>::ConstIterator mat_it_editor =
                 m_material_editor_to_property.constBegin();
     while (mat_it_editor != m_material_editor_to_property.constEnd()) {

--- a/GUI/coregui/Views/PropertyEditor/PropertyVariantManager.cpp
+++ b/GUI/coregui/Views/PropertyEditor/PropertyVariantManager.cpp
@@ -155,7 +155,7 @@ QIcon PropertyVariantManager::valueIcon(const QtProperty *property) const
 
 void PropertyVariantManager::setValue(QtProperty *property, const QVariant &val)
 {
-    qDebug() << "PropertyVariantManager::setValue(QtProperty *property, const QVariant &val)";
+//    qDebug() << "PropertyVariantManager::setValue(QtProperty *property, const QVariant &val)";
     if (m_theMaterialValues.contains(property)) {
         if( val.userType() != materialTypeId() ) return;
         MaterialProperty mat = val.value<MaterialProperty>();
@@ -213,7 +213,7 @@ void PropertyVariantManager::setValue(QtProperty *property, const QVariant &val)
 
 void PropertyVariantManager::initializeProperty(QtProperty *property)
 {
-    qDebug() << "PropertyVariantManager::initializeProperty(QtProperty *property)";
+//    qDebug() << "PropertyVariantManager::initializeProperty(QtProperty *property)";
     if (propertyType(property) == materialTypeId()) {
         MaterialProperty m;
         m_theMaterialValues[property] = m;

--- a/GUI/coregui/mainwindow/mainwindow.cpp
+++ b/GUI/coregui/mainwindow/mainwindow.cpp
@@ -66,7 +66,7 @@ MainWindow::MainWindow(QWidget *parent)
 
 //    m_applicationModels->createTestSample();
 //    m_applicationModels->createTestJob();
-//    m_applicationModels->createTestRealData();
+    m_applicationModels->createTestRealData();
 }
 
 MaterialModel *MainWindow::materialModel()
@@ -279,7 +279,7 @@ void MainWindow::initViews()
     //m_tabWidget->insertTab(MODELVIEW, m_sessionModelView, QIcon(":/images/main_sessionmodel.svg"), "Models");
 //    m_tabWidget->insertTab(TESTVIEW, testView, QIcon(":/images/main_jobview.svg"), "TestView");
 
-//    m_tabWidget->setCurrentIndex(IMPORT);
+    m_tabWidget->setCurrentIndex(IMPORT);
 
     // enabling technical view
     QSettings settings;

--- a/GUI/coregui/mainwindow/mainwindow.cpp
+++ b/GUI/coregui/mainwindow/mainwindow.cpp
@@ -66,7 +66,7 @@ MainWindow::MainWindow(QWidget *parent)
 
 //    m_applicationModels->createTestSample();
 //    m_applicationModels->createTestJob();
-    m_applicationModels->createTestRealData();
+//    m_applicationModels->createTestRealData();
 }
 
 MaterialModel *MainWindow::materialModel()
@@ -279,7 +279,7 @@ void MainWindow::initViews()
     //m_tabWidget->insertTab(MODELVIEW, m_sessionModelView, QIcon(":/images/main_sessionmodel.svg"), "Models");
 //    m_tabWidget->insertTab(TESTVIEW, testView, QIcon(":/images/main_jobview.svg"), "TestView");
 
-    m_tabWidget->setCurrentIndex(IMPORT);
+    m_tabWidget->setCurrentIndex(WELCOME);
 
     // enabling technical view
     QSettings settings;

--- a/GUI/coregui/utils/GUIHelpers.cpp
+++ b/GUI/coregui/utils/GUIHelpers.cpp
@@ -245,5 +245,15 @@ QString createUuid()
     return  QUuid::createUuid().toString();
 }
 
+bool isTheSame(const QStringList &lhs, const QStringList &rhs)
+{
+    if(lhs.size() != rhs.size()) return false;
+    for(int i=0; i<lhs.size(); ++i)
+        if(lhs.at(i) != rhs.at(i))
+            return false;
+
+    return true;
+}
+
 
 } // namespace GUIHelpers

--- a/GUI/coregui/utils/GUIHelpers.h
+++ b/GUI/coregui/utils/GUIHelpers.h
@@ -80,6 +80,8 @@ template<class T, class... Ts> std::unique_ptr<T> make_unique(Ts&&... params)
 
 BA_CORE_API_ QString createUuid();
 
+BA_CORE_API_ bool isTheSame(const QStringList &lhs, const QStringList &rhs);
+
 } // namespace GUIHelpers
 
 #endif // GUIHELPERS_H

--- a/GUI/main/main.cpp
+++ b/GUI/main/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
     QLocale::setDefault(QLocale(QLocale::English, QLocale::UnitedStates));
     qRegisterMetaType<QVector<double> >("QVector<double>");
     qRegisterMetaType<FitProgressInfo>("FitProgressInfo");
-    QMetaType::registerComparators<ComboProperty>();
+//    QMetaType::registerComparators<ComboProperty>();
 
     QApplication a(argc, argv);
 

--- a/GUI/main/main.cpp
+++ b/GUI/main/main.cpp
@@ -18,6 +18,7 @@
 #include "SplashScreen.h"
 #include "appoptions.h"
 #include "mainwindow.h"
+#include "ComboProperty.h"
 #include <QApplication>
 #include <QDebug>
 #include <QLocale>
@@ -39,6 +40,7 @@ int main(int argc, char *argv[])
     QLocale::setDefault(QLocale(QLocale::English, QLocale::UnitedStates));
     qRegisterMetaType<QVector<double> >("QVector<double>");
     qRegisterMetaType<FitProgressInfo>("FitProgressInfo");
+    QMetaType::registerComparators<ComboProperty>();
 
     QApplication a(argc, argv);
 

--- a/Tests/UnitTests/GUI/CMakeLists.txt
+++ b/Tests/UnitTests/GUI/CMakeLists.txt
@@ -30,4 +30,4 @@ target_link_libraries(TestGUI ${BornAgainGUI_LIBRARY})
 qt5_use_modules(TestGUI Widgets Core Gui Designer PrintSupport Network Test)
 
 # add execution of TestCore just after compilation
-add_custom_command(TARGET TestGUI POST_BUILD COMMAND TestGUI)
+add_custom_target(TestGUI0 ALL DEPENDS TestGUI COMMAND TestGUI)

--- a/Tests/UnitTests/GUI/TestComboProperty.h
+++ b/Tests/UnitTests/GUI/TestComboProperty.h
@@ -1,0 +1,58 @@
+#ifndef TESTCOMBOPROPERTY_H
+#define TESTCOMBOPROPERTY_H
+
+#include <QtTest>
+#include "ComboProperty.h"
+#include <QDebug>
+
+class TestComboProperty : public QObject {
+    Q_OBJECT
+
+private slots:
+    void test_ComboEquality();
+    void test_VariantEquality();
+};
+
+inline void TestComboProperty::test_ComboEquality()
+{
+        ComboProperty c1;
+        ComboProperty c2;
+        QVERIFY(c1 == c2);
+
+        c1 << "a1" << "a2";
+        c2 << "a1" << "a2";
+        QVERIFY(c1 == c2);
+
+        c2 << "a3";
+        QVERIFY(c1 != c2);
+        c2.setValue("a2");
+        QVERIFY(c1 != c2);
+
+        c1 << "a3";
+        c1.setValue("a2");
+        QVERIFY(c1 == c2);
+}
+
+inline void TestComboProperty::test_VariantEquality()
+{
+    QVariant v1(1.0);
+    QVariant v2(2.0);
+    QVariant v3(2.0);
+    QVERIFY(v1 != v2);
+    QVERIFY(v2 == v3);
+
+    ComboProperty c1 = ComboProperty() << "a1" << "a2";
+    ComboProperty c2 = ComboProperty() << "a1" << "a2";
+    QVERIFY(c1.getVariant() == c2.getVariant());
+
+    c2 << "a3";
+    QVERIFY(c1.getVariant() != c2.getVariant());
+    c2.setValue("a2");
+    QVERIFY(c1.getVariant() != c2.getVariant());
+
+    c1 << "a3";
+    c1.setValue("a2");
+    QVERIFY(c1.getVariant() == c2.getVariant());
+}
+
+#endif // TESTCOMBOPROPERTY_H

--- a/Tests/UnitTests/GUI/TestGUI.cpp
+++ b/Tests/UnitTests/GUI/TestGUI.cpp
@@ -17,10 +17,13 @@
 #include "TestGUIHelpers.h"
 #include "TestFitParameterModel.h"
 #include "TestMaterialModel.h"
+#include "TestComboProperty.h"
 
 int main(int argc, char** argv) {
     QCoreApplication app(argc, argv);
     Q_UNUSED(app);
+
+    QMetaType::registerComparators<ComboProperty>();
 
     TestFormFactorItems testFormFactorItems;
     TestFTDistributionItems testFTDistributionItems;
@@ -37,6 +40,7 @@ int main(int argc, char** argv) {
     TestGUIHelpers testGUIHelpers;
     TestFitParameterModel testFitParameterModel;
     TestMaterialModel testMaterialModel;
+    TestComboProperty testComboProperty;
 
     bool status(false);
 
@@ -55,8 +59,8 @@ int main(int argc, char** argv) {
     status |= QTest::qExec(&testParticleDistributionItem, argc, argv);
     status |= QTest::qExec(&testGUIHelpers, argc, argv);
     status |= QTest::qExec(&testFitParameterModel, argc, argv);
-
     status |= QTest::qExec(&testMaterialModel, argc, argv);
+    status |= QTest::qExec(&testComboProperty, argc, argv);
 
     return status;
 }


### PR DESCRIPTION
Implemented linking between RealDataItem and InstrumentItem: 

- adapts instrument binning to match real data, if necessary
- automatically tracks changes in instrument layout (xmin, xmax) and propagates to RealData image
- disables linking if instrument binning has suddenly changed
- preserves linking state after save/load

Item http://apps.jcns.fz-juelich.de/redmine/issues/1488 is now 75% ready.