### PR TITLE
New unit tests: numeric checks of RT computation

### DIFF
--- a/Tests/UnitTests/Core/Axes/CVectorTest.h
+++ b/Tests/UnitTests/Core/Axes/CVectorTest.h
@@ -1,6 +1,3 @@
-#ifndef CVECTORTEST_H
-#define CVECTORTEST_H
-
 #include "Vectors3D.h"
 #include "EigenCore.h"
 #include "Complex.h"
@@ -45,5 +42,3 @@ TEST_F(CVectorTest, BasicArithmetics)
     EXPECT_EQ( vec_e+complex_t(0,1)*vec_f,
                cvector_t(complex_t(1.,5.), complex_t(2.,6), complex_t(3,7)) );
 }
-
-#endif // CVECTORTEST_H

--- a/Tests/UnitTests/Core/Axes/ConstKBinAxisTest.h
+++ b/Tests/UnitTests/Core/Axes/ConstKBinAxisTest.h
@@ -1,6 +1,3 @@
-#ifndef CONSTKBINAXISTEST_H
-#define CONSTKBINAXISTEST_H
-
 #include "ConstKBinAxis.h"
 #include "DataFormatUtils.h"
 #include "Units.h"
@@ -95,5 +92,3 @@ TEST_F(ConstKBinAxisTest, ClippedAxis)
     }
     delete clip2;
 }
-
-#endif // CONSTKBINAXISTEST_H

--- a/Tests/UnitTests/Core/Axes/CustomBinAxisTest.h
+++ b/Tests/UnitTests/Core/Axes/CustomBinAxisTest.h
@@ -1,6 +1,3 @@
-#ifndef CUSTOMBINAXISTEST_H
-#define CUSTOMBINAXISTEST_H
-
 #include "CustomBinAxis.h"
 #include "DataFormatUtils.h"
 #include "MathConstants.h"
@@ -32,6 +29,3 @@ TEST_F(CusomBinAxisTest, IOStream)
     EXPECT_TRUE(m_axis == *result);
     delete result;
 }
-
-
-#endif // CUSTOMBINAXISTEST_H

--- a/Tests/UnitTests/Core/Axes/FixedBinAxisTest.h
+++ b/Tests/UnitTests/Core/Axes/FixedBinAxisTest.h
@@ -1,6 +1,3 @@
-#ifndef FIXEDBINAXISTEST_H
-#define FIXEDBINAXISTEST_H
-
 #include "FixedBinAxis.h"
 #include "Exceptions.h"
 #include "DataFormatUtils.h"
@@ -175,6 +172,3 @@ TEST_F(FixedBinAxisTest, ClippedAxis)
     EXPECT_TRUE(*clip2 != axis);
     delete clip2;
 }
-
-
-#endif // FIXEDBINAXISTEST_H

--- a/Tests/UnitTests/Core/Axes/Histogram1DTest.h
+++ b/Tests/UnitTests/Core/Axes/Histogram1DTest.h
@@ -1,6 +1,3 @@
-#ifndef HISTOGRAM1DTEST_H
-#define HISTOGRAM1DTEST_H
-
 #include "Histogram1D.h"
 #include "Exceptions.h"
 #include <memory>
@@ -248,5 +245,3 @@ TEST_F(Histogram1DTest, Addition)
         EXPECT_EQ(3.0, hist1.getBinContent(i));
     }
 }
-
-#endif // HISTOGRAM1DTEST_H

--- a/Tests/UnitTests/Core/Axes/Histogram2DTest.h
+++ b/Tests/UnitTests/Core/Axes/Histogram2DTest.h
@@ -1,6 +1,3 @@
-#ifndef HISTOGRAM2DTEST_H
-#define HISTOGRAM2DTEST_H
-
 #include "Histogram2D.h"
 #include <memory>
 
@@ -436,5 +433,3 @@ TEST_F(Histogram2DTest, GetMaximumGetMinimum)
     EXPECT_EQ(59.0, hist.getMaximum());
     EXPECT_EQ(size_t(49), hist.getMaximumBinIndex());
 }
-
-#endif // HISTOGRAM2DTEST_H

--- a/Tests/UnitTests/Core/Axes/KVectorTest.h
+++ b/Tests/UnitTests/Core/Axes/KVectorTest.h
@@ -1,6 +1,3 @@
-#ifndef KVECTORTEST_H
-#define KVECTORTEST_H
-
 #include "Vectors3D.h"
 #include "Transform3D.h"
 
@@ -126,5 +123,3 @@ TEST_F(KVectorTest, BasicTransformation)
     ASSERT_NEAR( v.y(), a.y(), epsilon );
     ASSERT_NEAR( v.z(), a.z(), epsilon );
 }
-
-#endif // KVECTORTEST_H

--- a/Tests/UnitTests/Core/Axes/LabelMapTest.h
+++ b/Tests/UnitTests/Core/Axes/LabelMapTest.h
@@ -1,6 +1,3 @@
-#ifndef LABELMAPTEST_H
-#define LABELMAPTEST_H
-
 #include "SampleLabelHandler.h"
 #include "INamed.h"
 #include <map>
@@ -152,5 +149,3 @@ TEST_F(LabelMapTest, LabelMapReInsert)
     EXPECT_EQ(omap.size(), size_t(3));
     EXPECT_EQ(omap.value(P_n2.get()), "99.0");
 }
-
-#endif // LABELMAPTEST_H

--- a/Tests/UnitTests/Core/Axes/VariableBinAxisTest.h
+++ b/Tests/UnitTests/Core/Axes/VariableBinAxisTest.h
@@ -1,6 +1,3 @@
-#ifndef VARIABLEBINAXISTEST_H
-#define VARIABLEBINAXISTEST_H
-
 #include "VariableBinAxis.h"
 #include "DataFormatUtils.h"
 
@@ -252,7 +249,3 @@ TEST_F(VariableBinAxisTest, ClippedAxis)
 
 
 }
-
-
-
-#endif // VARIABLEBINAXISTEST_H

--- a/Tests/UnitTests/Core/DataStructure/IntensityDataFunctionsTest.h
+++ b/Tests/UnitTests/Core/DataStructure/IntensityDataFunctionsTest.h
@@ -1,8 +1,3 @@
-#ifndef INTENSITYDATAFUNCTIONSTEST_H
-#define INTENSITYDATAFUNCTIONSTEST_H
-
-
-
 #include "IntensityDataFunctions.h"
 #include "VariableBinAxis.h"
 
@@ -191,5 +186,3 @@ TEST_F(IntensityDataFunctionsTest, outputDataCoordinatesToFromBinf)
     EXPECT_FLOAT_EQ(y, 21.0);
 
 }
-
-#endif // INTENSITYDATAFUNCTIONSTEST_H

--- a/Tests/UnitTests/Core/DataStructure/LLDataTest.h
+++ b/Tests/UnitTests/Core/DataStructure/LLDataTest.h
@@ -1,6 +1,3 @@
-#ifndef LLDATATEST_H
-#define LLDATATEST_H
-
 #include "LLData.h"
 #include <algorithm>
 #include "IMaterial.h"
@@ -389,6 +386,3 @@ TEST_F(LLDataTest, Accessors) {
     delete [] coordinate2d;
 
 }
-
-
-#endif // LLDATATEST_H

--- a/Tests/UnitTests/Core/DataStructure/OutputDataIteratorTest.h
+++ b/Tests/UnitTests/Core/DataStructure/OutputDataIteratorTest.h
@@ -1,6 +1,3 @@
-#ifndef OUTPUTDATAITERATORTEST_H
-#define OUTPUTDATAITERATORTEST_H
-
 #include "OutputDataIterator.h"
 
 class OutputDataIteratorTest : public ::testing::Test
@@ -60,5 +57,3 @@ TEST_F(OutputDataIteratorTest, ConstIterate)
     ++it;
     EXPECT_EQ(it, p_data->end());
 }
-
-#endif // OUTPUTDATAITERATORTEST_H

--- a/Tests/UnitTests/Core/DataStructure/OutputDataTest.h
+++ b/Tests/UnitTests/Core/DataStructure/OutputDataTest.h
@@ -1,6 +1,3 @@
-#ifndef OUTPUTDATATEST_H
-#define OUTPUTDATATEST_H
-
 #include "OutputData.h"
 #include <algorithm>
 #include "IntensityDataFunctions.h"
@@ -467,5 +464,3 @@ TEST_F(OutputDataTest, MixedTypeOperations)
 // 0 | 0   5   10  15  20  25  30  35  40  45 |
 // --------------------------------------------
 //   | 0   1   2   3   4   5   6   7   8   9  | x
-
-#endif // OUTPUTDATATEST_H

--- a/Tests/UnitTests/Core/Detector/DetectorMaskTest.h
+++ b/Tests/UnitTests/Core/Detector/DetectorMaskTest.h
@@ -1,6 +1,3 @@
-#ifndef DETECTORMASKTEST_H
-#define DETECTORMASKTEST_H
-
 #include "DetectorMask.h"
 #include "SphericalDetector.h"
 #include "Polygon.h"
@@ -164,6 +161,3 @@ TEST_F(DetectorMaskTest, CopyConstructor)
         }
     }
 }
-
-
-#endif // DETECTORMASKTEST_H

--- a/Tests/UnitTests/Core/Detector/PolygonTest.h
+++ b/Tests/UnitTests/Core/Detector/PolygonTest.h
@@ -1,6 +1,3 @@
-#ifndef POLYGONTEST_H
-#define POLYGONTEST_H
-
 #include "Polygon.h"
 #include <memory>
 
@@ -135,6 +132,3 @@ TEST_F(PolygonTest, ConstructFrom2DArray)
 //    }
 
 //}
-
-
-#endif // POLYGONTEST_H

--- a/Tests/UnitTests/Core/Detector/PrecomputedTest.h
+++ b/Tests/UnitTests/Core/Detector/PrecomputedTest.h
@@ -1,6 +1,3 @@
-#ifndef PRECOMPUTEDTEST_H
-#define PRECOMPUTEDTEST_H
-
 #include "Precomputed.h"
 #include <memory>
 
@@ -25,5 +22,3 @@ TEST_F(PrecomputedTest, Factorial)
     */
     EXPECT_NEAR(precomputed.factorial[150], 5.71338395644585459e262, 4*eps*precomputed.factorial[150]);
 }
-
-#endif // PRECOMPUTEDTEST_H

--- a/Tests/UnitTests/Core/Detector/RectangularDetectorTest.h
+++ b/Tests/UnitTests/Core/Detector/RectangularDetectorTest.h
@@ -1,6 +1,3 @@
-#ifndef RECTANGULARDETECTORTEST_H
-#define RECTANGULARDETECTORTEST_H
-
 #include "RectangularDetector.h"
 #include "GISASSimulation.h"
 #include "SimulationElement.h"
@@ -261,6 +258,3 @@ TEST_F(RectangularDetectorTest, PerpToReflectedBeamDpos)
     EXPECT_DOUBLE_EQ(phi(k), phi(element));
     EXPECT_NEAR(alpha(k), alpha(element), 1e-10*std::abs(alpha(k)));
 }
-
-
-#endif // RECTANGULARDETECTORTEST_H

--- a/Tests/UnitTests/Core/Detector/SpecialFunctionsTest.h
+++ b/Tests/UnitTests/Core/Detector/SpecialFunctionsTest.h
@@ -13,9 +13,6 @@
 //
 // ************************************************************************** //
 
-#ifndef SPECIALFUNCTIONSTEST_H
-#define SPECIALFUNCTIONSTEST_H
-
 #include "MathFunctions.h"
 #include "MathConstants.h"
 
@@ -93,5 +90,3 @@ TEST_F(SpecialFunctionsTest, csinc)
         z=std::polar(1e-3,ph); EXPECT_CNEAR( MathFunctions::sinc(z), 1.-z*z/6.*(1.-z*z/20.), eps );
     }
 }
-
-#endif // SPECIALFUNCTIONSTEST_H

--- a/Tests/UnitTests/Core/Detector/SpecialFunctionsTest.h
+++ b/Tests/UnitTests/Core/Detector/SpecialFunctionsTest.h
@@ -2,7 +2,7 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      Tests/UnitTests/Core/3/SpecialFunctionsTest.h
+//! @file      Tests/UnitTests/Core/Detector/SpecialFunctionsTest.h
 //! @brief     Defines unit test for Form factors.
 //!
 //! @homepage  http://bornagainproject.org

--- a/Tests/UnitTests/Core/Detector/SphericalDetectorTest.h
+++ b/Tests/UnitTests/Core/Detector/SphericalDetectorTest.h
@@ -1,6 +1,3 @@
-#ifndef SPHERICALDETECTORTEST_H
-#define SPHERICALDETECTORTEST_H
-
 #include "SphericalDetector.h"
 #include "Exceptions.h"
 #include "OutputData.h"
@@ -366,5 +363,3 @@ TEST_F(SphericalDetectorTest, Clone)
     EXPECT_EQ(detectorIndexes, expectedDetectorIndexes);
     EXPECT_EQ(elementIndexes, expectedElementIndexes);
 }
-
-#endif // SPHERICALDETECTORTEST_H

--- a/Tests/UnitTests/Core/Fresnel/MatrixRTCoefficientsTest.h
+++ b/Tests/UnitTests/Core/Fresnel/MatrixRTCoefficientsTest.h
@@ -1,6 +1,3 @@
-#ifndef MATRIXRTCOEFFICIENTSTEST_H
-#define MATRIXRTCOEFFICIENTSTEST_H
-
 #include "MatrixRTCoefficients.h"
 
 class MatrixRTCoefficientsTest : public ::testing :: Test
@@ -79,5 +76,3 @@ TEST_F(MatrixRTCoefficientsTest, getKz)
     EXPECT_EQ(complex_t(0.0,0.0), vector(0));
     EXPECT_EQ(complex_t(0.0,0.0), vector(1));
 }
-
-#endif // MATRIXRTCOEFFICIENTSTEST_H

--- a/Tests/UnitTests/Core/Fresnel/ScalarRTCoefficientsTest.h
+++ b/Tests/UnitTests/Core/Fresnel/ScalarRTCoefficientsTest.h
@@ -1,6 +1,3 @@
-#ifndef SCALARRTCOEFFICIENTSTEST_H
-#define SCALARRTCOEFFICIENTSTEST_H
-
 #include "ScalarRTCoefficients.h"
 
 class ScalarRTCoefficientsTest : public ::testing :: Test
@@ -132,5 +129,3 @@ TEST_F(ScalarRTCoefficientsTest, getScalar)
     EXPECT_EQ(complex_t(1.0,0.5), scrtCustom.getScalarR());
     EXPECT_EQ(complex_t(1.0,1.0), scrtCustom.getScalarKz());
 }
-
-#endif // SCALARRTCOEFFICIENTSTEST_H

--- a/Tests/UnitTests/Core/Fresnel/SpecularMatrixTest.h
+++ b/Tests/UnitTests/Core/Fresnel/SpecularMatrixTest.h
@@ -1,6 +1,3 @@
-#ifndef SPECULARMATRIXTEST_H
-#define SPECULARMATRIXTEST_H
-
 #include "SpecularMatrix.h"
 #include "Units.h"
 
@@ -29,5 +26,3 @@ TEST_F(SpecularMatrixTest, initial)
 
     SpecularMatrix::execute(mLayer, v, coeff);
 }
-
-#endif // SPECULARMATRIXTEST_H

--- a/Tests/UnitTests/Core/Fresnel/SpecularSimulationTest.h
+++ b/Tests/UnitTests/Core/Fresnel/SpecularSimulationTest.h
@@ -1,6 +1,3 @@
-#ifndef SPECULARSIMULATIONTEST_H
-#define SPECULARSIMULATIONTEST_H
-
 #include "SpecularSimulation.h"
 #include "HomogeneousMaterial.h"
 #include "IMultiLayerBuilder.h"
@@ -120,5 +117,3 @@ TEST_F(SpecularSimulationTest, SimulationClone)
     EXPECT_EQ(size_t(10), clone->getScalarT(0).size());
     EXPECT_EQ(size_t(10), clone->getScalarKz(0).size());
 }
-
-#endif // SPECULARSIMULATIONTEST_H

--- a/Tests/UnitTests/Core/Other/BeamTest.h
+++ b/Tests/UnitTests/Core/Other/BeamTest.h
@@ -1,6 +1,3 @@
-#ifndef BEAMTEST_H
-#define BEAMTEST_H
-
 #include "Beam.h"
 #include "BornAgainNamespace.h"
 #include "MathConstants.h"
@@ -57,6 +54,3 @@ TEST_F(BeamTest, BeamAssignment)
     EXPECT_EQ(complex_t(0.4, 0.0), beam_copy.getPolarization()(1, 1));
     */
 }
-
-
-#endif // BEAMTEST_H

--- a/Tests/UnitTests/Core/Other/ChiSquaredModuleTest.h
+++ b/Tests/UnitTests/Core/Other/ChiSquaredModuleTest.h
@@ -1,6 +1,3 @@
-#ifndef CHISQUAREDMODULETEST_H
-#define CHISQUAREDMODULETEST_H
-
 #include "ChiSquaredModule.h"
 #include "ISquaredFunction.h"
 #include "BornAgainNamespace.h"
@@ -108,8 +105,6 @@ TEST_F(ChiSquaredModuleTest, CloneOfEmpty)
 ////    m_chi_isgisaxs.setOutputDataNormalizer( OutputDataNormalizerScaleAndShift() );
 ////    EXPECT_FLOAT_EQ( double(0.005), m_chi_isgisaxs.calculateChiSquared());
 //}
-
-#endif // CHISQUAREDMODULETEST_H
 
 
 

--- a/Tests/UnitTests/Core/Other/CumulativeValueTest.h
+++ b/Tests/UnitTests/Core/Other/CumulativeValueTest.h
@@ -1,6 +1,3 @@
-#ifndef CUMULATIVEVALUETEST_H
-#define CUMULATIVEVALUETEST_H
-
 #include "CumulativeValue.h"
 
 
@@ -84,7 +81,3 @@ TEST_F(CumulativeValueTest, Comparison)
     EXPECT_TRUE(cv1 < cv2);
 
 }
-
-
-
-#endif // CUMULATIVEVALUETEST_H

--- a/Tests/UnitTests/Core/Other/GISASSimulationTest.h
+++ b/Tests/UnitTests/Core/Other/GISASSimulationTest.h
@@ -1,6 +1,3 @@
-#ifndef GISASSIMULATIONTEST_H
-#define GISASSIMULATIONTEST_H
-
 #include "Beam.h"
 #include "BornAgainNamespace.h"
 #include "GISASSimulation.h"
@@ -87,5 +84,3 @@ TEST_F(GISASSimulationTest, SimulationClone)
 
 //    delete clonedSimulation;
 }
-
-#endif // GISASSIMULATIONTEST_H

--- a/Tests/UnitTests/Core/Other/HomogeneousMagneticMaterialTest.h
+++ b/Tests/UnitTests/Core/Other/HomogeneousMagneticMaterialTest.h
@@ -1,6 +1,3 @@
-#ifndef HOMOGENEOUSMAGNETICMATERIALTEST_H
-#define HOMOGENEOUSMAGNETICMATERIALTEST_H
-
 #include "HomogeneousMagneticMaterial.h"
 #include "Rotations.h"
 #include "Units.h"
@@ -121,5 +118,3 @@ TEST_F(HomogeneousMagneticMaterialTest, HomogeneousMagneticMaterialClone)
     delete tMaterial;
     delete clone;
 }
-
-#endif // HOMOGENEOUSMAGNETICMATERIALTEST_H

--- a/Tests/UnitTests/Core/Other/HomogeneousMaterialTest.h
+++ b/Tests/UnitTests/Core/Other/HomogeneousMaterialTest.h
@@ -1,6 +1,3 @@
-#ifndef HOMOGENEOUSMATERIALTEST_H
-#define HOMOGENEOUSMATERIALTEST_H
-
 #include "HomogeneousMaterial.h"
 #include "Rotations.h"
 #include "Units.h"
@@ -104,5 +101,3 @@ TEST_F(HomogeneousMaterialTest, HomogeneousMaterialClone)
     delete tMaterial;
     delete clone;
 }
-
-#endif // HOMOGENEOUSMATERIALTEST_H

--- a/Tests/UnitTests/Core/Other/InstrumentTest.h
+++ b/Tests/UnitTests/Core/Other/InstrumentTest.h
@@ -1,6 +1,3 @@
-#ifndef INSTRUMENTTEST_H
-#define INSTRUMENTTEST_H
-
 #include "MathConstants.h"
 #include "Instrument.h"
 #include "BornAgainNamespace.h"
@@ -54,5 +51,3 @@ TEST_F(InstrumentTest, InstrumentClone)
     EXPECT_EQ( size_t(0), clone.getDetectorDimension() );
     EXPECT_EQ( 0.0, clone.getBeamIntensity() );
 }
-
-#endif // INSTRUMENTTEST_H

--- a/Tests/UnitTests/Core/Other/RelDiffTest.h
+++ b/Tests/UnitTests/Core/Other/RelDiffTest.h
@@ -1,6 +1,3 @@
-#ifndef RELDIFFTEST_H
-#define RELDIFFTEST_H
-
 #include "Numeric.h"
 #include <algorithm>
 
@@ -25,5 +22,3 @@ TEST_F(RelDiffTest, RelDiffAlmostEq)
 //    EXPECT_FALSE( Numeric::areAlmostEqual(-1e-120, 0, 1.) );
     EXPECT_FALSE( Numeric::areAlmostEqual(-1e+120, 0, 1.) );
 }
-
-#endif // RELDIFFTEST_H

--- a/Tests/UnitTests/Core/Other/Shape2DTest.h
+++ b/Tests/UnitTests/Core/Other/Shape2DTest.h
@@ -1,6 +1,3 @@
-#ifndef SHAPE2DTEST_H
-#define SHAPE2DTEST_H
-
 #include "Rectangle.h"
 #include "Ellipse.h"
 #include "Line.h"
@@ -104,5 +101,3 @@ TEST_F(Shape2DTest, HorizontalLine)
     EXPECT_TRUE(line.contains(Bin1D(0.0, 1.0), Bin1D(0.5, 1.5)));
     EXPECT_FALSE(line.contains(Bin1D(0.0, 1.0), Bin1D(1.01, 2.0)));
 }
-
-#endif // SHAPE2DTEST_H

--- a/Tests/UnitTests/Core/Other/TRangeTest.h
+++ b/Tests/UnitTests/Core/Other/TRangeTest.h
@@ -1,6 +1,3 @@
-#ifndef TRANGETEST_H
-#define TRANGETEST_H
-
 #include "TRange.h"
 #include <algorithm>
 
@@ -91,5 +88,3 @@ TEST_F(TRangeTest, TSampledRangeNSamples)
     EXPECT_EQ(5000u, floatSampledRange->getNSamples());
     EXPECT_EQ(6000u, doubleSampledRange->getNSamples());
 }
-
-#endif // TRANGETEST_H

--- a/Tests/UnitTests/Core/Other/ThreadInfoTest.h
+++ b/Tests/UnitTests/Core/Other/ThreadInfoTest.h
@@ -13,9 +13,6 @@
 //
 // ************************************************************************** //
 
-#ifndef THREADINFOTEST_H
-#define THREADINFOTEST_H
-
 #include "ThreadInfo.h"
 
 
@@ -35,5 +32,3 @@ TEST_F(ThreadInfoTest, DefaultValues)
     EXPECT_EQ(0, thread_info.n_threads);
     EXPECT_EQ(0, thread_info.current_thread);
 }
-
-#endif // THREADINFOTEST_H

--- a/Tests/UnitTests/Core/Other/ThreadInfoTest.h
+++ b/Tests/UnitTests/Core/Other/ThreadInfoTest.h
@@ -2,7 +2,7 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      Tests/UnitTests/Core/4/ThreadInfoTest.h
+//! @file      Tests/UnitTests/Core/Other/ThreadInfoTest.h
 //! @brief     Defines unit test for ThreadInfo class.
 //!
 //! @homepage  http://bornagainproject.org

--- a/Tests/UnitTests/Core/Parameters/DistributionHandlerTest.h
+++ b/Tests/UnitTests/Core/Parameters/DistributionHandlerTest.h
@@ -1,6 +1,3 @@
-#ifndef DISTRIBUTIONHANDLERTEST_H
-#define DISTRIBUTIONHANDLERTEST_H
-
 #include "IParameterized.h"
 #include "DistributionHandler.h"
 #include "Distributions.h"
@@ -42,6 +39,3 @@ TEST_F(DistributionHandlerTest, DistributionHandlerConstructor)
     delete parameterPool;
     */
 }
-
-
-#endif // DISTRIBUTIONHANDLERTEST_H

--- a/Tests/UnitTests/Core/Parameters/DistributionsTest.h
+++ b/Tests/UnitTests/Core/Parameters/DistributionsTest.h
@@ -1,6 +1,3 @@
-#ifndef DISTRIBUTIONSTEST_H
-#define DISTRIBUTIONSTEST_H
-
 #include "MathConstants.h"
 #include "BornAgainNamespace.h"
 #include "Distributions.h"
@@ -400,5 +397,3 @@ TEST_F(DistributionsTest, DistributionCosineClone)
     EXPECT_EQ(1-M_PI, list2[0]);
     EXPECT_EQ(1+M_PI, list2[1]);
 }
-
-#endif // DISTRIBUTIONSTEST_H

--- a/Tests/UnitTests/Core/Parameters/FTDistributionsTest.h
+++ b/Tests/UnitTests/Core/Parameters/FTDistributionsTest.h
@@ -1,6 +1,3 @@
-#ifndef FTDISTRIBUTIONSTEST_H
-#define FTDISTRIBUTIONSTEST_H
-
 #include "FTDistributions1D.h"
 #include "FTDistributions2D.h"
 #include "BornAgainNamespace.h"
@@ -288,5 +285,3 @@ TEST_F(FTDistributionsTest, FTDistribution2DVoigtClone)
     EXPECT_EQ(BornAgain::FTDistribution2DVoigtType, P_clone->getName());
     EXPECT_NEAR(-0.6635305, P_clone->evaluate(0.2, 0.5),0.000001);
 }
-
-#endif // FTDISTRIBUTIONSTEST_H

--- a/Tests/UnitTests/Core/Parameters/IParameterizedTest.h
+++ b/Tests/UnitTests/Core/Parameters/IParameterizedTest.h
@@ -1,6 +1,3 @@
-#ifndef IPARAMETERIZEDTEST_H
-#define IPARAMETERIZEDTEST_H
-
 #include "IParameterized.h"
 #include <stdexcept>
 
@@ -77,6 +74,3 @@ TEST_F(IParameterizedTest, SetParameterValue)
     EXPECT_EQ( 0.0, m_parameterized.getParameterPool()->size());
     */
 }
-
-
-#endif // IPARAMETERIZEDTEST_H

--- a/Tests/UnitTests/Core/Parameters/ParameterDistributionTest.h
+++ b/Tests/UnitTests/Core/Parameters/ParameterDistributionTest.h
@@ -1,6 +1,3 @@
-#ifndef PARAMETERDISTRIBUTIONTEST_H
-#define PARAMETERDISTRIBUTIONTEST_H
-
 #include "ParameterDistribution.h"
 #include "Distributions.h"
 #include "Exceptions.h"
@@ -140,6 +137,3 @@ TEST_F(ParameterDistributionTest, GenerateSamples)
     EXPECT_EQ(sample_values[1].value, xmin + (xmax-xmin)/2.0);
     EXPECT_EQ(sample_values[2].value, xmax);
 }
-
-
-#endif // PARAMETERDISTRIBUTIONTEST_H

--- a/Tests/UnitTests/Core/Parameters/ParameterPoolTest.h
+++ b/Tests/UnitTests/Core/Parameters/ParameterPoolTest.h
@@ -1,6 +1,3 @@
-#ifndef PARAMETERPOOLTEST_H
-#define PARAMETERPOOLTEST_H
-
 #include "ParameterPool.h"
 
 /* TEMPORARILY DISABLED
@@ -122,4 +119,3 @@ TEST_F(ParameterPoolTest, LimitsOnParameterValue)
 }
 
 */
-#endif // PARAMETERPOOLTEST_H

--- a/Tests/UnitTests/Core/Parameters/RealParameterWrapperTest.h
+++ b/Tests/UnitTests/Core/Parameters/RealParameterWrapperTest.h
@@ -1,6 +1,3 @@
-#ifndef REALPARAMETERWRAPPERTEST_H
-#define REALPARAMETERWRAPPERTEST_H
-
 #include "IParameterized.h"
 #include "RealParameter.h"
 #include <stdexcept>
@@ -98,5 +95,3 @@ TEST_F(RealParameterTest, LimitedParameter)
     EXPECT_EQ(par1->getValue(), 11.);
 }
 */
-
-#endif // REALPARAMETERWRAPPERTEST_H

--- a/Tests/UnitTests/Core/Sample/FormFactorBasicTest.h
+++ b/Tests/UnitTests/Core/Sample/FormFactorBasicTest.h
@@ -2,7 +2,7 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      Tests/UnitTests/Core/1/FormFactorBasicTest.h
+//! @file      Tests/UnitTests/Core/Sample/FormFactorBasicTest.h
 //! @brief     Trvial and basic unit tests for particle-shape form factors.
 //!
 //! @homepage  http://bornagainproject.org

--- a/Tests/UnitTests/Core/Sample/FormFactorCoherentSumTest.h
+++ b/Tests/UnitTests/Core/Sample/FormFactorCoherentSumTest.h
@@ -1,6 +1,3 @@
-#ifndef FORMFACTORWRAPPERTEST_H
-#define FORMFACTORWRAPPERTEST_H
-
 #include "FormFactorCoherentSum.h"
 #include "FormFactorTrivial.h"
 #include "Exceptions.h"
@@ -31,5 +28,3 @@ TEST_F(FormFactorCoherentSumTest, FormFactor)
     ffw.scaleRelativeAbundance(2.0);
     EXPECT_EQ(0.0, ffw.radialExtension());
 }
-
-#endif // FORMFACTORWRAPPERTEST_H

--- a/Tests/UnitTests/Core/Sample/LayerRoughnessTest.h
+++ b/Tests/UnitTests/Core/Sample/LayerRoughnessTest.h
@@ -1,6 +1,3 @@
-#ifndef LAYERROUGHNESSTEST_H
-#define LAYERROUGHNESSTEST_H
-
 #include "LayerRoughness.h"
 #include "BornAgainNamespace.h"
 #include "ParameterPattern.h"
@@ -72,5 +69,3 @@ TEST_F(LayerRoughnessTest , LayerRoughnessPool)
     EXPECT_EQ(4.3, roughnessPool.getLatteralCorrLength());
     EXPECT_EQ(BornAgain::LayerBasicRoughnessType, roughnessPool.getName());
 }
-
-#endif // LAYERROUGHNESSTEST_H

--- a/Tests/UnitTests/Core/Sample/LayerTest.h
+++ b/Tests/UnitTests/Core/Sample/LayerTest.h
@@ -1,6 +1,3 @@
-#ifndef LAYERTEST_H
-#define LAYERTEST_H
-
 #include "Layer.h"
 #include "HomogeneousMaterial.h"
 #include "ParticleLayout.h"
@@ -60,5 +57,3 @@ TEST_F(LayerTest, LayerAndDecoration)
     layer.addLayout(layout2);
     EXPECT_EQ("ParticleLayout", layer.getLayout(1)->getName());
 }
-
-#endif // LAYERTEST_H

--- a/Tests/UnitTests/Core/Sample/MultiLayerTest.h
+++ b/Tests/UnitTests/Core/Sample/MultiLayerTest.h
@@ -1,3 +1,5 @@
+//! Trivial construct/clone/get tests for class MultiLayer. No physics tested here.
+
 #ifndef MULTILAYERTEST_H
 #define MULTILAYERTEST_H
 
@@ -45,7 +47,7 @@ TEST_F(MultiLayerTest, BasicProperty)
 
     //set parameter
     mLayer.setParameterValue(BornAgain::CrossCorrelationLength, 2.54);
-    EXPECT_EQ(2.54,mLayer.getCrossCorrLength());
+    EXPECT_EQ(2.54, mLayer.getCrossCorrLength());
 
     // adding layers
     mLayer.addLayer(topLayer);

--- a/Tests/UnitTests/Core/Sample/MultiLayerTest.h
+++ b/Tests/UnitTests/Core/Sample/MultiLayerTest.h
@@ -17,10 +17,11 @@ class MultiLayerTest : public ::testing::Test
 {
 protected:
     MultiLayerTest()
-        : air("air", 0, 1.0)
-        , iron("iron", 0, 1.51)
-        , chromium("chromium", 0, 3.68)
-        , stone("stone", 0, 1.6)
+        // The following delta, beta are all unphysical. Values don't matter here.
+        : air("air", 1e-6, 9e-4)
+        , iron("iron", 2e-5, 8e-5)
+        , chromium("chromium", 3e-7, 7e-6)
+        , stone("stone", 4e-4, 8e-7)
         , topLayer(air, 0*Units::nanometer)
         , layer1(iron, 20*Units::nanometer)
         , layer2(chromium, 40*Units::nanometer)

--- a/Tests/UnitTests/Core/Sample/MultiLayerTest.h
+++ b/Tests/UnitTests/Core/Sample/MultiLayerTest.h
@@ -1,8 +1,5 @@
 //! Trivial construct/clone/get tests for class MultiLayer. No physics tested here.
 
-#ifndef MULTILAYERTEST_H
-#define MULTILAYERTEST_H
-
 #include "BornAgainNamespace.h"
 #include "HomogeneousMagneticMaterial.h"
 #include "Layer.h"
@@ -579,5 +576,3 @@ TEST_F(MultiLayerTest, MultiLayerZtoIndex)
     EXPECT_EQ(size_t(3), mLayer.zToLayerIndex(-60.0));
     EXPECT_EQ(size_t(4), mLayer.zToLayerIndex(-61.0));
 }
-
-#endif // MULTILAYERTEST_H

--- a/Tests/UnitTests/Core/Sample/ParticleCompositionTest.h
+++ b/Tests/UnitTests/Core/Sample/ParticleCompositionTest.h
@@ -1,6 +1,3 @@
-#ifndef PARTICLECOMPOSITIONTEST_H
-#define PARTICLECOMPOSITIONTEST_H
-
 #include "FormFactorFullSphere.h"
 #include "HomogeneousMaterial.h"
 #include "MathConstants.h"
@@ -105,5 +102,3 @@ TEST_F(ParticleCompositionTest, ParticleCompositionClone)
     delete lb;
     delete lbClone;
 }
-
-#endif // PARTICLECOMPOSITIONTEST_H

--- a/Tests/UnitTests/Core/Sample/ParticleCoreShellTest.h
+++ b/Tests/UnitTests/Core/Sample/ParticleCoreShellTest.h
@@ -1,6 +1,3 @@
-#ifndef PARTICLECORESHELLTEST_H
-#define PARTICLECORESHELLTEST_H
-
 #include "HardParticles.h"
 #include "ParticleCoreShell.h"
 #include "BornAgainNamespace.h"
@@ -110,5 +107,3 @@ TEST_F(ParticleCoreShellTest, ComplexCoreShellClone)
     EXPECT_EQ(coreshell.getCoreParticle()->getPosition(), relative_pos);
     EXPECT_EQ(clone->getCoreParticle()->getPosition(), relative_pos);
 }
-
-#endif // PARTICLECORESHELLTEST_H

--- a/Tests/UnitTests/Core/Sample/ParticleLayoutTest.h
+++ b/Tests/UnitTests/Core/Sample/ParticleLayoutTest.h
@@ -1,6 +1,3 @@
-#ifndef PARTICLELAYOUTTEST_H
-#define PARTICLELAYOUTTEST_H
-
 #include "ParticleLayout.h"
 #include "InterferenceFunctionNone.h"
 
@@ -235,5 +232,3 @@ TEST_F(ParticleLayoutTest, ParticleLayoutInterferenceFunction)
 
     EXPECT_TRUE(nullptr!=particleDecoration.getInterferenceFunction());
 }
-
-#endif // PARTICLELAYOUTTEST_H

--- a/Tests/UnitTests/Core/Sample/ParticleTest.h
+++ b/Tests/UnitTests/Core/Sample/ParticleTest.h
@@ -1,6 +1,3 @@
-#ifndef PARTICLETEST_H
-#define PARTICLETEST_H
-
 #include "Particle.h"
 #include "BornAgainNamespace.h"
 #include "MathConstants.h"
@@ -131,5 +128,3 @@ TEST_F(ParticleTest, SetParam)
 
     delete particle2;
 }
-
-#endif // PARTICLETEST_H

--- a/Tests/UnitTests/Core/Sample/RTTest.h
+++ b/Tests/UnitTests/Core/Sample/RTTest.h
@@ -1,0 +1,62 @@
+//! Numeric tests of RT computation.
+
+#include "BornAgainNamespace.h"
+#include "HomogeneousMagneticMaterial.h"
+#include "Layer.h"
+#include "Layer.h"
+#include "LayerInterface.h"
+#include "LayerRoughness.h"
+#include "MathConstants.h"
+#include "MultiLayer.h"
+#include "ParticleLayout.h"
+#include "SpecularMatrix.h"
+
+#include <iostream> // TODO remove when stable
+
+class RTTest : public ::testing::Test
+{
+protected:
+    RTTest() {}
+    void set_four() {
+        sample1.addLayer(topLayer);
+        sample1.addLayer( Layer(amat, 10) );
+        sample1.addLayer( Layer(bmat, 20) );
+        sample1.addLayer(substrate);
+    }
+    void printCoeffs(const std::vector<ScalarRTCoefficients>& coeffs) {
+        for (size_t i=0; i<coeffs.size(); ++i) {
+            const ScalarRTCoefficients& coeff = coeffs[i];
+            std::cout << i << " " << coeff.t_r(0) << " " << coeff.t_r(1) << "\n";
+        }
+    }
+    const HomogeneousMaterial air {"air", 1e-8, 1e-8};
+    const HomogeneousMaterial amat {"material A", 2e-6, 8e-7};
+    const HomogeneousMaterial bmat {"material B (high absorption)", 3e-6, 1e-4};
+    const HomogeneousMaterial stone {"substrate material", 1e-6, 1e-7};
+    const Layer topLayer {air, 0};
+    const Layer substrate {stone, 0};
+    const kvector_t k { 1, 0, 1e-2 };
+    MultiLayer sample1, sample2;
+    std::vector<ScalarRTCoefficients> coeffs1, coeffs2;
+};
+
+
+TEST_F(RTTest, BasicProperty)
+{
+    sample1.addLayer( topLayer );
+    sample1.addLayer( Layer(amat, 10) );
+    sample1.addLayer( Layer(amat, 10) );
+    sample1.addLayer( substrate );
+
+    sample2.addLayer( topLayer );
+    sample2.addLayer( Layer(amat, 20) );
+    sample2.addLayer( substrate );
+
+    SpecularMatrix::execute(sample1, k, coeffs1);
+    SpecularMatrix::execute(sample2, k, coeffs2);
+
+    printCoeffs( coeffs1 );
+    printCoeffs( coeffs2 );
+
+    EXPECT_EQ(1,1);
+}

--- a/Tests/UnitTests/Core/Sample/RTTest.h
+++ b/Tests/UnitTests/Core/Sample/RTTest.h
@@ -1,4 +1,4 @@
-//! Numeric tests of RT computation.
+//! Numeric tests of scalar RT computation.
 
 #include "BornAgainNamespace.h"
 #include "HomogeneousMagneticMaterial.h"
@@ -17,46 +17,52 @@ class RTTest : public ::testing::Test
 {
 protected:
     RTTest() {}
-    void set_four() {
-        sample1.addLayer(topLayer);
-        sample1.addLayer( Layer(amat, 10) );
-        sample1.addLayer( Layer(bmat, 20) );
-        sample1.addLayer(substrate);
-    }
     void printCoeffs(const std::vector<ScalarRTCoefficients>& coeffs) {
         for (size_t i=0; i<coeffs.size(); ++i) {
             const ScalarRTCoefficients& coeff = coeffs[i];
             std::cout << i << " " << coeff.t_r(0) << " " << coeff.t_r(1) << "\n";
         }
     }
+    void compareCoeffs(const ScalarRTCoefficients& coeff1, const ScalarRTCoefficients& coeff2) {
+        EXPECT_NEAR(abs(coeff1.t_r(0)),   abs(coeff2.t_r(0)),   1e-14);
+        EXPECT_NEAR(coeff1.t_r(0).real(), coeff2.t_r(0).real(), 1e-10);
+        EXPECT_NEAR(coeff1.t_r(0).imag(), coeff2.t_r(0).imag(), 1e-10);
+        EXPECT_NEAR(abs(coeff1.t_r(1)),   abs(coeff2.t_r(1)),   1e-14);
+        EXPECT_NEAR(coeff1.t_r(1).real(), coeff2.t_r(1).real(), 1e-10);
+        EXPECT_NEAR(coeff1.t_r(1).imag(), coeff2.t_r(1).imag(), 1e-10);
+    }
     const HomogeneousMaterial air {"air", 1e-8, 1e-8};
     const HomogeneousMaterial amat {"material A", 2e-6, 8e-7};
-    const HomogeneousMaterial bmat {"material B (high absorption)", 3e-6, 1e-4};
+    const HomogeneousMaterial bmat {"material B (high absorption)", 3e-6, 2e-4};
     const HomogeneousMaterial stone {"substrate material", 1e-6, 1e-7};
     const Layer topLayer {air, 0};
     const Layer substrate {stone, 0};
-    const kvector_t k { 1, 0, 1e-2 };
+    const kvector_t k { 1, 0, 1e-3 };
     MultiLayer sample1, sample2;
     std::vector<ScalarRTCoefficients> coeffs1, coeffs2;
 };
 
 
-TEST_F(RTTest, BasicProperty)
+TEST_F(RTTest, SplitLayer)
 {
+    const int n = 40;
+
     sample1.addLayer( topLayer );
-    sample1.addLayer( Layer(amat, 10) );
-    sample1.addLayer( Layer(amat, 10) );
+    sample1.addLayer( Layer(amat, n*10) );
     sample1.addLayer( substrate );
 
     sample2.addLayer( topLayer );
-    sample2.addLayer( Layer(amat, 20) );
+    for (size_t i=0; i<n; ++i)
+        sample2.addLayer( Layer(amat, 10) );
     sample2.addLayer( substrate );
 
     SpecularMatrix::execute(sample1, k, coeffs1);
     SpecularMatrix::execute(sample2, k, coeffs2);
 
-    printCoeffs( coeffs1 );
-    printCoeffs( coeffs2 );
+    // printCoeffs( coeffs1 );
+    // printCoeffs( coeffs2 );
 
-    EXPECT_EQ(1,1);
+    compareCoeffs(coeffs1[0], coeffs2[0]);
+    compareCoeffs(coeffs1[1], coeffs2[1]);
+    compareCoeffs(coeffs1.back(), coeffs2.back());
 }

--- a/Tests/UnitTests/Core/Sample/testlist.h
+++ b/Tests/UnitTests/Core/Sample/testlist.h
@@ -4,6 +4,7 @@
 #include "FormFactorCoherentSumTest.h"
 #include "LayerTest.h"
 #include "MultiLayerTest.h"
+#include "RTTest.h"
 #include "ParticleCoreShellTest.h"
 #include "LayerRoughnessTest.h"
 #include "ParticleTest.h"

--- a/Tests/UnitTests/Fit/0/AttLimitsTest.h
+++ b/Tests/UnitTests/Fit/0/AttLimitsTest.h
@@ -1,6 +1,3 @@
-#ifndef ATTLIMITSTEST_H
-#define ATTLIMITSTEST_H
-
 #include "AttLimits.h"
 #include "gtest/gtest.h"
 
@@ -78,5 +75,3 @@ TEST_F(AttLimitsTest, Limited)
     EXPECT_EQ(0.0, limits.lowerLimit());
     EXPECT_EQ(0.0, limits.upperLimit());
 }
-
-#endif

--- a/Tests/UnitTests/Fit/0/FitObjectTest.h
+++ b/Tests/UnitTests/Fit/0/FitObjectTest.h
@@ -1,6 +1,3 @@
-#ifndef FITOBJECTTEST_H
-#define FITOBJECTTEST_H
-
 #include "FitObject.h"
 #include "GISASSimulation.h"
 #include "BornAgainNamespace.h"
@@ -99,5 +96,3 @@ TEST_F(FitObjectTest, RoiPair)
     EXPECT_EQ(obj.chiSquaredMap().getAxis(1).getMin(), roi_ymin);
     EXPECT_EQ(obj.chiSquaredMap().getAxis(1).getMax(), roi_ymax);
 }
-
-#endif // FITOBJECTTEST_H

--- a/Tests/UnitTests/Fit/0/FitParameterLinkedTest.h
+++ b/Tests/UnitTests/Fit/0/FitParameterLinkedTest.h
@@ -1,6 +1,3 @@
-#ifndef FITPARAMETERLINKEDTEST_H
-#define FITPARAMETERLINKEDTEST_H
-
 #include "IParameterized.h"
 #include "RealParameter.h"
 #include "ParameterPool.h"
@@ -103,5 +100,3 @@ TEST_F(FitParameterLinkedTest, FitParameterLinkedParamPool)
     EXPECT_EQ(obj3.getParameter("2"), 2.3);
     */
 }
-
-#endif // FITPARAMETERLINKEDTEST_H

--- a/Tests/UnitTests/Fit/0/FitParameterSetTest.h
+++ b/Tests/UnitTests/Fit/0/FitParameterSetTest.h
@@ -1,6 +1,3 @@
-#ifndef FITPARAMETERSETTEST_H
-#define FITPARAMETERSETTEST_H
-
 #include "FitParameter.h"
 #include "FitParameterSet.h"
 #include "gtest/gtest.h"
@@ -125,5 +122,3 @@ TEST_F(FitParameterSetTest, fixRelease)
     EXPECT_FALSE(par2->limits().isFixed());
     EXPECT_TRUE(par3->limits().isFixed());
 }
-
-#endif

--- a/Tests/UnitTests/Fit/0/FitParameterTest.h
+++ b/Tests/UnitTests/Fit/0/FitParameterTest.h
@@ -1,6 +1,3 @@
-#ifndef FITPARAMETERTEST_H
-#define FITPARAMETERTEST_H
-
 #include "FitParameter.h"
 #include "gtest/gtest.h"
 #include <memory>
@@ -120,5 +117,3 @@ TEST_F(FitParameterTest, Clone)
     EXPECT_EQ(lim1, clone->limits().lowerLimit());
     EXPECT_EQ(lim2, clone->limits().upperLimit());
 }
-
-#endif

--- a/Tests/UnitTests/Fit/0/FitSuiteTest.h
+++ b/Tests/UnitTests/Fit/0/FitSuiteTest.h
@@ -1,6 +1,3 @@
-#ifndef FITSUITETEST_H
-#define FITSUITETEST_H
-
 #include "FitSuite.h"
 #include "FitParameter.h"
 #include "gtest/gtest.h"
@@ -47,5 +44,3 @@ TEST_F(FitSuiteTest, addFitParameter)
     EXPECT_EQ(4.0, par3.value());
     EXPECT_TRUE(par3.limits().isFixed());
 }
-
-#endif

--- a/Tests/UnitTests/Fit/0/MinimizerOptionsTest.h
+++ b/Tests/UnitTests/Fit/0/MinimizerOptionsTest.h
@@ -1,6 +1,3 @@
-#ifndef MINIMIZEROPTIONSTEST_H
-#define MINIMIZEROPTIONSTEST_H
-
 #include "MinimizerOptions.h"
 #include "gtest/gtest.h"
 #include <exception>
@@ -45,5 +42,3 @@ TEST_F(MinimizerOptionsTest, setOptionsFromString)
 
     EXPECT_THROW(options.setOptionString("Strategy=5;XXX=y;Tolerance=0.0001;"), std::runtime_error);
 }
-
-#endif

--- a/Tests/UnitTests/Fit/0/MultiOptionTest.h
+++ b/Tests/UnitTests/Fit/0/MultiOptionTest.h
@@ -1,6 +1,3 @@
-#ifndef MULTIOPTIONTEST_H
-#define MULTIOPTIONTEST_H
-
 #include "MultiOption.h"
 #include "gtest/gtest.h"
 #include <iostream>
@@ -100,6 +97,3 @@ TEST_F(MultiOptionTest, SetFromString)
     opt3.setFromString("yyy");
     EXPECT_EQ("yyy", opt3.get<std::string>());
 }
-
-
-#endif

--- a/Tests/UnitTests/Fit/0/OptionContainerTest.h
+++ b/Tests/UnitTests/Fit/0/OptionContainerTest.h
@@ -1,6 +1,3 @@
-#ifndef OPTIONCONTAINERTEST_H
-#define OPTIONCONTAINERTEST_H
-
 #include "OptionContainer.h"
 #include "gtest/gtest.h"
 #include <exception>
@@ -129,5 +126,3 @@ TEST_F(OptionContainerTest, Assignment)
     EXPECT_EQ(1.1, test.optionValue<double>("option #2"));
     EXPECT_EQ("xxx", test.optionValue<std::string>("option #3"));
 }
-
-#endif

--- a/Tests/UnitTests/Fit/0/RealLimitsTest.h
+++ b/Tests/UnitTests/Fit/0/RealLimitsTest.h
@@ -1,6 +1,3 @@
-#ifndef LIMITSTEST_H
-#define LIMITSTEST_H
-
 #include "RealLimits.h"
 #include <limits>
 
@@ -170,5 +167,3 @@ TEST_F(RealLimitsTest, CopyConstructor)
     EXPECT_TRUE(lim1 == lim3);
     EXPECT_FALSE(lim1 != lim3);
 }
-
-#endif

--- a/Tests/UnitTests/Fit/0/StringUtilsTest.h
+++ b/Tests/UnitTests/Fit/0/StringUtilsTest.h
@@ -1,6 +1,3 @@
-#ifndef STRINGUTILSTEST_H
-#define STRINGUTILSTEST_H
-
 #include "StringUtils.h"
 
 
@@ -18,6 +15,3 @@ TEST_F(StringUtilsTest, removeSubstring)
     std::string result = StringUtils::removeSubstring(target, "one");
     EXPECT_EQ(result, " two three five ");
 }
-
-#endif
-

--- a/Tests/UnitTests/GUI/GUICoreObjectCorrespondence.h
+++ b/Tests/UnitTests/GUI/GUICoreObjectCorrespondence.h
@@ -1,6 +1,3 @@
-#ifndef GUICOREOBJECTCORRESPONDENCE_H
-#define GUICOREOBJECTCORRESPONDENCE_H
-
 #include "SessionItem.h"
 #include "IParameterized.h"
 
@@ -27,5 +24,3 @@ inline void GUICoreObjectCorrespondence(const SessionItem& gui_object,
     }
     */
 }
-
-#endif // GUICOREOBJECTCORRESPONDENCE_H

--- a/Tests/UnitTests/GUI/TestComboProperty.h
+++ b/Tests/UnitTests/GUI/TestComboProperty.h
@@ -1,6 +1,3 @@
-#ifndef TESTCOMBOPROPERTY_H
-#define TESTCOMBOPROPERTY_H
-
 #include <QtTest>
 #include "ComboProperty.h"
 #include <QDebug>
@@ -54,5 +51,3 @@ inline void TestComboProperty::test_VariantEquality()
     c1.setValue("a2");
     QVERIFY(c1.getVariant() == c2.getVariant());
 }
-
-#endif // TESTCOMBOPROPERTY_H

--- a/Tests/UnitTests/GUI/TestFTDistributionItems.h
+++ b/Tests/UnitTests/GUI/TestFTDistributionItems.h
@@ -1,6 +1,3 @@
-#ifndef TESTFTDISTRIBUTIONITEMS_H
-#define TESTFTDISTRIBUTIONITEMS_H
-
 #include <QtTest>
 #include "TransformToDomain.h"
 #include "TransformFromDomain.h"
@@ -30,5 +27,3 @@ inline void TestFTDistributionItems::test_FTDistribution1DCauchy()
     item2.setItemValue(FTDistribution1DGaussItem::P_CORR_LENGTH, pdf2.getOmega());
     QVERIFY(item2.getItemValue(FTDistribution1DGaussItem::P_CORR_LENGTH) == 3.0);
 }
-
-#endif // TESTFTDISTRIBUTIONITEMS_H

--- a/Tests/UnitTests/GUI/TestFitParameterModel.h
+++ b/Tests/UnitTests/GUI/TestFitParameterModel.h
@@ -1,6 +1,3 @@
-#ifndef TESTFITPARAMETERMODEL_H
-#define TESTFITPARAMETERMODEL_H
-
 #include <QtTest>
 #include "JobModel.h"
 #include "FitParameterProxyModel.h"
@@ -238,7 +235,5 @@ inline void TestFitParameterModel::test_addTwoFitParameterAndLinks()
 //    QModelIndex linkIndex1 = proxy.index(0, 0, index1);
 
 }
-
-#endif // TESTFITPARAMETERMODEL_H
 
 

--- a/Tests/UnitTests/GUI/TestFormFactorItems.h
+++ b/Tests/UnitTests/GUI/TestFormFactorItems.h
@@ -1,6 +1,3 @@
-#ifndef TESTFORMFACTORITEMS_H
-#define TESTFORMFACTORITEMS_H
-
 #include <QtTest>
 #include "FormFactors.h"
 #include "FormFactorItems.h"
@@ -32,5 +29,3 @@ inline void TestFormFactorItems::test_AnisoPyramidItem()
     QVERIFY(p_ff->getHeight() == 13.0);
     QVERIFY( Numeric::areAlmostEqual(p_ff->getAlpha(), Units::deg2rad(60.0)));
 }
-
-#endif // TESTFORMFACTORITEMS_H

--- a/Tests/UnitTests/GUI/TestGUICoreObjectCorrespondence.h
+++ b/Tests/UnitTests/GUI/TestGUICoreObjectCorrespondence.h
@@ -1,6 +1,3 @@
-#ifndef TESTGUICOREOBJECTCORRESPONDENCE_H
-#define TESTGUICOREOBJECTCORRESPONDENCE_H
-
 #include <QtTest>
 
 class TestGUICoreObjectCorrespondence : public QObject {
@@ -37,5 +34,3 @@ private slots:
 //    void test_2DParacrystal();
 //    void test_2DLattice();
 };
-
-#endif // TESTGUICOREOBJECTCORRESPONDENCE_H

--- a/Tests/UnitTests/GUI/TestGUIHelpers.h
+++ b/Tests/UnitTests/GUI/TestGUIHelpers.h
@@ -1,6 +1,3 @@
-#ifndef TESTGUIHELPERS_H
-#define TESTGUIHELPERS_H
-
 #include <QtTest>
 #include "GUIHelpers.h"
 
@@ -31,5 +28,3 @@ inline void TestGUIHelpers::test_VersionString()
     QCOMPARE(GUIHelpers::isVersionMatchMinimal("1.4.9", min_version), false);
     QCOMPARE(GUIHelpers::isVersionMatchMinimal("0.6.9", min_version), false);
 }
-
-#endif // TESTGUIHELPERS_H

--- a/Tests/UnitTests/GUI/TestLayerRoughnessItems.h
+++ b/Tests/UnitTests/GUI/TestLayerRoughnessItems.h
@@ -1,6 +1,3 @@
-#ifndef TESTLAYERROUGHNESSITEMS_H
-#define TESTLAYERROUGHNESSITEMS_H
-
 #include <QtTest>
 #include "LayerRoughness.h"
 #include "LayerRoughnessItems.h"
@@ -40,7 +37,4 @@ inline void TestLayerRoughnessItems::test_LayerRoughnessFromDomain()
     QCOMPARE(roughness.getHurstParameter(), roughnessItem.getItemValue(LayerBasicRoughnessItem::P_HURST).toDouble());
     QCOMPARE(roughness.getLatteralCorrLength(), roughnessItem.getItemValue(LayerBasicRoughnessItem::P_LATERAL_CORR_LENGTH).toDouble());
 }
-
-
-#endif // TESTLAYERROUGHNESSITEMS_H
 

--- a/Tests/UnitTests/GUI/TestMapperCases.h
+++ b/Tests/UnitTests/GUI/TestMapperCases.h
@@ -1,6 +1,3 @@
-#ifndef TESTMAPPERCASES_H
-#define TESTMAPPERCASES_H
-
 #include "SessionItem.h"
 #include "SampleModel.h"
 #include "InstrumentModel.h"
@@ -120,5 +117,3 @@ inline void TestMapperCases::test_SimulationOptionsComputationToggle()
     item->setItemValue(SimulationOptionsItem::P_COMPUTATION_METHOD, combo.getVariant());
     QVERIFY(item->getItem(SimulationOptionsItem::P_MC_POINTS)->isEnabled() == true);
 }
-
-#endif // TESTMAPPERCASES_H

--- a/Tests/UnitTests/GUI/TestMapperForItem.h
+++ b/Tests/UnitTests/GUI/TestMapperForItem.h
@@ -1,6 +1,3 @@
-#ifndef TESTMAPPERFORITEM_H
-#define TESTMAPPERFORITEM_H
-
 #include "SessionItem.h"
 #include "SampleModel.h"
 #include "LayerItem.h"
@@ -341,7 +338,3 @@ inline void TestMapperForItem::test_TwoWidgetsSubscription()
     QCOMPARE(w2.m_onPropertyChangeCount, 2);
 
 }
-
-
-
-#endif // TESTMAPPERFORITEM_H

--- a/Tests/UnitTests/GUI/TestMaterialModel.h
+++ b/Tests/UnitTests/GUI/TestMaterialModel.h
@@ -1,6 +1,3 @@
-#ifndef TESTMATERIALMODEL_H
-#define TESTMATERIALMODEL_H
-
 #include "MaterialModel.h"
 #include "MaterialItem.h"
 #include "RefractiveIndexItem.h"
@@ -67,5 +64,3 @@ inline void TestMaterialModel::test_cloneMaterial()
 
 
 }
-
-#endif // TESTMATERIALMODEL_H

--- a/Tests/UnitTests/GUI/TestParaCrystalItems.h
+++ b/Tests/UnitTests/GUI/TestParaCrystalItems.h
@@ -1,6 +1,3 @@
-#ifndef TESTPARACRYSTALITEMS_H
-#define TESTPARACRYSTALITEMS_H
-
 #include <QtTest>
 #include "InterferenceFunctionItems.h"
 #include "GroupProperty.h"
@@ -63,6 +60,4 @@ inline void TestParaCrystalItems::test_Para1D_PDFGroupProperty()
         QCOMPARE(pdfItem->modelType(), pdf_name);
     }
 }
-
-#endif // TESTPARACRYSTALITEMS_H
 

--- a/Tests/UnitTests/GUI/TestParameterizedItem.h
+++ b/Tests/UnitTests/GUI/TestParameterizedItem.h
@@ -1,7 +1,3 @@
-#ifndef TESTPARAMETERIZEDITEM_H
-#define TESTPARAMETERIZEDITEM_H
-
-
 #include <QtTest>
 #include "SessionItem.h"
 #include "GUIHelpers.h"
@@ -68,7 +64,4 @@ inline void TestParameterizedItem::test_SelectableGroupProperty()
 //    SessionItem item;
 //    QCOMPARE(item.getSubItems().size(), 0);
 }
-
-
-#endif // TESTPARAMETERIZEDITEM_H
 

--- a/Tests/UnitTests/GUI/TestParticleDistributionItem.h
+++ b/Tests/UnitTests/GUI/TestParticleDistributionItem.h
@@ -1,7 +1,3 @@
-#ifndef TESTPARTICLEDISTRIBUTIONITEM_H
-#define TESTPARTICLEDISTRIBUTIONITEM_H
-
-
 #include <QtTest>
 #include "SampleModel.h"
 #include "ParticleDistributionItem.h"
@@ -51,6 +47,3 @@ inline void TestParticleDistributionItem::test_AddParticle()
     qDebug() << prop.getValues();
 
 }
-
-
-#endif // TESTPARTICLEDISTRIBUTIONITEM_H

--- a/Tests/UnitTests/GUI/TestParticleItem.h
+++ b/Tests/UnitTests/GUI/TestParticleItem.h
@@ -1,7 +1,3 @@
-#ifndef TESTPARTICLEITEM_H
-#define TESTPARTICLEITEM_H
-
-
 #include <QtTest>
 #include "SampleModel.h"
 #include "SessionItem.h"
@@ -122,7 +118,3 @@ inline void TestParticleItem::test_InitialState()
 
 
 //}
-
-
-
-#endif // TESTPARTICLEITEM_H

--- a/Tests/UnitTests/GUI/TestSessionItem.h
+++ b/Tests/UnitTests/GUI/TestSessionItem.h
@@ -1,7 +1,3 @@
-#ifndef TESTSESSIONITEM_H
-#define TESTSESSIONITEM_H
-
-
 #include <QtTest>
 #include "SessionItem.h"
 #include "GUIHelpers.h"
@@ -227,6 +223,3 @@ inline void TestSessionItem::test_model_types()
 ////    SessionItem item;
 ////    QCOMPARE(item.getSubItems().size(), 0);
 //}
-
-
-#endif // TESTSESSIONITEM_H

--- a/Tests/UnitTests/GUI/TestSessionModel.h
+++ b/Tests/UnitTests/GUI/TestSessionModel.h
@@ -1,6 +1,3 @@
-#ifndef TESTSESSIONMODEL_H
-#define TESTSESSIONMODEL_H
-
 #include <QtTest>
 #include "SessionModel.h"
 #include "SampleModel.h"
@@ -171,7 +168,4 @@ inline void TestSessionModel::test_copyParameterizedItem()
     delete instrumentModel;
     delete jobModel;
 }
-
-
-#endif // TESTSESSIONMODEL_H
 

--- a/Tests/UnitTests/GUI/verify_throw_macro.h
+++ b/Tests/UnitTests/GUI/verify_throw_macro.h
@@ -13,9 +13,6 @@
 //
 // ************************************************************************** //
 
-#ifndef VERIFY_THROW_MACRO_H
-#define VERIFY_THROW_MACRO_H
-
 #include <QTest>
 
 #define QVERIFY_THROW(expression, ExpectedExceptionType) \
@@ -28,6 +25,3 @@ catch (...) {} \
 if (!QTest::qVerify(caught_, #expression ", " #ExpectedExceptionType, "", __FILE__, __LINE__))\
 return; \
 } while(0)
-
-
-#endif // VERIFY_THROW_MACRO_H


### PR DESCRIPTION
Checks that repeated matrix multiplication in multilayer RT coefficients computation is done correctly and that it is numerically stable. This resolves #1734: cannot confirm my suspicion that the computation is ill conditioned.

Also updated some file headers and removed all include guards from unit test h files, as proposed in #1735.