### PR TITLE
New INode tree hierarchy

### DIFF
--- a/Core/Aggregate/InterferenceFunction2DParaCrystal.cpp
+++ b/Core/Aggregate/InterferenceFunction2DParaCrystal.cpp
@@ -68,17 +68,6 @@ InterferenceFunction2DParaCrystal* InterferenceFunction2DParaCrystal::clone() co
     return result;
 }
 
-std::string InterferenceFunction2DParaCrystal::to_str(int indent) const
-{
-    std::stringstream ss;
-    ss << std::string(4*indent, '.') << " " << getName() << " " << *getParameterPool() << "\n";
-    std::vector<const IFTDistribution2D*> pdfs = getProbabilityDistributions();
-    ss << std::string(4*(indent+1), '.') << " pdfs: " << *pdfs[0] << " " << *pdfs[1] << "\n";
-    for(auto child: getChildren() )
-        ss << child->to_str(indent+1);
-    return ss.str();
-}
-
 //! Sets the probability distributions (Fourier transformed) for the two lattice directions.
 //! @param pdf_1: probability distribution in first lattice direction
 //! @param pdf_2: probability distribution in second lattice direction

--- a/Core/Aggregate/InterferenceFunction2DParaCrystal.cpp
+++ b/Core/Aggregate/InterferenceFunction2DParaCrystal.cpp
@@ -74,7 +74,7 @@ std::string InterferenceFunction2DParaCrystal::to_str(int indent) const
     ss << std::string(4*indent, '.') << " " << getName() << " " << *getParameterPool() << "\n";
     std::vector<const IFTDistribution2D*> pdfs = getProbabilityDistributions();
     ss << std::string(4*(indent+1), '.') << " pdfs: " << *pdfs[0] << " " << *pdfs[1] << "\n";
-    for( const ISample* child: getChildren() )
+    for(auto child: getChildren() )
         ss << child->to_str(indent+1);
     return ss.str();
 }

--- a/Core/Aggregate/InterferenceFunction2DParaCrystal.h
+++ b/Core/Aggregate/InterferenceFunction2DParaCrystal.h
@@ -40,8 +40,6 @@ public:
 
     void accept(ISampleVisitor* visitor) const final { visitor->visit(this); }
 
-    std::string to_str(int indent=0) const final;
-
     static InterferenceFunction2DParaCrystal* createSquare(double peak_distance,
                                                            double damping_length = 0.0,
                                                            double domain_size_1 = 0.0,

--- a/Core/Aggregate/InterferenceFunctionRadialParaCrystal.cpp
+++ b/Core/Aggregate/InterferenceFunctionRadialParaCrystal.cpp
@@ -59,7 +59,7 @@ std::string InterferenceFunctionRadialParaCrystal::to_str(int indent) const
     std::stringstream ss;
     ss << std::string(4*indent, '.') << " " << getName() << " " << *getParameterPool() << "\n";
     ss << std::string(4*(indent+1), '.') << " pdf: " << *getProbabilityDistribution() << "\n";
-    for( const ISample* child: getChildren() )
+    for(auto child: getChildren() )
         ss << child->to_str(indent+1);
     return ss.str();
 }

--- a/Core/Aggregate/InterferenceFunctionRadialParaCrystal.cpp
+++ b/Core/Aggregate/InterferenceFunctionRadialParaCrystal.cpp
@@ -54,16 +54,6 @@ InterferenceFunctionRadialParaCrystal* InterferenceFunctionRadialParaCrystal::cl
     return result;
 }
 
-std::string InterferenceFunctionRadialParaCrystal::to_str(int indent) const
-{
-    std::stringstream ss;
-    ss << std::string(4*indent, '.') << " " << getName() << " " << *getParameterPool() << "\n";
-    ss << std::string(4*(indent+1), '.') << " pdf: " << *getProbabilityDistribution() << "\n";
-    for(auto child: getChildren() )
-        ss << child->to_str(indent+1);
-    return ss.str();
-}
-
 double InterferenceFunctionRadialParaCrystal::evaluate(const kvector_t q) const
 {
     if (!mP_pdf)

--- a/Core/Aggregate/InterferenceFunctionRadialParaCrystal.h
+++ b/Core/Aggregate/InterferenceFunctionRadialParaCrystal.h
@@ -32,8 +32,6 @@ public:
 
     void accept(ISampleVisitor* visitor) const final { visitor->visit(this); }
 
-    std::string to_str(int indent=0) const final;
-
     void setKappa(double kappa) { m_kappa = kappa; }
     double getKappa() const final { return m_kappa; }
 

--- a/Core/Multilayer/Layer.cpp
+++ b/Core/Multilayer/Layer.cpp
@@ -55,17 +55,6 @@ Layer* Layer::cloneInvertB() const
     return p_clone;
 }
 
-std::string Layer::to_str(int indent) const
-{
-    std::stringstream ss;
-    ss << std::string(4*indent, '.') << " " << getName() << " "
-       << (getMaterial() ? getMaterial()->getName() : "0_MATERIAL") << " "
-       << getRefractiveIndex() << " " << *getParameterPool() << "\n";
-    for(auto child: getChildren() )
-        ss << child->to_str(indent+1);
-    return ss.str();
-}
-
 //! Sets layer thickness in nanometers.
 void Layer::setThickness(double thickness)
 {

--- a/Core/Multilayer/Layer.cpp
+++ b/Core/Multilayer/Layer.cpp
@@ -61,7 +61,7 @@ std::string Layer::to_str(int indent) const
     ss << std::string(4*indent, '.') << " " << getName() << " "
        << (getMaterial() ? getMaterial()->getName() : "0_MATERIAL") << " "
        << getRefractiveIndex() << " " << *getParameterPool() << "\n";
-    for( const ISample* child: getChildren() )
+    for(auto child: getChildren() )
         ss << child->to_str(indent+1);
     return ss.str();
 }

--- a/Core/Multilayer/Layer.h
+++ b/Core/Multilayer/Layer.h
@@ -38,8 +38,6 @@ public:
 
     void accept(ISampleVisitor* visitor) const final { visitor->visit(this); }
 
-    std::string to_str(int indent=0) const final;
-
     void setThickness(double thickness);
     double getThickness() const { return m_thickness; }
 

--- a/Core/Multilayer/MultiLayer.cpp
+++ b/Core/Multilayer/MultiLayer.cpp
@@ -35,11 +35,6 @@ MultiLayer::~MultiLayer()
     clear();
 }
 
-std::string MultiLayer::to_str(int indent) const
-{
-    return std::string(80, '-') + "\n" + ISample::to_str(indent);
-}
-
 void MultiLayer::init_parameters()
 {
     getParameterPool()->clear(); // non-trivially needed

--- a/Core/Multilayer/MultiLayer.h
+++ b/Core/Multilayer/MultiLayer.h
@@ -45,8 +45,6 @@ public:
 
     virtual void accept(ISampleVisitor* visitor) const { visitor->visit(this); }
 
-    virtual std::string to_str(int indent=0) const;
-
     size_t getNumberOfLayers() const { return m_layers.size(); }
     size_t getNumberOfInterfaces() const { return m_interfaces.size(); }
 

--- a/Core/Parametrization/INode.cpp
+++ b/Core/Parametrization/INode.cpp
@@ -7,9 +7,9 @@
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
-//! @copyright Forschungszentrum Jülich GmbH 2015
+//! @copyright Forschungszentrum Jülich GmbH 2016
 //! @authors   Scientific Computing Group at MLZ Garching
-//! @authors   C. Durniak, M. Ganeva, G. Pospelov, W. Van Herck, J. Wuttke
+//! @authors   M. Ganeva, G. Pospelov, W. Van Herck, J. Wuttke
 //
 // ************************************************************************** //
 

--- a/Core/Parametrization/INode.cpp
+++ b/Core/Parametrization/INode.cpp
@@ -19,7 +19,7 @@
 #include "NodeUtils.h"
 #include <algorithm>
 
-std::string INode::to_my_str() const
+std::string INode::to_str() const
 {
     return NodeUtils::nodeToString(*this);
 }

--- a/Core/Parametrization/INode.cpp
+++ b/Core/Parametrization/INode.cpp
@@ -16,7 +16,13 @@
 #include "INode.h"
 #include "StringUsageMap.h"
 #include "Exceptions.h"
+#include "NodeUtils.h"
 #include <algorithm>
+
+std::string INode::to_my_str() const
+{
+    return NodeUtils::nodeToString(*this);
+}
 
 void INode::registerChild(INode *sample)
 {

--- a/Core/Parametrization/INode.cpp
+++ b/Core/Parametrization/INode.cpp
@@ -14,3 +14,61 @@
 // ************************************************************************** //
 
 #include "INode.h"
+#include "StringUsageMap.h"
+#include "Exceptions.h"
+#include <algorithm>
+
+void INode::registerChild(INode *sample)
+{
+    if(!sample)
+        throw Exceptions::NullPointerException(
+            "ISample::registerChild -> Error. Null pointer.");
+    m_samples.push_back(sample);
+}
+
+//! remove registered child from the container
+
+void INode::deregisterChild(INode* sample)
+{
+    auto it = std::find(m_samples.begin(), m_samples.end(), sample);
+    if (it != m_samples.end())
+        m_samples.erase(it);
+}
+
+std::vector<const INode *> INode::getChildren() const
+{
+    std::vector<const INode*> result;
+    for (size_t i=0; i<m_samples.size(); ++i)
+        result.push_back(m_samples[i]);
+    return result;
+}
+
+std::string INode::addParametersToExternalPool(
+    const std::string& path, ParameterPool* external_pool, int copy_number) const
+{
+    std::string new_path
+        = IParameterized::addParametersToExternalPool(path, external_pool, copy_number);
+
+    // We need a mechanism to handle cases with multiple children with the same name.
+    // First run through all direct children and save their names
+    StringUsageMap strUsageMap;
+    for (size_t i = 0; i < m_samples.size(); ++i)
+        strUsageMap.add(new_path + m_samples[i]->getName()); // saving child names
+
+    // Now run through the direct children again and assign a copy number for
+    // all children with the same name
+    StringUsageMap strUsageMap2;
+    for (size_t i = 0; i < m_samples.size(); ++i) {
+        std::string child_name = new_path + m_samples[i]->getName();
+        strUsageMap2.add(child_name);
+        // Copy number starts from 0:
+        int ncopy = strUsageMap2[child_name] - 1;
+
+        // If the child is the only one with that name, we do not want any copy number:
+        if (strUsageMap[child_name] == 1)
+            ncopy = -1;
+
+        m_samples[i]->addParametersToExternalPool(new_path, external_pool, ncopy);
+    }
+    return new_path;
+}

--- a/Core/Parametrization/INode.cpp
+++ b/Core/Parametrization/INode.cpp
@@ -1,0 +1,16 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Core/Parametrization/INode.cpp
+//! @brief     Implements class INode.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2015
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   C. Durniak, M. Ganeva, G. Pospelov, W. Van Herck, J. Wuttke
+//
+// ************************************************************************** //
+
+#include "INode.h"

--- a/Core/Parametrization/INode.h
+++ b/Core/Parametrization/INode.h
@@ -33,12 +33,8 @@ public:
     //! Calls the ISampleVisitor's visit method.
     virtual void accept(ISampleVisitor* p_visitor) const=0;
 
-    std::string to_my_str() const;
-
-    virtual std::string to_str(int /*indent*/) const
-    {
-        return std::string("FIXME");
-    }
+    //! Returns multiline string representing tree structure below the node.
+    virtual std::string to_str() const;
 
     //! Registers child in the container.
     void registerChild(INode* sample);

--- a/Core/Parametrization/INode.h
+++ b/Core/Parametrization/INode.h
@@ -1,0 +1,32 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Core/Parametrization/INode.h
+//! @brief     Defines class INode.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2015
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   C. Durniak, M. Ganeva, G. Pospelov, W. Van Herck, J. Wuttke
+//
+// ************************************************************************** //
+
+#ifndef INODE_H
+#define INODE_H
+
+#include "IParameterized.h"
+
+//! Base class for tree-like structures containing parameterized objects.
+//! @ingroup tools_internal
+
+class BA_CORE_API_ INode : public IParameterized
+{
+public:
+    INode(){}
+    virtual ~INode(){}
+
+};
+
+#endif // INODE_H

--- a/Core/Parametrization/INode.h
+++ b/Core/Parametrization/INode.h
@@ -33,6 +33,8 @@ public:
     //! Calls the ISampleVisitor's visit method.
     virtual void accept(ISampleVisitor* p_visitor) const=0;
 
+    std::string to_my_str() const;
+
     virtual std::string to_str(int /*indent*/) const
     {
         return std::string("FIXME");
@@ -54,8 +56,6 @@ public:
 private:
     //! List of registered children.
     std::vector<INode*> m_samples;
-
-
 };
 
 #endif // INODE_H

--- a/Core/Parametrization/INode.h
+++ b/Core/Parametrization/INode.h
@@ -7,9 +7,9 @@
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
-//! @copyright Forschungszentrum Jülich GmbH 2015
+//! @copyright Forschungszentrum Jülich GmbH 2016
 //! @authors   Scientific Computing Group at MLZ Garching
-//! @authors   C. Durniak, M. Ganeva, G. Pospelov, W. Van Herck, J. Wuttke
+//! @authors   M. Ganeva, G. Pospelov, W. Van Herck, J. Wuttke
 //
 // ************************************************************************** //
 
@@ -30,13 +30,11 @@ public:
     INode(){}
     virtual ~INode(){}
 
-    //! Calls the ISampleVisitor's visit method.
     virtual void accept(ISampleVisitor* p_visitor) const=0;
 
     //! Returns multiline string representing tree structure below the node.
     virtual std::string to_str() const;
 
-    //! Registers child in the container.
     void registerChild(INode* sample);
 
     //! Removes registered child from the container

--- a/Core/Parametrization/INode.h
+++ b/Core/Parametrization/INode.h
@@ -17,6 +17,9 @@
 #define INODE_H
 
 #include "IParameterized.h"
+#include <vector>
+
+class ISampleVisitor;
 
 //! Base class for tree-like structures containing parameterized objects.
 //! @ingroup tools_internal
@@ -26,6 +29,32 @@ class BA_CORE_API_ INode : public IParameterized
 public:
     INode(){}
     virtual ~INode(){}
+
+    //! Calls the ISampleVisitor's visit method.
+    virtual void accept(ISampleVisitor* p_visitor) const=0;
+
+    virtual std::string to_str(int /*indent*/) const
+    {
+        return std::string("FIXME");
+    }
+
+    //! Registers child in the container.
+    void registerChild(INode* sample);
+
+    //! Removes registered child from the container
+    void deregisterChild(INode *sample);
+
+    //! Returns a vector of children (const).
+    virtual std::vector<const INode*> getChildren() const;
+
+    //! Adds parameters from local pool to external pool and recursively calls its direct children.
+    virtual std::string addParametersToExternalPool(
+        const std::string& path, ParameterPool* external_pool, int copy_number = -1) const;
+
+private:
+    //! List of registered children.
+    std::vector<INode*> m_samples;
+
 
 };
 

--- a/Core/Parametrization/NodeUtils.cpp
+++ b/Core/Parametrization/NodeUtils.cpp
@@ -34,7 +34,7 @@ namespace {
     std::string poolToMultiString(const INode &node, int depth) {
         std::ostringstream result;
 
-        for(auto par : node.getParameterPool()->getParameters())
+        for (auto par : node.getParameterPool()->getParameters())
             result << s_indent(depth)
                    << "'" << par->getName() << "':" << par->getValue() << "\n";
 
@@ -46,19 +46,18 @@ namespace {
         std::ostringstream result;
 
         const std::vector<RealParameter*> pars = node.getParameterPool()->getParameters();
-        if(pars.size())
-            result << " (";
+        if (pars.empty())
+            return {};
 
+        result << " (";
         size_t index(0);
-        for(auto par : pars) {
+        for (auto par : pars) {
             result << "'" << par->getName() << "':" << par->getValue();
             ++index;
-            if(index!=pars.size())
+            if (index!=pars.size())
                 result << " ";
         }
-
-        if(pars.size())
-            result << ")";
+        result << ")";
 
         return result.str();
     }

--- a/Core/Parametrization/NodeUtils.cpp
+++ b/Core/Parametrization/NodeUtils.cpp
@@ -1,0 +1,66 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Core/Parametrization/NodeUtils.cpp
+//! @brief     Implements collection of utility functions for INode.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2015
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   C. Durniak, M. Ganeva, G. Pospelov, W. Van Herck, J. Wuttke
+//
+// ************************************************************************** //
+
+#include "NodeUtils.h"
+#include "SampleTreeIterator.h"
+#include "ISampleIteratorStrategy.h"
+#include "RealParameter.h"
+#include "ParameterPool.h"
+#include "INode.h"
+#include <functional>
+#include <sstream>
+
+namespace {
+
+    // Returns string filled with '.'
+    std::string s_indent(int depth) {
+        const int multiplier = 4;
+        return std::string(multiplier*depth, '.');
+    }
+
+    // Returns multiline string representing pool parameters of given node.
+    std::string poolToString(const INode &node, int depth) {
+        std::ostringstream result;
+
+        for(auto par : node.getParameterPool()->getParameters())
+            result << s_indent(depth)
+                   << "'" << par->getName() << "':" << par->getValue() << "\n";
+
+        return result.str();
+    }
+
+    // Returns a string representing given node.
+    std::string nodeString(const INode& node, int depth) {
+        std::ostringstream result;
+        result << s_indent(depth) << node.getName() << "\n";
+        result << poolToString(node, depth+1);
+        return result.str();
+    }
+}
+
+std::string NodeUtils::nodeToString(const INode& node)
+{
+    std::ostringstream result;
+
+    SampleTreeIterator<SampleIteratorPreorderStrategy> it(&node);
+    it.first();
+    while (!it.isDone()) {
+        const INode *child = it.getCurrent();
+        result << nodeString(*child, it.depth()-1);
+        it.next();
+    }
+
+    return result.str();
+}

--- a/Core/Parametrization/NodeUtils.cpp
+++ b/Core/Parametrization/NodeUtils.cpp
@@ -31,7 +31,7 @@ namespace {
     }
 
     // Returns multiline string representing pool parameters of given node.
-    std::string poolToString(const INode &node, int depth) {
+    std::string poolToMultiString(const INode &node, int depth) {
         std::ostringstream result;
 
         for(auto par : node.getParameterPool()->getParameters())
@@ -41,11 +41,33 @@ namespace {
         return result.str();
     }
 
+    // Returns single line string representing pool parameters of given node.
+    std::string poolToString(const INode &node) {
+        std::ostringstream result;
+
+        const std::vector<RealParameter*> pars = node.getParameterPool()->getParameters();
+        if(pars.size())
+            result << " (";
+
+        size_t index(0);
+        for(auto par : pars) {
+            result << "'" << par->getName() << "':" << par->getValue();
+            ++index;
+            if(index!=pars.size())
+                result << " ";
+        }
+
+        if(pars.size())
+            result << ")";
+
+        return result.str();
+    }
+
     // Returns a string representing given node.
     std::string nodeString(const INode& node, int depth) {
         std::ostringstream result;
-        result << s_indent(depth) << node.getName() << "\n";
-        result << poolToString(node, depth+1);
+        //result << s_indent(depth) << node.getName() << "\n" << poolToMultiString(node, depth+1);
+        result << s_indent(depth) << node.getName() << poolToString(node) << "\n";
         return result.str();
     }
 }

--- a/Core/Parametrization/NodeUtils.h
+++ b/Core/Parametrization/NodeUtils.h
@@ -1,0 +1,31 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Core/Parametrization/NodeUtils.h
+//! @brief     Defines collection of utility functions for INode.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2015
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   C. Durniak, M. Ganeva, G. Pospelov, W. Van Herck, J. Wuttke
+//
+// ************************************************************************** //
+
+#ifndef NODEUTILS_H
+#define NODEUTILS_H
+
+#include "WinDllMacros.h"
+#include<string>
+
+class INode;
+
+namespace NodeUtils {
+
+    //! Returns multiline string representing tree structure starting from given node.
+    BA_CORE_API_ std::string nodeToString(const INode& node);
+
+} //namespace NodeUtils
+
+#endif // NODEUTILS_H

--- a/Core/Particle/Particle.cpp
+++ b/Core/Particle/Particle.cpp
@@ -87,7 +87,7 @@ std::string Particle::to_str(int indent) const
     ss << std::string(4*indent, '.') << " " << getName() << " "
        << (getMaterial() ? getMaterial()->getName() : "0_MATERIAL") << " "
        << getRefractiveIndex() << "\n";
-    for( const ISample* child: getChildren() )
+    for(auto child: getChildren() )
         ss << child->to_str(indent+1);
     return ss.str();
 }

--- a/Core/Particle/Particle.cpp
+++ b/Core/Particle/Particle.cpp
@@ -81,17 +81,6 @@ Particle* Particle::cloneInvertB() const
     return p_result;
 }
 
-std::string Particle::to_str(int indent) const
-{
-    std::stringstream ss;
-    ss << std::string(4*indent, '.') << " " << getName() << " "
-       << (getMaterial() ? getMaterial()->getName() : "0_MATERIAL") << " "
-       << getRefractiveIndex() << "\n";
-    for(auto child: getChildren() )
-        ss << child->to_str(indent+1);
-    return ss.str();
-}
-
 void Particle::setAmbientMaterial(const IMaterial& material)
 {
     if(mP_ambient_material.get() != &material)

--- a/Core/Particle/Particle.h
+++ b/Core/Particle/Particle.h
@@ -40,8 +40,6 @@ public:
 
     virtual void accept(ISampleVisitor* visitor) const { visitor->visit(this); }
 
-    virtual std::string to_str(int indent=0) const;
-
     void setAmbientMaterial(const IMaterial& material) final;
     const IMaterial* getAmbientMaterial() const final { return mP_ambient_material.get(); }
 

--- a/Core/Particle/ParticleDistribution.cpp
+++ b/Core/Particle/ParticleDistribution.cpp
@@ -49,7 +49,7 @@ std::string ParticleDistribution::to_str(int indent) const
 {
     std::stringstream ss;
     ss << std::string(4*indent, '.') << " " << getName() << "\n";
-    for( const ISample* child: getChildren() )
+    for(auto child: getChildren() )
         ss << child->to_str(indent+1);
     return ss.str();
 }

--- a/Core/Particle/ParticleDistribution.cpp
+++ b/Core/Particle/ParticleDistribution.cpp
@@ -45,14 +45,6 @@ ParticleDistribution* ParticleDistribution::cloneInvertB() const
                                               "cloneInvertB: should never be called");
 }
 
-std::string ParticleDistribution::to_str(int indent) const
-{
-    std::stringstream ss;
-    ss << std::string(4*indent, '.') << " " << getName() << "\n";
-    for(auto child: getChildren() )
-        ss << child->to_str(indent+1);
-    return ss.str();
-}
 void ParticleDistribution::setAmbientMaterial(const IMaterial& material)
 {
     mP_particle->setAmbientMaterial(material);

--- a/Core/Particle/ParticleDistribution.h
+++ b/Core/Particle/ParticleDistribution.h
@@ -34,9 +34,6 @@ public:
 
     void accept(ISampleVisitor* visitor) const final { visitor->visit(this); }
 
-    //! Returns textual representation of *this and its descendants.
-    std::string to_str(int indent=0) const final;
-
     //! Sets the refractive index of the ambient material.
     void setAmbientMaterial(const IMaterial& material) final;
 

--- a/Core/Scattering/ISample.cpp
+++ b/Core/Scattering/ISample.cpp
@@ -27,15 +27,6 @@ ISample* ISample::cloneInvertB() const
         "ISample::cloneInvertB() -> Error! Method is not implemented");
 }
 
-std::string ISample::to_str(int indent) const
-{
-    std::stringstream ss;
-    ss << std::string(4*indent, '.') << " " << getName() << " " << *getParameterPool() << "\n";
-    for(auto child: getChildren() )
-        ss << child->to_str(indent+1);
-    return ss.str();
-}
-
 std::vector<const IMaterial*> ISample::containedMaterials() const
 {
     std::vector<const IMaterial*> result;

--- a/Core/Scattering/ISample.cpp
+++ b/Core/Scattering/ISample.cpp
@@ -35,7 +35,7 @@ std::vector<const IMaterial*> ISample::containedMaterials() const
     if( const IMaterial* material = getAmbientMaterial() )
         result.push_back( material );
     for(auto child: getChildren() ) {
-        if(const ISample *sample = dynamic_cast<const ISample *>(child)) {
+        if(const ISample* sample = dynamic_cast<const ISample *>(child)) {
             for( const IMaterial* material: sample->containedMaterials() )
                 result.push_back( material );
         }

--- a/Core/Scattering/ISample.cpp
+++ b/Core/Scattering/ISample.cpp
@@ -31,7 +31,7 @@ std::string ISample::to_str(int indent) const
 {
     std::stringstream ss;
     ss << std::string(4*indent, '.') << " " << getName() << " " << *getParameterPool() << "\n";
-    for( const ISample* child: getChildren() )
+    for(auto child: getChildren() )
         ss << child->to_str(indent+1);
     return ss.str();
 }
@@ -43,63 +43,11 @@ std::vector<const IMaterial*> ISample::containedMaterials() const
         result.push_back( material );
     if( const IMaterial* material = getAmbientMaterial() )
         result.push_back( material );
-    for( const ISample* child: getChildren() )
-        for( const IMaterial* material: child->containedMaterials() )
-            result.push_back( material );
-    return result;
-}
-
-void ISample::registerChild(ISample* sample)
-{
-    if(!sample)
-        throw Exceptions::NullPointerException(
-            "ISample::registerChild -> Error. Null pointer.");
-    m_samples.push_back(sample);
-}
-
-//! remove registered child from the container
-
-void ISample::deregisterChild(ISample* sample)
-{
-    auto it = std::find(m_samples.begin(), m_samples.end(), sample);
-    if (it != m_samples.end())
-        m_samples.erase(it);
-}
-
-std::vector<const ISample*> ISample::getChildren() const
-{
-    std::vector<const ISample*> result;
-    for (size_t i=0; i<m_samples.size(); ++i)
-        result.push_back(m_samples[i]);
-    return result;
-}
-
-std::string ISample::addParametersToExternalPool(
-    const std::string& path, ParameterPool* external_pool, int copy_number) const
-{
-    std::string new_path
-        = IParameterized::addParametersToExternalPool(path, external_pool, copy_number);
-
-    // We need a mechanism to handle cases with multiple children with the same name.
-    // First run through all direct children and save their names
-    StringUsageMap strUsageMap;
-    for (size_t i = 0; i < m_samples.size(); ++i)
-        strUsageMap.add(new_path + m_samples[i]->getName()); // saving child names
-
-    // Now run through the direct children again and assign a copy number for
-    // all children with the same name
-    StringUsageMap strUsageMap2;
-    for (size_t i = 0; i < m_samples.size(); ++i) {
-        std::string child_name = new_path + m_samples[i]->getName();
-        strUsageMap2.add(child_name);
-        // Copy number starts from 0:
-        int ncopy = strUsageMap2[child_name] - 1;
-
-        // If the child is the only one with that name, we do not want any copy number:
-        if (strUsageMap[child_name] == 1)
-            ncopy = -1;
-
-        m_samples[i]->addParametersToExternalPool(new_path, external_pool, ncopy);
+    for(auto child: getChildren() ) {
+        if(const ISample *sample = dynamic_cast<const ISample *>(child)) {
+            for( const IMaterial* material: sample->containedMaterials() )
+                result.push_back( material );
+        }
     }
-    return new_path;
+    return result;
 }

--- a/Core/Scattering/ISample.h
+++ b/Core/Scattering/ISample.h
@@ -17,7 +17,7 @@
 #define ISAMPLE_H
 
 #include "ICloneable.h"
-#include "IParameterized.h"
+#include "INode.h"
 #include "ISampleVisitor.h"
 #include <vector>
 
@@ -26,7 +26,7 @@ class IMaterial;
 //! Pure virtual base class for sample components and properties related to scattering.
 //! @ingroup samples_internal
 
-class BA_CORE_API_ ISample : public ICloneable, public IParameterized
+class BA_CORE_API_ ISample : public ICloneable, public INode
 {
 public:
     //! Returns a clone of this ISample object.

--- a/Core/Scattering/ISample.h
+++ b/Core/Scattering/ISample.h
@@ -35,9 +35,6 @@ public:
     //! Returns a clone with inverted magnetic fields.
     virtual ISample* cloneInvertB() const;
 
-    //! Returns textual representation of this and its descendants.
-    virtual std::string to_str(int indent=0) const;
-
     //! Returns nullptr, unless overwritten to return a specific material.
     virtual const IMaterial* getMaterial() const { return nullptr; }
 

--- a/Core/Scattering/ISample.h
+++ b/Core/Scattering/ISample.h
@@ -35,9 +35,6 @@ public:
     //! Returns a clone with inverted magnetic fields.
     virtual ISample* cloneInvertB() const;
 
-    //! Calls the ISampleVisitor's visit method.
-    virtual void accept(ISampleVisitor* p_visitor) const=0;
-
     //! Returns textual representation of this and its descendants.
     virtual std::string to_str(int indent=0) const;
 
@@ -51,24 +48,6 @@ public:
     std::vector<const IMaterial*> containedMaterials() const;
 
     template<class T> std::vector<const T*> containedSubclass() const;
-
-    //! Registers child in the container.
-    void registerChild(ISample* sample);
-
-    //! Removes registered child from the container
-    void deregisterChild(ISample* sample);
-
-    //! Returns a vector of children (const).
-    virtual std::vector<const ISample*> getChildren() const;
-
-    //! Adds parameters from local pool to external pool and recursively calls its direct children.
-    virtual std::string addParametersToExternalPool(
-        const std::string& path, ParameterPool* external_pool, int copy_number = -1) const;
-
-private:
-    //! List of registered children.
-    std::vector<ISample*> m_samples;
-
 };
 
 //! Returns vector of children of type T.
@@ -78,9 +57,12 @@ std::vector<const T*> ISample::containedSubclass() const
     std::vector<const T*> result;
     if( const T* t = dynamic_cast<const T*>(this) )
         result.push_back( t );
-    for( const ISample* child: getChildren() )
-        for( const T* t: child->containedSubclass<T>() )
-            result.push_back( t );
+    for(auto child: getChildren() ) {
+        if(const ISample *sample = dynamic_cast<const ISample *>(child)) {
+            for( const T* t: sample->containedSubclass<T>() )
+                result.push_back( t );
+        }
+    }
     return result;
 }
 

--- a/Core/Scattering/ISampleIteratorStrategy.cpp
+++ b/Core/Scattering/ISampleIteratorStrategy.cpp
@@ -30,7 +30,7 @@ SampleIteratorPreorderStrategy::~SampleIteratorPreorderStrategy()
 {
 }
 
-IteratorMemento SampleIteratorPreorderStrategy::first(const ISample *p_root)
+IteratorMemento SampleIteratorPreorderStrategy::first(const INode *p_root)
 {
     IteratorMemento iterator_stack;
     iterator_stack.push_state( IteratorState(p_root) );
@@ -39,12 +39,12 @@ IteratorMemento SampleIteratorPreorderStrategy::first(const ISample *p_root)
 
 void SampleIteratorPreorderStrategy::next(IteratorMemento &iterator_stack) const
 {
-    const ISample *p_sample = iterator_stack.getCurrent();
+    const INode *p_sample = iterator_stack.getCurrent();
     if( !p_sample ) {
         throw Exceptions::NullPointerException("CompositeIteratorPreorderStrategy::next(): "
                                    "Error! Null object in the tree of objects");
     }
-    std::vector<const ISample*> children = p_sample->getChildren();
+    std::vector<const INode*> children = p_sample->getChildren();
     if (children.size()>0) {
         iterator_stack.push_state( IteratorState(children) );
         return;
@@ -76,11 +76,11 @@ SampleIteratorPostorderStrategy::~SampleIteratorPostorderStrategy()
 {
 }
 
-IteratorMemento SampleIteratorPostorderStrategy::first(const ISample *p_root)
+IteratorMemento SampleIteratorPostorderStrategy::first(const INode *p_root)
 {
     IteratorMemento iterator_stack;
     iterator_stack.push_state( IteratorState(p_root) );
-    std::vector<const ISample *> children = p_root->getChildren();
+    std::vector<const INode *> children = p_root->getChildren();
     while (children.size()>0) {
         iterator_stack.push_state( IteratorState(children) );
         children = iterator_stack.getCurrent()->getChildren();
@@ -96,7 +96,7 @@ void SampleIteratorPostorderStrategy::next(IteratorMemento &iterator_stack) cons
         iterator_stack.pop_state();
         return;
     }
-    std::vector<const ISample *> children = iterator_stack.getCurrent()->getChildren();
+    std::vector<const INode *> children = iterator_stack.getCurrent()->getChildren();
     while (children.size()>0) {
         iterator_stack.push_state( IteratorState(children) );
         children = iterator_stack.getCurrent()->getChildren();

--- a/Core/Scattering/ISampleIteratorStrategy.h
+++ b/Core/Scattering/ISampleIteratorStrategy.h
@@ -27,7 +27,7 @@ public:
 
     virtual ISampleIteratorStrategy* clone() const=0;
 
-    virtual IteratorMemento first(const ISample* p_root)=0;
+    virtual IteratorMemento first(const INode* p_root)=0;
     virtual void next(IteratorMemento &iterator_stack) const=0;
     virtual bool isDone(IteratorMemento &iterator_stack) const=0;
 };
@@ -40,7 +40,7 @@ public:
     virtual SampleIteratorPreorderStrategy* clone() const;
 
     virtual ~SampleIteratorPreorderStrategy();
-    virtual IteratorMemento first(const ISample* p_root);
+    virtual IteratorMemento first(const INode* p_root);
     virtual void next(IteratorMemento &iterator_stack) const;
     virtual bool isDone(IteratorMemento &iterator_stack) const;
 };
@@ -53,7 +53,7 @@ public:
     virtual SampleIteratorPostorderStrategy* clone() const;
 
     virtual ~SampleIteratorPostorderStrategy();
-    virtual IteratorMemento first(const ISample* p_root);
+    virtual IteratorMemento first(const INode* p_root);
     virtual void next(IteratorMemento &iterator_stack) const;
     virtual bool isDone(IteratorMemento &iterator_stack) const;
 };

--- a/Core/Scattering/ISampleVisitor.cpp
+++ b/Core/Scattering/ISampleVisitor.cpp
@@ -23,7 +23,7 @@ void VisitSampleTreePreorder(const ISample& sample, ISampleVisitor& visitor)
     it.first();
     while (!it.isDone()) {
         visitor.setDepth(it.depth());
-        const ISample *child = it.getCurrent();
+        const INode *child = it.getCurrent();
         child->accept(&visitor);
         it.next();
     }
@@ -35,7 +35,7 @@ void VisitSampleTreePostorder(const ISample& sample, ISampleVisitor& visitor)
     it.first();
     while (!it.isDone()) {
         visitor.setDepth(it.depth());
-        const ISample *child = it.getCurrent();
+        const INode *child = it.getCurrent();
         child->accept(&visitor);
         it.next();
     }
@@ -45,6 +45,12 @@ void ISampleVisitor::visit(const ISample*)
 {
     throw Exceptions::NotImplementedException(
         "ISampleVisitor::visit(const ISample*) -> Error. Not implemented.");
+}
+
+void ISampleVisitor::visit(const INode*)
+{
+    throw Exceptions::NotImplementedException(
+        "ISampleVisitor::visit(const INode*) -> Error. Not implemented.");
 }
 
 void ISampleVisitor::visit(const IClusteredParticles*)

--- a/Core/Scattering/ISampleVisitor.h
+++ b/Core/Scattering/ISampleVisitor.h
@@ -18,6 +18,7 @@
 
 #include "WinDllMacros.h"
 
+class INode;
 class ISample;
 // - the order according to the hierarchy as reported by IDE
 class IClusteredParticles;
@@ -116,6 +117,7 @@ public:
 
     // visiting methods (the order according to the hierarchy as reported by IDE)
 
+    virtual void visit(const INode*);
     virtual void visit(const ISample*);
 
     virtual void visit(const IClusteredParticles*);

--- a/Core/Scattering/SampleTreeIterator.cpp
+++ b/Core/Scattering/SampleTreeIterator.cpp
@@ -17,13 +17,13 @@
 
 
 
-IteratorState::IteratorState(const ISample *single_element)
+IteratorState::IteratorState(const INode *single_element)
     : m_position(0)
 {
     m_samples.push_back(single_element);
 }
 
-IteratorState::IteratorState(std::vector<const ISample *> samples)
+IteratorState::IteratorState(std::vector<const INode *> samples)
     : m_samples(samples)
     , m_position(0)
 {

--- a/Core/Scattering/SampleTreeIterator.h
+++ b/Core/Scattering/SampleTreeIterator.h
@@ -16,9 +16,10 @@
 #ifndef SAMPLETREEITERATOR_H
 #define SAMPLETREEITERATOR_H
 
-#include "ISample.h"
+#include "INode.h"
 #include <ostream>
 #include <stack>
+#include <vector>
 
 //! Holds state of iterator at single level for SampleTreeIterator.
 //! @ingroup samples_internal
@@ -26,12 +27,12 @@
 class IteratorState
 {
 public:
-    IteratorState(const ISample* single_element);
-    IteratorState(std::vector<const ISample*> samples);
+    IteratorState(const INode* single_element);
+    IteratorState(std::vector<const INode*> samples);
 
     virtual ~IteratorState() {}
 
-    const ISample* getCurrent() const { return m_samples[m_position]; }
+    const INode* getCurrent() const { return m_samples[m_position]; }
     bool isEnd() const { return m_position>=m_samples.size(); }
     void next() { ++m_position; }
 
@@ -41,7 +42,7 @@ public:
                              << iterator_state.m_samples.size(); }
 
 private:
-    std::vector<const ISample*> m_samples;
+    std::vector<const INode*> m_samples;
     size_t m_position;
 
     IteratorState();
@@ -61,7 +62,7 @@ public:
     IteratorState& get_state() { return m_state_stack.top(); }
     bool empty() const { return m_state_stack.empty(); }
     void reset() { while(!m_state_stack.empty()) m_state_stack.pop(); }
-    const ISample* getCurrent() { return m_state_stack.top().getCurrent(); }
+    const INode* getCurrent() { return m_state_stack.top().getCurrent(); }
     void next() { m_state_stack.top().next(); }
     size_t size() const { return m_state_stack.size(); }
 protected:
@@ -69,13 +70,13 @@ protected:
 };
 
 
-//! Iterator through ISample tree of objects inside ISample object.
+//! Iterator through INode tree of objects.
 //!
 //! Usage example:
 //!    SampleTreeIterator<Strategy> it(&sample);
 //!    it.first();
 //!    while( !it.is_done() ) {
-//!        ISample *p_sample = it.get_current();
+//!        INode *p_sample = it.get_current();
 //!        it.next();
 //!     }
 //! @ingroup samples_internal
@@ -84,22 +85,22 @@ template <class Strategy>
 class BA_CORE_API_ SampleTreeIterator
 {
 public:
-    SampleTreeIterator(const ISample *root);
+    SampleTreeIterator(const INode *root);
     virtual ~SampleTreeIterator() {}
 
     void first();
     void next();
-    const ISample* getCurrent();
+    const INode* getCurrent();
     bool isDone() const;
     size_t depth() const;
 protected:
     Strategy m_strategy;
     IteratorMemento m_memento_itor;
-    const ISample* mp_root;
+    const INode* mp_root;
 };
 
 template <class Strategy>
-inline SampleTreeIterator<Strategy>::SampleTreeIterator(const ISample *root)
+inline SampleTreeIterator<Strategy>::SampleTreeIterator(const INode *root)
     : mp_root(root)
 {
 }
@@ -117,7 +118,7 @@ inline void SampleTreeIterator<Strategy>::next()
 }
 
 template <class Strategy>
-inline const ISample *SampleTreeIterator<Strategy>::getCurrent()
+inline const INode *SampleTreeIterator<Strategy>::getCurrent()
 {
     return m_memento_itor.getCurrent();
 }

--- a/Examples/python/simulation/ex01_BasicParticles/CylindersAndPrisms.py
+++ b/Examples/python/simulation/ex01_BasicParticles/CylindersAndPrisms.py
@@ -37,6 +37,7 @@ def get_sample():
     multi_layer.addLayer(air_layer)
     multi_layer.addLayer(substrate_layer)
     multi_layer.printParameters()
+    print(multi_layer.to_str())
     return multi_layer
 
 

--- a/Tests/UnitTests/Core/Sample/MultiLayerTest.h
+++ b/Tests/UnitTests/Core/Sample/MultiLayerTest.h
@@ -516,10 +516,10 @@ TEST_F(MultiLayerTest, MultiLayerCompositeTest)
     std::vector<const LayerInterface *> interface_buffer;
     int counter(0);
 
-    std::vector<const ISample*> children = mLayer.getChildren();
+    std::vector<const INode*> children = mLayer.getChildren();
     for(size_t index=0; index<children.size();++index)
     {
-        const ISample *sample = children[index];
+        const INode *sample = children[index];
         if(counter%2 == 1)
         {
             const LayerInterface *interface = dynamic_cast<const LayerInterface *>(sample);

--- a/Wrap/swig/directors.i
+++ b/Wrap/swig/directors.i
@@ -3,11 +3,8 @@
 
 %feature("director") IMultiLayerBuilder;
 %feature("director") INamed;
-%feature("director") INamedShared;
 %feature("director") IParameterized;
-%feature("director") IParameterizedShared;
-%feature("director") IParameterizedTemplate<ICloneable>;
-%feature("director") IParameterizedTemplate<IShareable>;
+%feature("director") INode;
 %feature("director") ISample;
 %feature("director") IFormFactor;
 %feature("director") IFormFactorBorn;

--- a/Wrap/swig/libBornAgainCore.i
+++ b/Wrap/swig/libBornAgainCore.i
@@ -150,6 +150,7 @@
 #include "ILayout.h"
 #include "IMaterial.h"
 #include "INamed.h"
+#include "INode.h"
 #include "INoncopyable.h"
 #include "IObserver.h"
 #include "IParameterized.h"
@@ -253,6 +254,7 @@
 %include "ICloneable.h"
 %include "INamed.h"
 %include "IParameterized.h"
+%include "INode.h"
 
 // SWIG does not automatically instantiate templates, so we declare these by hand
 %template(kvector_t) BasicVector3D<double>;

--- a/auto/Wrap/libBornAgainCore.py
+++ b/auto/Wrap/libBornAgainCore.py
@@ -2020,9 +2020,9 @@ class INode(IParameterized):
         return _libBornAgainCore.INode_accept(self, p_visitor)
 
 
-    def to_str(self, arg0):
-        """to_str(INode self, int arg0) -> std::string"""
-        return _libBornAgainCore.INode_to_str(self, arg0)
+    def to_str(self):
+        """to_str(INode self) -> std::string"""
+        return _libBornAgainCore.INode_to_str(self)
 
 
     def registerChild(self, sample):
@@ -4123,19 +4123,6 @@ class ISample(ICloneable, INode):
 
         """
         return _libBornAgainCore.ISample_cloneInvertB(self)
-
-
-    def to_str(self, indent=0):
-        """
-        to_str(ISample self, int indent=0) -> std::string
-        to_str(ISample self) -> std::string
-
-        std::string ISample::to_str(int indent=0) const
-
-        Returns textual representation of this and its descendants. 
-
-        """
-        return _libBornAgainCore.ISample_to_str(self, indent)
 
 
     def getMaterial(self):
@@ -19203,19 +19190,6 @@ class InterferenceFunctionRadialParaCrystal(IInterferenceFunction):
         return _libBornAgainCore.InterferenceFunctionRadialParaCrystal_accept(self, visitor)
 
 
-    def to_str(self, indent=0):
-        """
-        to_str(InterferenceFunctionRadialParaCrystal self, int indent=0) -> std::string
-        to_str(InterferenceFunctionRadialParaCrystal self) -> std::string
-
-        std::string InterferenceFunctionRadialParaCrystal::to_str(int indent=0) const  final
-
-        Returns textual representation of this and its descendants. 
-
-        """
-        return _libBornAgainCore.InterferenceFunctionRadialParaCrystal_to_str(self, indent)
-
-
     def setKappa(self, kappa):
         """
         setKappa(InterferenceFunctionRadialParaCrystal self, double kappa)
@@ -19568,19 +19542,6 @@ class InterferenceFunction2DParaCrystal(IInterferenceFunction):
 
         """
         return _libBornAgainCore.InterferenceFunction2DParaCrystal_accept(self, visitor)
-
-
-    def to_str(self, indent=0):
-        """
-        to_str(InterferenceFunction2DParaCrystal self, int indent=0) -> std::string
-        to_str(InterferenceFunction2DParaCrystal self) -> std::string
-
-        std::string InterferenceFunction2DParaCrystal::to_str(int indent=0) const  final
-
-        Returns textual representation of this and its descendants. 
-
-        """
-        return _libBornAgainCore.InterferenceFunction2DParaCrystal_to_str(self, indent)
 
 
     def createSquare(peak_distance, damping_length=0.0, domain_size_1=0.0, domain_size_2=0.0):
@@ -20475,19 +20436,6 @@ class Layer(ISample):
         return _libBornAgainCore.Layer_accept(self, visitor)
 
 
-    def to_str(self, indent=0):
-        """
-        to_str(Layer self, int indent=0) -> std::string
-        to_str(Layer self) -> std::string
-
-        std::string Layer::to_str(int indent=0) const  final
-
-        Returns textual representation of this and its descendants. 
-
-        """
-        return _libBornAgainCore.Layer_to_str(self, indent)
-
-
     def setThickness(self, thickness):
         """
         setThickness(Layer self, double thickness)
@@ -21302,19 +21250,6 @@ class MultiLayer(ISample):
 
         """
         return _libBornAgainCore.MultiLayer_accept(self, visitor)
-
-
-    def to_str(self, indent=0):
-        """
-        to_str(MultiLayer self, int indent=0) -> std::string
-        to_str(MultiLayer self) -> std::string
-
-        std::string MultiLayer::to_str(int indent=0) const
-
-        Returns textual representation of this and its descendants. 
-
-        """
-        return _libBornAgainCore.MultiLayer_to_str(self, indent)
 
 
     def getNumberOfLayers(self):
@@ -22884,19 +22819,6 @@ class Particle(IParticle):
         return _libBornAgainCore.Particle_accept(self, visitor)
 
 
-    def to_str(self, indent=0):
-        """
-        to_str(Particle self, int indent=0) -> std::string
-        to_str(Particle self) -> std::string
-
-        std::string Particle::to_str(int indent=0) const
-
-        Returns textual representation of this and its descendants. 
-
-        """
-        return _libBornAgainCore.Particle_to_str(self, indent)
-
-
     def setAmbientMaterial(self, material):
         """
         setAmbientMaterial(Particle self, IMaterial material)
@@ -23357,19 +23279,6 @@ class ParticleDistribution(IAbstractParticle):
 
         """
         return _libBornAgainCore.ParticleDistribution_accept(self, visitor)
-
-
-    def to_str(self, indent=0):
-        """
-        to_str(ParticleDistribution self, int indent=0) -> std::string
-        to_str(ParticleDistribution self) -> std::string
-
-        std::string ParticleDistribution::to_str(int indent=0) const  final
-
-        Returns textual representation of *this and its descendants. 
-
-        """
-        return _libBornAgainCore.ParticleDistribution_to_str(self, indent)
 
 
     def setAmbientMaterial(self, material):

--- a/auto/Wrap/libBornAgainCore.py
+++ b/auto/Wrap/libBornAgainCore.py
@@ -2014,6 +2014,31 @@ class INode(IParameterized):
             self.this = this
     __swig_destroy__ = _libBornAgainCore.delete_INode
     __del__ = lambda self: None
+
+    def accept(self, p_visitor):
+        """accept(INode self, ISampleVisitor p_visitor)"""
+        return _libBornAgainCore.INode_accept(self, p_visitor)
+
+
+    def to_str(self, arg0):
+        """to_str(INode self, int arg0) -> std::string"""
+        return _libBornAgainCore.INode_to_str(self, arg0)
+
+
+    def registerChild(self, sample):
+        """registerChild(INode self, INode sample)"""
+        return _libBornAgainCore.INode_registerChild(self, sample)
+
+
+    def deregisterChild(self, sample):
+        """deregisterChild(INode self, INode sample)"""
+        return _libBornAgainCore.INode_deregisterChild(self, sample)
+
+
+    def getChildren(self):
+        """getChildren(INode self) -> std::vector< INode const *,std::allocator< INode const * > >"""
+        return _libBornAgainCore.INode_getChildren(self)
+
     def __disown__(self):
         self.this.disown()
         _libBornAgainCore.disown_INode(self)
@@ -4100,18 +4125,6 @@ class ISample(ICloneable, INode):
         return _libBornAgainCore.ISample_cloneInvertB(self)
 
 
-    def accept(self, p_visitor):
-        """
-        accept(ISample self, ISampleVisitor p_visitor)
-
-        virtual void ISample::accept(ISampleVisitor *p_visitor) const  =0
-
-        Calls the  ISampleVisitor's visit method. 
-
-        """
-        return _libBornAgainCore.ISample_accept(self, p_visitor)
-
-
     def to_str(self, indent=0):
         """
         to_str(ISample self, int indent=0) -> std::string
@@ -4159,28 +4172,6 @@ class ISample(ICloneable, INode):
 
         """
         return _libBornAgainCore.ISample_containedMaterials(self)
-
-
-    def registerChild(self, sample):
-        """registerChild(ISample self, ISample sample)"""
-        return _libBornAgainCore.ISample_registerChild(self, sample)
-
-
-    def deregisterChild(self, sample):
-        """deregisterChild(ISample self, ISample sample)"""
-        return _libBornAgainCore.ISample_deregisterChild(self, sample)
-
-
-    def getChildren(self):
-        """
-        getChildren(ISample self) -> swig_dummy_type_const_isample_vector
-
-        virtual std::vector<const ISample*> ISample::getChildren() const
-
-        Returns a vector of children. 
-
-        """
-        return _libBornAgainCore.ISample_getChildren(self)
 
 
     def __init__(self):
@@ -7136,6 +7127,7 @@ class ISampleVisitor(_object):
 
     def visit(self, *args):
         """
+        visit(ISampleVisitor self, INode arg2)
         visit(ISampleVisitor self, ISample arg2)
         visit(ISampleVisitor self, IClusteredParticles arg2)
         visit(ISampleVisitor self, Crystal arg2)

--- a/auto/Wrap/libBornAgainCore.py
+++ b/auto/Wrap/libBornAgainCore.py
@@ -1988,6 +1988,49 @@ class IParameterized(INamed):
 IParameterized_swigregister = _libBornAgainCore.IParameterized_swigregister
 IParameterized_swigregister(IParameterized)
 
+class INode(IParameterized):
+    """Proxy of C++ INode class."""
+
+    __swig_setmethods__ = {}
+    for _s in [IParameterized]:
+        __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
+    __setattr__ = lambda self, name, value: _swig_setattr(self, INode, name, value)
+    __swig_getmethods__ = {}
+    for _s in [IParameterized]:
+        __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
+    __getattr__ = lambda self, name: _swig_getattr(self, INode, name)
+    __repr__ = _swig_repr
+
+    def __init__(self):
+        """__init__(INode self) -> INode"""
+        if self.__class__ == INode:
+            _self = None
+        else:
+            _self = self
+        this = _libBornAgainCore.new_INode(_self, )
+        try:
+            self.this.append(this)
+        except Exception:
+            self.this = this
+    __swig_destroy__ = _libBornAgainCore.delete_INode
+    __del__ = lambda self: None
+    def __disown__(self):
+        self.this.disown()
+        _libBornAgainCore.disown_INode(self)
+        return weakref_proxy(self)
+
+    def onChange(self):
+        """onChange(INode self)"""
+        return _libBornAgainCore.INode_onChange(self)
+
+
+    def _print(self, ostr):
+        """_print(INode self, std::ostream & ostr)"""
+        return _libBornAgainCore.INode__print(self, ostr)
+
+INode_swigregister = _libBornAgainCore.INode_swigregister
+INode_swigregister(INode)
+
 class kvector_t(_object):
     """
 
@@ -4009,7 +4052,7 @@ class IShape2D(ICloneable, INamed):
 IShape2D_swigregister = _libBornAgainCore.IShape2D_swigregister
 IShape2D_swigregister(IShape2D)
 
-class ISample(ICloneable, IParameterized):
+class ISample(ICloneable, INode):
     """
 
 
@@ -4024,11 +4067,11 @@ class ISample(ICloneable, IParameterized):
     """
 
     __swig_setmethods__ = {}
-    for _s in [ICloneable, IParameterized]:
+    for _s in [ICloneable, INode]:
         __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
     __setattr__ = lambda self, name, value: _swig_setattr(self, ISample, name, value)
     __swig_getmethods__ = {}
-    for _s in [ICloneable, IParameterized]:
+    for _s in [ICloneable, INode]:
         __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
     __getattr__ = lambda self, name: _swig_getattr(self, ISample, name)
     __repr__ = _swig_repr

--- a/auto/Wrap/libBornAgainCore_wrap.h
+++ b/auto/Wrap/libBornAgainCore_wrap.h
@@ -87,6 +87,56 @@ private:
 };
 
 
+class SwigDirector_INode : public INode, public Swig::Director {
+
+public:
+    SwigDirector_INode(PyObject *self);
+    virtual ~SwigDirector_INode();
+    virtual std::string addParametersToExternalPool(std::string const &path, ParameterPool *external_pool, int copy_number = -1) const;
+    virtual void onChange();
+    virtual void onChangeSwigPublic() {
+      IParameterized::onChange();
+    }
+    virtual void print(std::ostream &ostr) const;
+    virtual void printSwigPublic(std::ostream &ostr) const {
+      IParameterized::print(ostr);
+    }
+
+/* Internal director utilities */
+public:
+    bool swig_get_inner(const char *swig_protected_method_name) const {
+      std::map<std::string, bool>::const_iterator iv = swig_inner.find(swig_protected_method_name);
+      return (iv != swig_inner.end() ? iv->second : false);
+    }
+    void swig_set_inner(const char *swig_protected_method_name, bool swig_val) const {
+      swig_inner[swig_protected_method_name] = swig_val;
+    }
+private:
+    mutable std::map<std::string, bool> swig_inner;
+
+#if defined(SWIG_PYTHON_DIRECTOR_VTABLE)
+/* VTable implementation */
+    PyObject *swig_get_method(size_t method_index, const char *method_name) const {
+      PyObject *method = vtable[method_index];
+      if (!method) {
+        swig::SwigVar_PyObject name = SWIG_Python_str_FromChar(method_name);
+        method = PyObject_GetAttr(swig_get_self(), name);
+        if (!method) {
+          std::string msg = "Method in class INode doesn't exist, undefined ";
+          msg += method_name;
+          Swig::DirectorMethodException::raise(msg.c_str());
+        }
+        vtable[method_index] = method;
+      }
+      return method;
+    }
+private:
+    mutable swig::SwigVar_PyObject vtable[2];
+#endif
+
+};
+
+
 class SwigDirector_ISample : public ISample, public Swig::Director {
 
 public:

--- a/auto/Wrap/libBornAgainCore_wrap.h
+++ b/auto/Wrap/libBornAgainCore_wrap.h
@@ -101,6 +101,9 @@ public:
     virtual void printSwigPublic(std::ostream &ostr) const {
       IParameterized::print(ostr);
     }
+    virtual void accept(ISampleVisitor *p_visitor) const;
+    virtual std::string to_str(int arg0) const;
+    virtual std::vector< INode const *,std::allocator< INode const * > > getChildren() const;
 
 /* Internal director utilities */
 public:
@@ -131,7 +134,7 @@ private:
       return method;
     }
 private:
-    mutable swig::SwigVar_PyObject vtable[2];
+    mutable swig::SwigVar_PyObject vtable[5];
 #endif
 
 };
@@ -153,12 +156,12 @@ public:
     virtual void printSwigPublic(std::ostream &ostr) const {
       IParameterized::print(ostr);
     }
-    virtual ISample *cloneInvertB() const;
     virtual void accept(ISampleVisitor *p_visitor) const;
     virtual std::string to_str(int indent = 0) const;
+    virtual std::vector< INode const *,std::allocator< INode const * > > getChildren() const;
+    virtual ISample *cloneInvertB() const;
     virtual IMaterial const *getMaterial() const;
     virtual IMaterial const *getAmbientMaterial() const;
-    virtual std::vector< ISample const *,std::allocator< ISample const * > > getChildren() const;
 
 /* Internal director utilities */
 public:
@@ -348,12 +351,12 @@ public:
     virtual void printSwigPublic(std::ostream &ostr) const {
       IParameterized::print(ostr);
     }
-    virtual ISample *cloneInvertB() const;
     virtual void accept(ISampleVisitor *visitor) const;
     virtual std::string to_str(int indent = 0) const;
+    virtual std::vector< INode const *,std::allocator< INode const * > > getChildren() const;
+    virtual ISample *cloneInvertB() const;
     virtual IMaterial const *getMaterial() const;
     virtual IMaterial const *getAmbientMaterial() const;
-    virtual std::vector< ISample const *,std::allocator< ISample const * > > getChildren() const;
     virtual void setAmbientMaterial(IMaterial const &arg0);
     virtual complex_t evaluate(WavevectorInfo const &wavevectors) const;
     virtual double getVolume() const;
@@ -411,12 +414,12 @@ public:
     virtual void printSwigPublic(std::ostream &ostr) const {
       IParameterized::print(ostr);
     }
-    virtual ISample *cloneInvertB() const;
     virtual void accept(ISampleVisitor *visitor) const;
     virtual std::string to_str(int indent = 0) const;
+    virtual std::vector< INode const *,std::allocator< INode const * > > getChildren() const;
+    virtual ISample *cloneInvertB() const;
     virtual IMaterial const *getMaterial() const;
     virtual IMaterial const *getAmbientMaterial() const;
-    virtual std::vector< ISample const *,std::allocator< ISample const * > > getChildren() const;
     virtual void setAmbientMaterial(IMaterial const &arg0);
     virtual complex_t evaluate(WavevectorInfo const &wavevectors) const;
     virtual double getVolume() const;

--- a/auto/Wrap/libBornAgainCore_wrap.h
+++ b/auto/Wrap/libBornAgainCore_wrap.h
@@ -102,7 +102,7 @@ public:
       IParameterized::print(ostr);
     }
     virtual void accept(ISampleVisitor *p_visitor) const;
-    virtual std::string to_str(int arg0) const;
+    virtual std::string to_str() const;
     virtual std::vector< INode const *,std::allocator< INode const * > > getChildren() const;
 
 /* Internal director utilities */
@@ -157,7 +157,7 @@ public:
       IParameterized::print(ostr);
     }
     virtual void accept(ISampleVisitor *p_visitor) const;
-    virtual std::string to_str(int indent = 0) const;
+    virtual std::string to_str() const;
     virtual std::vector< INode const *,std::allocator< INode const * > > getChildren() const;
     virtual ISample *cloneInvertB() const;
     virtual IMaterial const *getMaterial() const;
@@ -192,7 +192,7 @@ private:
       return method;
     }
 private:
-    mutable swig::SwigVar_PyObject vtable[11];
+    mutable swig::SwigVar_PyObject vtable[10];
 #endif
 
 };
@@ -352,7 +352,7 @@ public:
       IParameterized::print(ostr);
     }
     virtual void accept(ISampleVisitor *visitor) const;
-    virtual std::string to_str(int indent = 0) const;
+    virtual std::string to_str() const;
     virtual std::vector< INode const *,std::allocator< INode const * > > getChildren() const;
     virtual ISample *cloneInvertB() const;
     virtual IMaterial const *getMaterial() const;
@@ -392,7 +392,7 @@ private:
       return method;
     }
 private:
-    mutable swig::SwigVar_PyObject vtable[16];
+    mutable swig::SwigVar_PyObject vtable[15];
 #endif
 
 };
@@ -415,7 +415,7 @@ public:
       IParameterized::print(ostr);
     }
     virtual void accept(ISampleVisitor *visitor) const;
-    virtual std::string to_str(int indent = 0) const;
+    virtual std::string to_str() const;
     virtual std::vector< INode const *,std::allocator< INode const * > > getChildren() const;
     virtual ISample *cloneInvertB() const;
     virtual IMaterial const *getMaterial() const;
@@ -456,7 +456,7 @@ private:
       return method;
     }
 private:
-    mutable swig::SwigVar_PyObject vtable[17];
+    mutable swig::SwigVar_PyObject vtable[16];
 #endif
 
 };


### PR DESCRIPTION
* New class INode (name can be changed) is introduced between IParameterized and ISample.
* All existing children bookkeeping activity is moved from ISample up to INode.
* ISample::to_str is removed from everywhere in the favor of single INode::to_str()

In the following I'm going to make INode actually own its children, provide unit tests and make some renaming.