### PR TITLE
WarningSign refactoring

### DIFF
--- a/Core/Fitting/FitSuiteImpl.cpp
+++ b/Core/Fitting/FitSuiteImpl.cpp
@@ -182,6 +182,10 @@ void FitSuiteImpl::link_fit_parameters()
 {
     std::unique_ptr<ParameterPool> pool(m_fit_objects.createParameterTree());
     auto parameters = FitSuiteUtils::linkedParameters(*m_kernel->fitParameters());
+
+    if(parameters.empty())
+        throw Exceptions::RuntimeErrorException("No fit Parameters defined.");
+
     for (auto par: parameters)
         par->addMatchedParameters(*pool);
 

--- a/GUI/coregui/Models/FitParameterItems.cpp
+++ b/GUI/coregui/Models/FitParameterItems.cpp
@@ -20,6 +20,7 @@
 #include "ModelPath.h"
 #include "FitParameter.h"
 #include "ParameterTreeItems.h"
+#include "JobItem.h"
 #include <cmath>
 
 namespace
@@ -122,15 +123,16 @@ std::unique_ptr<FitParameter> FitParameterItem::createFitParameter() const
     result->setStartValue(getItemValue(FitParameterItem::P_START_VALUE).toDouble());
     result->setLimits(attLimits());
 
-    const SessionItem* jobItem = ModelPath::ancestor(this, Constants::JobItemType);
+    const JobItem* jobItem = dynamic_cast<const JobItem*>(ModelPath::ancestor(this, Constants::JobItemType));
     Q_ASSERT(jobItem);
 
     foreach (SessionItem* linkItem, getItems(FitParameterItem::T_LINK)) {
-//        QString link = linkItem->getItemValue(FitParameterLinkItem::P_LINK).toString();
-//        std::string domainPath = "*" + ModelPath::translateParameterName(jobItem, link);
-//        linkItem->setItemValue(FitParameterLinkItem::P_DOMAIN, QString::fromStdString(domainPath));
+        QString link = linkItem->getItemValue(FitParameterLinkItem::P_LINK).toString();
 
-        ParameterItem *parItem = dynamic_cast<ParameterItem*>(linkItem);
+        ParameterItem *parItem = dynamic_cast<ParameterItem*>(
+                    ModelPath::getItemFromPath(link, jobItem->parameterContainerItem()));
+        Q_ASSERT(parItem);
+
         QString translation = "*/" + ModelPath::itemPathTranslation(*parItem->linkedItem(), jobItem);
         parItem->setItemValue(ParameterItem::P_DOMAIN, translation);
 

--- a/GUI/coregui/Models/JobItem.cpp
+++ b/GUI/coregui/Models/JobItem.cpp
@@ -276,7 +276,13 @@ FitSuiteItem *JobItem::fitSuiteItem()
     return dynamic_cast<FitSuiteItem *>(getItem(JobItem::T_FIT_SUITE));
 }
 
-ParameterContainerItem *JobItem::parameterContainerItem()
+ParameterContainerItem* JobItem::parameterContainerItem()
+{
+    return const_cast<ParameterContainerItem*>(
+        static_cast<const JobItem*>(this)->parameterContainerItem());
+}
+
+const ParameterContainerItem *JobItem::parameterContainerItem() const
 {
     return dynamic_cast<ParameterContainerItem *>(getItem(JobItem::T_PARAMETER_TREE));
 }

--- a/GUI/coregui/Models/JobItem.h
+++ b/GUI/coregui/Models/JobItem.h
@@ -96,6 +96,8 @@ public:
 
     FitSuiteItem *fitSuiteItem();
     ParameterContainerItem *parameterContainerItem();
+    const ParameterContainerItem *parameterContainerItem() const;
+
     FitParameterContainerItem *fitParameterContainerItem();
     RealDataItem *realDataItem();
 

--- a/GUI/coregui/Models/JobQueueData.cpp
+++ b/GUI/coregui/Models/JobQueueData.cpp
@@ -273,14 +273,14 @@ void JobQueueData::processFinishedJob(JobWorker *runner, JobItem *jobItem)
     jobItem->setDuration(runner->getSimulationDuration());
 
     // propagating status of runner
-    jobItem->setStatus(runner->getStatus());
-    if(jobItem->isFailed()) {
+    if(runner->getStatus() == Constants::STATUS_FAILED) {
         jobItem->setComments(runner->getFailureMessage());
     } else {
         // propagating simulation results
         GISASSimulation *simulation = getSimulation(runner->getIdentifier());
         jobItem->setResults(simulation);
     }
+    jobItem->setStatus(runner->getStatus());
 
     // fixing job progress (if job was successfull, but due to wrong estimation, progress not 100%)
     if(jobItem->isCompleted())

--- a/GUI/coregui/Views/FitWidgets/RunFitControlWidget.cpp
+++ b/GUI/coregui/Views/FitWidgets/RunFitControlWidget.cpp
@@ -19,7 +19,7 @@
 #include "FitSuiteItem.h"
 #include "JobItem.h"
 #include "JobMessagePanel.h"
-#include "WarningSignWidget.h"
+#include "WarningSign.h"
 #include "mainwindow_constants.h"
 #include <QFont>
 #include <QHBoxLayout>
@@ -28,8 +28,6 @@
 #include <QSlider>
 
 namespace {
-const int warning_sign_xpos = 42;
-const int warning_sign_ypos = 42;
 const int default_update_interval = 10;
 const std::vector<int> slider_to_interval = {1,2,3,4,5,10,15,20,25,30,50,100,200,500,1000};
 const QString slider_tooltip = "Updates fit progress every Nth iteration";
@@ -43,7 +41,7 @@ RunFitControlWidget::RunFitControlWidget(QWidget *parent)
     , m_updateIntervalLabel(new QLabel("25"))
     , m_iterationsCountLabel(new QLabel)
     , m_currentItem(0)
-    , m_warningSign(0)
+    , m_warningSign(new WarningSign(this))
     , m_jobMessagePanel(0)
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
@@ -103,7 +101,7 @@ void RunFitControlWidget::setJobMessagePanel(JobMessagePanel *jobMessagePanel)
 void RunFitControlWidget::onFittingStarted(JobItem *jobItem)
 {
     m_currentItem = jobItem;
-    clearWarningSign();
+    m_warningSign->clear();
     m_startButton->setEnabled(false);
     m_stopButton->setEnabled(true);
 
@@ -138,19 +136,13 @@ void RunFitControlWidget::onFittingFinished(JobItem *jobItem)
 
 void RunFitControlWidget::onFittingError(const QString &what)
 {
-    clearWarningSign();
+    m_warningSign->clear();
     m_iterationsCountLabel->setText("");
 
     QString message;
     message.append("Current settings cause fitting failure.\n\n");
     message.append(what);
-
-    m_warningSign = new WarningSignWidget(this);
     m_warningSign->setWarningMessage(message);
-    QPoint pos = getPositionForWarningSign();
-    m_warningSign->setPosition(pos.x(), pos.y());
-    m_warningSign->show();
-
     m_jobMessagePanel->onMessage(message, QColor(Qt::darkRed));
 }
 
@@ -193,29 +185,6 @@ void RunFitControlWidget::onFitSuitePropertyChange(const QString &name)
         int niter = fitSuiteItem()->getItemValue(FitSuiteItem::P_ITERATION_COUNT).toInt();
         m_iterationsCountLabel->setText(QString::number(niter));
     }
-}
-
-void RunFitControlWidget::resizeEvent(QResizeEvent *event)
-{
-    Q_UNUSED(event);
-    if(m_warningSign) {
-        QPoint pos = getPositionForWarningSign();
-        m_warningSign->setPosition(pos.x(),pos.y());
-    }
-    QWidget::resizeEvent(event);
-}
-
-QPoint RunFitControlWidget::getPositionForWarningSign()
-{
-    int x = width()-warning_sign_xpos;
-    int y = height()-warning_sign_ypos;
-    return QPoint(x, y);
-}
-
-void RunFitControlWidget::clearWarningSign()
-{
-    delete m_warningSign;
-    m_warningSign = 0;
 }
 
 int RunFitControlWidget::sliderUpdateInterval()

--- a/GUI/coregui/Views/FitWidgets/RunFitControlWidget.h
+++ b/GUI/coregui/Views/FitWidgets/RunFitControlWidget.h
@@ -23,7 +23,7 @@
 class JobItem;
 class QPushButton;
 class QSlider;
-class WarningSignWidget;
+class WarningSign;
 class QLabel;
 class FitSuiteItem;
 class JobMessagePanel;
@@ -54,12 +54,7 @@ private slots:
     void onSliderValueChanged(int value);
     void onFitSuitePropertyChange(const QString &name);
 
-protected:
-    void resizeEvent(QResizeEvent *event);
-
 private:
-    QPoint getPositionForWarningSign();
-    void clearWarningSign();
     int sliderUpdateInterval();
     int sliderValueToUpdateInterval(int value);
     FitSuiteItem *fitSuiteItem();
@@ -71,7 +66,7 @@ private:
     QLabel *m_updateIntervalLabel;
     QLabel *m_iterationsCountLabel;
     JobItem *m_currentItem;
-    WarningSignWidget *m_warningSign;
+    WarningSign *m_warningSign;
     JobMessagePanel *m_jobMessagePanel;
 };
 

--- a/GUI/coregui/Views/InfoWidgets/DistributionWidget.cpp
+++ b/GUI/coregui/Views/InfoWidgets/DistributionWidget.cpp
@@ -19,6 +19,7 @@
 #include "Distributions.h"
 #include "qcustomplot.h"
 #include "RealLimitsItems.h"
+#include "WarningSign.h"
 #include <QLabel>
 #include <QVBoxLayout>
 #include <algorithm>
@@ -27,8 +28,6 @@ namespace
 {
 const QPair<double, double> default_xrange(-0.1, 0.1);
 const QPair<double, double> default_yrange(0.0, 1.1);
-const int warning_sign_xpos = 50;
-const int warning_sign_ypos = 18;
 
 QPair<double, double> xRangeForValue(double value);
 QPair<double, double> xRangeForValues(double value1, double value2);
@@ -44,7 +43,7 @@ DistributionWidget::DistributionWidget(QWidget *parent)
     , m_item(0)
     , m_label(new QLabel)
     , m_resetAction(new QAction(this))
-    , m_warningSign(0)
+    , m_warningSign(new WarningSign(this))
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
@@ -113,15 +112,9 @@ void DistributionWidget::plotItem()
     } catch (const std::exception &ex) {
         init_plot();
 
-        m_warningSign = new WarningSignWidget(this);
-
         QString message
-            = QString("Wrong parameters\n").append(QString::fromStdString(ex.what()));
-
+            = QString("Wrong parameters\n\n").append(QString::fromStdString(ex.what()));
         m_warningSign->setWarningMessage(message);
-        QPoint pos = positionForWarningSign();
-        m_warningSign->setPosition(pos.x(), pos.y());
-        m_warningSign->show();
     }
 
     m_plot->replot();
@@ -164,8 +157,7 @@ void DistributionWidget::resetView()
 
 void DistributionWidget::init_plot()
 {
-    delete m_warningSign;
-    m_warningSign = 0;
+    m_warningSign->clear();
 
     m_plot->clearGraphs();
     m_plot->clearItems();
@@ -330,27 +322,6 @@ void DistributionWidget::plotLimits(const RealLimits& limits)
 void DistributionWidget::setXAxisName(const QString& xAxisName)
 {
     m_plot->xAxis->setLabel(xAxisName);
-}
-
-//! adjusts position of warning label on widget move
-
-void DistributionWidget::resizeEvent(QResizeEvent *event)
-{
-    Q_UNUSED(event);
-    if (m_warningSign) {
-        QPoint pos = positionForWarningSign();
-        m_warningSign->setPosition(pos.x(), pos.y());
-    }
-}
-
-//! Returns position for warning sign at the bottom right corner of the editor. The position will
-//! be adjusted according to the visibility of scroll bars
-
-QPoint DistributionWidget::positionForWarningSign()
-{
-    int x = m_plot->geometry().topRight().x() - warning_sign_xpos;
-    int y = m_plot->geometry().topRight().y() + warning_sign_ypos;
-    return QPoint(x, y);
 }
 
 namespace {

--- a/GUI/coregui/Views/InfoWidgets/DistributionWidget.h
+++ b/GUI/coregui/Views/InfoWidgets/DistributionWidget.h
@@ -17,7 +17,6 @@
 #ifndef DISTRIBUTIONWIDGET_H
 #define DISTRIBUTIONWIDGET_H
 
-#include "WarningSignWidget.h"
 #include "qcustomplot.h"
 #include <QWidget>
 
@@ -27,6 +26,7 @@ class QCustomPlot;
 class DistributionItem;
 class QAction;
 class RealLimits;
+class WarningSign;
 
 //! The DistributionWidget class plots 1d functions corresponding to domain's Distribution1D
 class DistributionWidget : public QWidget
@@ -44,9 +44,6 @@ public:
 public slots:
     void onMouseMove(QMouseEvent *event);
     void onMousePress(QMouseEvent *event);
-
-protected:
-    void resizeEvent(QResizeEvent *event);
 
 private slots:
     void resetView();
@@ -69,7 +66,7 @@ private:
     QLabel *m_label;
     QAction *m_resetAction;
     QCPRange m_xRange, m_yRange;
-    WarningSignWidget *m_warningSign;
+    WarningSign *m_warningSign;
 };
 
 #endif // DISTRIBUTIONWIDGET_H

--- a/GUI/coregui/Views/InfoWidgets/InfoWidget.cpp
+++ b/GUI/coregui/Views/InfoWidgets/InfoWidget.cpp
@@ -86,17 +86,11 @@ void InfoWidget::onDockVisibilityChange(bool is_visible)
 {
     Q_ASSERT(m_pySampleWidget);
     if(isEditorVisible()) {
-        if(!is_visible) {
-            m_pySampleWidget->disableEditor();
-        } else {
-            //m_pySampleWidget->scheduleUpdate();
-            m_pySampleWidget->enableEditor();
-        }
+        if(!is_visible)
+            m_pySampleWidget->setEditorConnected(false);
+        else
+            m_pySampleWidget->setEditorConnected(true);
     }
-
-
-//    if(status != isEditorVisible())
-//        m_pySampleWidget->setEditorEnabled(status);
 }
 
 void InfoWidget::onExpandButtonClicked()
@@ -116,11 +110,11 @@ void InfoWidget::setEditorVisible(bool editor_status, bool dock_notify)
         }
         m_placeHolder->hide();
         m_pySampleWidget->show();
-        m_pySampleWidget->enableEditor();
+        m_pySampleWidget->setEditorConnected(true);
     } else {
         m_cached_height = height();
         m_pySampleWidget->hide();
-        m_pySampleWidget->disableEditor();
+        m_pySampleWidget->setEditorConnected(false);
         m_placeHolder->show();
         if(dock_notify) emit widgetHeightRequest(minimum_widget_height);
     }

--- a/GUI/coregui/Views/InfoWidgets/PySampleWidget.cpp
+++ b/GUI/coregui/Views/InfoWidgets/PySampleWidget.cpp
@@ -144,6 +144,8 @@ void PySampleWidget::setEditorConnected(bool isConnected)
         connect(m_updateTimer, SIGNAL(timeToUpdate()), this, SLOT(updateEditor()),
                 Qt::UniqueConnection);
 
+        m_updateTimer->scheduleUpdate();
+
     } else {
         disconnect(m_sampleModel, SIGNAL(rowsInserted(QModelIndex, int, int)), this,
                    SLOT(onModifiedRow(QModelIndex, int, int)));

--- a/GUI/coregui/Views/InfoWidgets/PySampleWidget.h
+++ b/GUI/coregui/Views/InfoWidgets/PySampleWidget.h
@@ -24,8 +24,8 @@ class SampleModel;
 class InstrumentModel;
 class QTextEdit;
 class QModelIndex;
-class QTimer;
 class PythonSyntaxHighlighter;
+class UpdateTimer;
 class WarningSign;
 
 //! The PySampleWidget displays Python script representing a MultiLayer at the bottom of SampleView
@@ -44,14 +44,8 @@ public slots:
     void onModifiedRow(const QModelIndex&, int, int);
     void onDataChanged(const QModelIndex&, const QModelIndex&);
 
-    void scheduleUpdate();
     void updateEditor();
-
-    void disableEditor();
-    void enableEditor();
-
-private slots:
-    void onTimerTimeout();
+    void setEditorConnected(bool isConnected);
 
 private:
     QString generateCodeSnippet();
@@ -60,10 +54,8 @@ private:
     QTextEdit* m_textEdit;
     SampleModel* m_sampleModel;
     InstrumentModel* m_instrumentModel;
-    QTimer* m_timer;
-    int m_time_to_update;
-    int m_n_of_sceduled_updates;
     PythonSyntaxHighlighter* m_highlighter;
+    UpdateTimer* m_updateTimer;
     WarningSign* m_warningSign;
 };
 

--- a/GUI/coregui/Views/InfoWidgets/PySampleWidget.h
+++ b/GUI/coregui/Views/InfoWidgets/PySampleWidget.h
@@ -26,7 +26,7 @@ class QTextEdit;
 class QModelIndex;
 class QTimer;
 class PythonSyntaxHighlighter;
-class WarningSignWidget;
+class WarningSign;
 
 //! The PySampleWidget displays Python script representing a MultiLayer at the bottom of SampleView
 //! Belongs to InfoWidget
@@ -35,14 +35,14 @@ class BA_CORE_API_ PySampleWidget : public QWidget
     Q_OBJECT
 
 public:
-    PySampleWidget(QWidget *parent = 0);
+    PySampleWidget(QWidget* parent = 0);
 
-    void setSampleModel(SampleModel *sampleModel);
-    void setInstrumentModel(InstrumentModel *instrumentModel);
+    void setSampleModel(SampleModel* sampleModel);
+    void setInstrumentModel(InstrumentModel* instrumentModel);
 
 public slots:
-    void onModifiedRow(const QModelIndex &, int, int);
-    void onDataChanged(const QModelIndex &, const QModelIndex &);
+    void onModifiedRow(const QModelIndex&, int, int);
+    void onDataChanged(const QModelIndex&, const QModelIndex&);
 
     void scheduleUpdate();
     void updateEditor();
@@ -53,22 +53,18 @@ public slots:
 private slots:
     void onTimerTimeout();
 
-protected:
-    void resizeEvent(QResizeEvent *event);
-
 private:
     QString generateCodeSnippet();
-    QPoint getPositionForWarningSign();
-    QString getWelcomeMessage();
+    QString welcomeMessage();
 
-    QTextEdit *m_textEdit;
-    SampleModel *m_sampleModel;
-    InstrumentModel *m_instrumentModel;
-    QTimer *m_timer;
+    QTextEdit* m_textEdit;
+    SampleModel* m_sampleModel;
+    InstrumentModel* m_instrumentModel;
+    QTimer* m_timer;
     int m_time_to_update;
     int m_n_of_sceduled_updates;
-    PythonSyntaxHighlighter *m_highlighter;
-    WarningSignWidget *m_warningSign;
+    PythonSyntaxHighlighter* m_highlighter;
+    WarningSign* m_warningSign;
 };
 
 #endif // PYSAMPLEWIDGET_H

--- a/GUI/coregui/Views/InfoWidgets/WarningSign.cpp
+++ b/GUI/coregui/Views/InfoWidgets/WarningSign.cpp
@@ -21,8 +21,8 @@
 #include <QScrollBar>
 
 namespace {
-const int xpos_offset = 38;
-const int ypos_offset = 38;
+const int xpos_offset = 40;
+const int ypos_offset = 40;
 }
 
 WarningSign::WarningSign(QWidget* parent)

--- a/GUI/coregui/Views/InfoWidgets/WarningSign.cpp
+++ b/GUI/coregui/Views/InfoWidgets/WarningSign.cpp
@@ -1,0 +1,111 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Views/InfoWidgets/WarningSign.cpp
+//! @brief     Implements class WarningSign
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
+//! @authors   Walter Van Herck, Joachim Wuttke
+//
+// ************************************************************************** //
+
+#include "WarningSign.h"
+#include "WarningSignWidget.h"
+#include <QAbstractScrollArea>
+#include <QEvent>
+#include <QScrollBar>
+
+namespace {
+const int xpos_offset = 38;
+const int ypos_offset = 38;
+}
+
+WarningSign::WarningSign(QWidget* parent)
+    : QObject(parent)
+    , m_warning_header(QStringLiteral("Houston, we have a problem."))
+    , m_warningWidget(0)
+    , m_area(nullptr)
+{
+    setArea(parent);
+}
+
+//! Clears warning message;
+
+void WarningSign::clear()
+{
+    delete m_warningWidget;
+    m_warningWidget = 0;
+    m_warning_message.clear();
+}
+
+void WarningSign::setWarningHeader(const QString& warningHeader)
+{
+    m_warning_header = warningHeader;
+}
+
+void WarningSign::setWarningMessage(const QString& warningMessage)
+{
+    Q_ASSERT(m_area);
+
+    m_warning_message = warningMessage;
+
+    if (!m_warningWidget)
+        m_warningWidget = new WarningSignWidget(m_area);
+
+    m_warningWidget->setWarningMessage(m_warning_message);
+    updateLabelGeometry();
+    m_warningWidget->show();
+}
+
+void WarningSign::setArea(QWidget* area)
+{
+    m_area = area;
+    m_area->installEventFilter(this);
+}
+
+bool WarningSign::eventFilter(QObject* obj, QEvent* event)
+{
+    if (event->type() == QEvent::Resize)
+        updateLabelGeometry();
+
+    return QObject::eventFilter(obj, event);
+}
+
+void WarningSign::updateLabelGeometry()
+{
+    if (!m_warningWidget || !m_area)
+        return;
+
+    QPoint pos = positionForWarningSign();
+    m_warningWidget->setPosition(pos.x(), pos.y());
+}
+
+QPoint WarningSign::positionForWarningSign() const
+{
+    Q_ASSERT(m_area);
+
+    int x = m_area->width() - xpos_offset;
+    int y = m_area->height() - ypos_offset;
+
+    if (QAbstractScrollArea* scrollArea = dynamic_cast<QAbstractScrollArea*>(m_area)) {
+
+        if (QScrollBar* horizontal = scrollArea->horizontalScrollBar()) {
+            if (horizontal->isVisible())
+                y -= horizontal->height();
+        }
+
+        if (QScrollBar* vertical = scrollArea->verticalScrollBar()) {
+            if (vertical->isVisible())
+                x -= vertical->width();
+        }
+    }
+
+    return QPoint(x, y);
+}
+
+

--- a/GUI/coregui/Views/InfoWidgets/WarningSign.cpp
+++ b/GUI/coregui/Views/InfoWidgets/WarningSign.cpp
@@ -83,6 +83,11 @@ void WarningSign::setArea(QWidget* area)
     m_area->installEventFilter(this);
 }
 
+bool WarningSign::isShown() const
+{
+    return (m_warningWidget == nullptr ? false : true);
+}
+
 bool WarningSign::eventFilter(QObject* obj, QEvent* event)
 {
     if (event->type() == QEvent::Resize)

--- a/GUI/coregui/Views/InfoWidgets/WarningSign.h
+++ b/GUI/coregui/Views/InfoWidgets/WarningSign.h
@@ -38,6 +38,8 @@ public:
 
     void setArea(QWidget *area);
 
+    bool isShown() const;
+
 protected:
     bool eventFilter(QObject *obj, QEvent *event);
 

--- a/GUI/coregui/Views/InfoWidgets/WarningSign.h
+++ b/GUI/coregui/Views/InfoWidgets/WarningSign.h
@@ -49,6 +49,7 @@ private:
     QString m_warning_message;
     WarningSignWidget* m_warningWidget;
     QWidget *m_area;
+    bool m_clear_just_had_happened;
 };
 
 #endif // WARNINGSIGN_H

--- a/GUI/coregui/Views/InfoWidgets/WarningSign.h
+++ b/GUI/coregui/Views/InfoWidgets/WarningSign.h
@@ -1,0 +1,54 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Views/InfoWidgets/WarningSign.h
+//! @brief     Defines class WarningSign
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
+//! @authors   Walter Van Herck, Joachim Wuttke
+//
+// ************************************************************************** //
+
+#ifndef WARNINGSIGN_H
+#define WARNINGSIGN_H
+
+#include "WinDllMacros.h"
+#include <QObject>
+
+class WarningSignWidget;
+class QWidget;
+
+//! The WarningSign controls appearance of WarningSignWidget on top of parent widget.
+
+class WarningSign : public QObject
+{
+public:
+    WarningSign(QWidget* parent);
+
+    void clear();
+
+    void setWarningHeader(const QString& warningHeader);
+
+    void setWarningMessage(const QString& warningMessage);
+
+    void setArea(QWidget *area);
+
+protected:
+    bool eventFilter(QObject *obj, QEvent *event);
+
+private:
+    void updateLabelGeometry();
+    QPoint positionForWarningSign() const;
+
+    QString m_warning_header;
+    QString m_warning_message;
+    WarningSignWidget* m_warningWidget;
+    QWidget *m_area;
+};
+
+#endif // WARNINGSIGN_H

--- a/GUI/coregui/Views/InfoWidgets/WarningSignWidget.cpp
+++ b/GUI/coregui/Views/InfoWidgets/WarningSignWidget.cpp
@@ -38,7 +38,12 @@ void WarningSignWidget::paintEvent(QPaintEvent *event) {
 void WarningSignWidget::mousePressEvent(QMouseEvent *event)
 {
     Q_UNUSED(event);
-    QMessageBox::warning(this, m_warning_header, m_warning_message);
+    QMessageBox box;
+    box.setWindowTitle(m_warning_header);
+    box.setInformativeText(m_warning_message);
+    box.setStandardButtons(QMessageBox::Ok);
+    box.setDefaultButton(QMessageBox::Ok);
+    box.exec();
 }
 
 //! set geometry of widget around center point

--- a/GUI/coregui/Views/InfoWidgets/WarningSignWidget.cpp
+++ b/GUI/coregui/Views/InfoWidgets/WarningSignWidget.cpp
@@ -21,14 +21,11 @@
 
 WarningSignWidget::WarningSignWidget(QWidget * parent)
     : QWidget(parent)
+    , m_pixmap(QStringLiteral(":/images/warning@2x.png"))
+    , m_warning_header(QStringLiteral("Houston, we have a problem."))
 {
     setAttribute(Qt::WA_NoSystemBackground);
-    //setAttribute(Qt::WA_TransparentForMouseEvents);
-    m_pixmap = QPixmap(":/images/warning@2x.png");
-    setToolTip(QString(
-        "Houston, we have a problem.\n"
-        "Click to see details."
-                   ));
+    setToolTip(m_warning_header+"\nClick to see details.");
 }
 
 void WarningSignWidget::paintEvent(QPaintEvent *event) {
@@ -41,11 +38,17 @@ void WarningSignWidget::paintEvent(QPaintEvent *event) {
 void WarningSignWidget::mousePressEvent(QMouseEvent *event)
 {
     Q_UNUSED(event);
-    QMessageBox::warning(this, "Houston, we have a problem.", m_warning_message);
+    QMessageBox::warning(this, m_warning_header, m_warning_message);
 }
 
 //! set geometry of widget around center point
 void WarningSignWidget::setPosition(int x, int y)
 {
     setGeometry(x, y, m_pixmap.width(), m_pixmap.height());
+}
+
+void WarningSignWidget::setWarningHeader(const QString& message)
+{
+    m_warning_header = message;
+    setToolTip(m_warning_header+"\nClick to see details.");
 }

--- a/GUI/coregui/Views/InfoWidgets/WarningSignWidget.h
+++ b/GUI/coregui/Views/InfoWidgets/WarningSignWidget.h
@@ -31,6 +31,7 @@ public:
 
     void setPosition(int x, int y);
 
+    void setWarningHeader(const QString &message);
     void setWarningMessage(const QString &message) {m_warning_message = message;}
 
 protected:
@@ -39,6 +40,7 @@ protected:
 
 private:
     QPixmap m_pixmap;
+    QString m_warning_header;
     QString m_warning_message;
 };
 

--- a/GUI/coregui/Views/JobWidgets/ParameterTuningWidget.cpp
+++ b/GUI/coregui/Views/JobWidgets/ParameterTuningWidget.cpp
@@ -108,6 +108,7 @@ void ParameterTuningWidget::setItem(JobItem *item)
             onPropertyChanged(name);
         }, this);
 
+        onPropertyChanged(JobItem::P_STATUS);
     }
 }
 

--- a/GUI/coregui/Views/JobWidgets/ParameterTuningWidget.cpp
+++ b/GUI/coregui/Views/JobWidgets/ParameterTuningWidget.cpp
@@ -28,7 +28,7 @@
 #include "ParameterTuningModel.h"
 #include "SampleModel.h"
 #include "SliderSettingsWidget.h"
-#include "WarningSignWidget.h"
+#include "WarningSign.h"
 #include <QApplication>
 #include <QItemSelectionModel>
 #include <QKeyEvent>
@@ -39,23 +39,18 @@
 #include <QTreeView>
 #include <QVBoxLayout>
 
-namespace {
-const int warning_sign_xpos = 38;
-const int warning_sign_ypos = 38;
-}
-
 ParameterTuningWidget::ParameterTuningWidget(QWidget *parent)
     : QWidget(parent)
     , m_jobModel(0)
     , m_currentJobItem(0)
     , m_parameterTuningModel(0)
     , m_sliderSettingsWidget(new SliderSettingsWidget(this))
+    , m_treeView(new QTreeView)
     , m_delegate(new ParameterTuningDelegate)
-    , m_warningSign(0)
+    , m_warningSign(new WarningSign(m_treeView))
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
-    m_treeView = new QTreeView();
     m_treeView->setStyleSheet(
         "QTreeView::branch {background: palette(base);}QTreeView::branch:has-siblings:!adjoins-item "
         "{border-image: url(:/images/treeview-vline.png) 0;}QTreeView::branch:has-siblings:"
@@ -213,13 +208,8 @@ void ParameterTuningWidget::makeSelected(ParameterItem *item)
 void ParameterTuningWidget::resizeEvent(QResizeEvent *event)
 {
     Q_UNUSED(event);
-    if(m_warningSign) {
-        QPoint pos = getPositionForWarningSign();
-        m_warningSign->setPosition(pos.x(),pos.y());
-    }
-    if(m_treeView) {
+    if(m_treeView)
         m_treeView->setColumnWidth(0, width()*0.5);
-    }
 }
 
 //! Context menu reimplemented to suppress the default one
@@ -231,43 +221,17 @@ void ParameterTuningWidget::contextMenuEvent(QContextMenuEvent *event)
 void ParameterTuningWidget::onPropertyChanged(const QString &property_name)
 {
     if(property_name == JobItem::P_STATUS) {
-        delete m_warningSign;
-        m_warningSign = 0;
+        m_warningSign->clear();
 
         if(m_currentJobItem->isFailed()) {
             QString message;
             message.append("Current parameter values cause simulation failure.\n\n");
             message.append(m_currentJobItem->getComments());
-
-            m_warningSign = new WarningSignWidget(this);
             m_warningSign->setWarningMessage(message);
-            QPoint pos = getPositionForWarningSign();
-            m_warningSign->setPosition(pos.x(), pos.y());
-            m_warningSign->show();
         }
 
         updateDragAndDropSettings();
     }
-}
-
-//! Returns position for warning sign at the bottom right corner of the tree view.
-//! The position will be adjusted according to the visibility of scroll bars
-QPoint ParameterTuningWidget::getPositionForWarningSign()
-{
-    int x = width()-warning_sign_xpos;
-    int y = height()-warning_sign_ypos;
-
-    if(QScrollBar *horizontal = m_treeView->horizontalScrollBar()) {
-        if(horizontal->isVisible())
-            y -= horizontal->height();
-    }
-
-    if(QScrollBar *vertical = m_treeView->verticalScrollBar()) {
-        if(vertical->isVisible())
-            x -= vertical->width();
-    }
-
-    return QPoint(x, y);
 }
 
 //! Disable drag-and-drop abilities, if job is in fit running state.

--- a/GUI/coregui/Views/JobWidgets/ParameterTuningWidget.h
+++ b/GUI/coregui/Views/JobWidgets/ParameterTuningWidget.h
@@ -28,7 +28,7 @@ class ParameterTuningDelegate;
 class ParameterTuningModel;
 class SliderSettingsWidget;
 class QTreeView;
-class WarningSignWidget;
+class WarningSign;
 class ParameterItem;
 
 class ParameterTuningWidget : public QWidget
@@ -64,7 +64,6 @@ private slots:
     void onCustomContextMenuRequested(const QPoint &point);
 
 private:
-    QPoint getPositionForWarningSign();
     void updateDragAndDropSettings();
 
     void setTuningDelegateEnabled(bool enabled);
@@ -76,7 +75,7 @@ private:
     SliderSettingsWidget *m_sliderSettingsWidget;
     QTreeView *m_treeView;
     ParameterTuningDelegate *m_delegate;
-    WarningSignWidget *m_warningSign;
+    WarningSign *m_warningSign;
 };
 
 #endif // PARAMETERTUNINGWIDGET_H

--- a/GUI/coregui/Views/SimulationWidgets/PythonScriptWidget.cpp
+++ b/GUI/coregui/Views/SimulationWidgets/PythonScriptWidget.cpp
@@ -18,33 +18,25 @@
 #include "DesignerHelper.h"
 #include "DomainSimulationBuilder.h"
 #include "GISASSimulation.h"
-#include "InstrumentModel.h"
 #include "PythonFormatting.h"
 #include "PythonSyntaxHighlighter.h"
-#include "SampleModel.h"
-#include "SimulationOptionsItem.h"
-#include "WarningSignWidget.h"
-#include "projectdocument.h"
-#include "projectmanager.h"
-#include <QDir>
-#include <QFile>
+#include "WarningSign.h"
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QPushButton>
-#include <QScrollBar>
 #include <QStandardPaths>
 #include <QStyle>
 #include <QTextEdit>
 #include <QTextStream>
 #include <QToolBar>
-#include <QToolButton>
 #include <QVBoxLayout>
+#include <memory>
 
 PythonScriptWidget::PythonScriptWidget(QWidget *parent)
     : QDialog(parent)
     , m_toolBar(0)
-    , m_textEdit(0)
-    , m_warningSign(0)
+    , m_textEdit(new QTextEdit)
+    , m_warningSign(new WarningSign(m_textEdit))
 {
     setWindowTitle("Python Script View");
     setMinimumSize(128, 128);
@@ -65,7 +57,6 @@ PythonScriptWidget::PythonScriptWidget(QWidget *parent)
     exportToFileButton->setAutoDefault(false);
     m_toolBar->addWidget(exportToFileButton);
 
-    m_textEdit = new QTextEdit;
     m_textEdit->setReadOnly(true);
     QFont textFont("Monospace");
     m_textEdit->setFont(textFont);
@@ -91,11 +82,9 @@ void PythonScriptWidget::generatePythonScript(const MultiLayerItem *sampleItem,
                                               const QString &outputDir)
 {
     m_outputDir = outputDir;
+    m_warningSign->clear();
 
-    delete m_warningSign;
-    m_warningSign = 0;
-
-    try{
+    try {
         const std::unique_ptr<GISASSimulation> P_simulation(
             DomainSimulationBuilder::getSimulation(sampleItem, instrumentItem, optionItem));
 
@@ -105,41 +94,26 @@ void PythonScriptWidget::generatePythonScript(const MultiLayerItem *sampleItem,
         m_textEdit->setText(code);
 
     } catch(const std::exception &ex) {
-        m_warningSign = new WarningSignWidget(this);
-
         QString message = QString(
             "Generation of Python Script failed. Code is not complete.\n\n"
             "It can happen if sample requires further assembling or some of sample parameters "
             "are not valid. See details below.\n\n%1").arg(QString::fromStdString(ex.what()));
 
         m_warningSign->setWarningMessage(message);
-        QPoint pos = getPositionForWarningSign();
-        m_warningSign->setPosition(pos.x(), pos.y());
-        m_warningSign->show();
-    }
-}
-
-//! adjusts position of warning label on widget move
-void PythonScriptWidget::resizeEvent(QResizeEvent *event)
-{
-    Q_UNUSED(event);
-    if(m_warningSign) {
-        QPoint pos = getPositionForWarningSign();
-        m_warningSign->setPosition(pos.x(),pos.y());
     }
 }
 
 void PythonScriptWidget::onExportToFileButton()
 {
     QString dirname(m_outputDir);
-    if(dirname.isEmpty())
+    if (dirname.isEmpty())
         dirname = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
 
-    QString file_name = QFileDialog::getSaveFileName(this, "Select file", dirname,
-                            "Python scipts (*.py)", 0,
-                            QFileDialog::DontResolveSymlinks);
+    QString file_name = QFileDialog::getSaveFileName(
+        this, "Select file", dirname, "Python scipts (*.py)", 0, QFileDialog::DontResolveSymlinks);
 
-    if(file_name.isEmpty()) return;
+    if (file_name.isEmpty())
+        return;
 
     QFile file(file_name);
     if (!file.open(QIODevice::WriteOnly)) {
@@ -153,27 +127,4 @@ void PythonScriptWidget::onExportToFileButton()
     out << m_textEdit->toPlainText();
     file.close();
     raise();
-}
-
-//! Returns position for warning sign at the bottom left corner of the editor. The position will
-//! be adjusted according to the visibility of scroll bars
-QPoint PythonScriptWidget::getPositionForWarningSign()
-{
-    const int warning_sign_xpos = 38;
-    const int warning_sign_ypos = 38;
-
-    int x = width()-warning_sign_xpos;
-    int y = height()-warning_sign_ypos;
-
-    if(QScrollBar *horizontal = m_textEdit->horizontalScrollBar()) {
-        if(horizontal->isVisible())
-            y -= horizontal->height();
-    }
-
-    if(QScrollBar *vertical = m_textEdit->verticalScrollBar()) {
-        if(vertical->isVisible())
-            x -= vertical->width();
-    }
-
-    return QPoint(x, y);
 }

--- a/GUI/coregui/Views/SimulationWidgets/PythonScriptWidget.h
+++ b/GUI/coregui/Views/SimulationWidgets/PythonScriptWidget.h
@@ -22,40 +22,33 @@
 
 class QToolBar;
 class QTextEdit;
-class WarningSignWidget;
-class ProjectManager;
-class SampleModel;
-class InstrumentModel;
+class WarningSign;
 class MultiLayerItem;
 class InstrumentItem;
 class SimulationOptionsItem;
 
 //! The PythonScriptWidget displays a python script which represents full simulation.
 //! Part of SimulationSetupWidget
+
 class BA_CORE_API_ PythonScriptWidget : public QDialog
 {
     Q_OBJECT
 
 public:
-    PythonScriptWidget(QWidget *parent = 0);
+    PythonScriptWidget(QWidget* parent = 0);
 
-    void generatePythonScript(const MultiLayerItem *sampleItem,
-                              const InstrumentItem *instrumentItem,
-                              const SimulationOptionsItem *optionItem = 0,
-                              const QString &outputDir = QString());
-
-protected:
-    virtual void resizeEvent(QResizeEvent *event);
+    void generatePythonScript(const MultiLayerItem* sampleItem,
+                              const InstrumentItem* instrumentItem,
+                              const SimulationOptionsItem* optionItem = 0,
+                              const QString& outputDir = QString());
 
 private slots:
     void onExportToFileButton();
 
 private:
-    QPoint getPositionForWarningSign();
-
-    QToolBar *m_toolBar;
-    QTextEdit *m_textEdit;
-    WarningSignWidget *m_warningSign;
+    QToolBar* m_toolBar;
+    QTextEdit* m_textEdit;
+    WarningSign* m_warningSign;
     QString m_outputDir;
 };
 


### PR DESCRIPTION
To unify the usage of WarningSign across the project and reduce code duplication. This resolves [Item 1492](http://apps.jcns.fz-juelich.de/redmine/issues/1492).