### PR TITLE
Feature #1769

### DIFF
--- a/Core/InputOutput/TiffHandler.cpp
+++ b/Core/InputOutput/TiffHandler.cpp
@@ -19,16 +19,10 @@
 #include "BornAgainNamespace.h"
 #include "SysUtils.h"
 
-namespace {
-const size_t supported_bitPerSample    = 32;
-const size_t supported_samplesPerPixel = 1;
-const size_t supported_sampleSize      = 4;
-}
-
 TiffHandler::TiffHandler()
     : m_tiff(0)
-    , m_width(0)
-    , m_height(0)
+    , m_width(0), m_height(0)
+    , m_bitsPerSample(0), m_samplesPerPixel(0), m_sampleFormat(0)
 {}
 
 TiffHandler::~TiffHandler()
@@ -68,12 +62,10 @@ void TiffHandler::read_header()
     assert(m_tiff);
     uint32 width(0);
     uint32 height(0);
-    uint16 photometric(0);
     if (!TIFFGetField(m_tiff, TIFFTAG_IMAGEWIDTH, &width)
-        || !TIFFGetField(m_tiff, TIFFTAG_IMAGELENGTH, &height)
-        || !TIFFGetField(m_tiff, TIFFTAG_PHOTOMETRIC, &photometric)) {
+        || !TIFFGetField(m_tiff, TIFFTAG_IMAGELENGTH, &height)) {
         throw Exceptions::FormatErrorException("TiffHandler::read_header() -> Error. "
-                                               "Can't read width/height/photometric info.");
+                                               "Can't read width/height.");
     }
 
     m_width = (size_t) width;
@@ -82,22 +74,42 @@ void TiffHandler::read_header()
     uint16 orientationTag(0);
     TIFFGetField(m_tiff, TIFFTAG_ORIENTATION, &orientationTag);
 
-    // BitsPerSample defaults to 1 according to the TIFF spec.
-    uint16 bitPerSample(0);
-    if (!TIFFGetField(m_tiff, TIFFTAG_BITSPERSAMPLE, &bitPerSample))
-        bitPerSample = 1;
-    uint16 samplesPerPixel(0); // they may be e.g. grayscale with 2 samples per pixel
-    if (!TIFFGetField(m_tiff, TIFFTAG_SAMPLESPERPIXEL, &samplesPerPixel))
-        samplesPerPixel = 1;
+    bool good = true;
 
-    if(bitPerSample!= supported_bitPerSample ||
-            samplesPerPixel != supported_samplesPerPixel) {
+    // BitsPerSample defaults to 1 according to the TIFF spec.
+    if (!TIFFGetField(m_tiff, TIFFTAG_BITSPERSAMPLE, &m_bitsPerSample))
+        m_bitsPerSample = 1;
+    if (8 != m_bitsPerSample && 16 != m_bitsPerSample && 32 != m_bitsPerSample)
+      good = false;
+
+    // they may be e.g. grayscale with 2 samples per pixel
+    if (!TIFFGetField(m_tiff, TIFFTAG_SAMPLESPERPIXEL, &m_samplesPerPixel))
+        m_samplesPerPixel = 1;
+    if (m_samplesPerPixel != 1)
+      good = false;
+
+    if (!TIFFGetField(m_tiff, TIFFTAG_SAMPLEFORMAT, &m_sampleFormat))
+      m_sampleFormat = 1;
+
+    switch (m_sampleFormat) {
+    case 1: // unsigned int
+    case 2: // signed int
+      break;
+    case 3: // IEEE float
+      if (32 != m_bitsPerSample)
+        good = false;
+      break;
+    default:
+      good = false;
+    }
+
+    if (!good) {
         std::ostringstream message;
         message << "TiffHandler::read_header() -> Error. "
                 << "Can't read tiff image with following parameters:" << std::endl
-                << "    TIFFTAG_PHOTOMETRIC: " << photometric << std::endl
-                << "    TIFFTAG_BITSPERSAMPLE: " << bitPerSample << std::endl
-                << "    TIFFTAG_SAMPLESPERPIXEL: " << samplesPerPixel << std::endl;
+                << "    TIFFTAG_BITSPERSAMPLE: " << m_bitsPerSample << std::endl
+                << "    TIFFTAG_SAMPLESPERPIXEL: " << m_samplesPerPixel << std::endl
+                << "    TIFFTAG_SAMPLEFORMAT: " << m_sampleFormat << std::endl;
         throw Exceptions::FormatErrorException(message.str());
     }
 
@@ -107,27 +119,10 @@ void TiffHandler::read_data()
 {
     assert(m_tiff);
 
-    uint16 sampleFormat(0);
-    if (!TIFFGetField(m_tiff, TIFFTAG_SAMPLEFORMAT, &sampleFormat))
-        sampleFormat = 1;
-
-    static_assert(
-          supported_sampleSize == sizeof(uint32) &&
-          supported_sampleSize == sizeof(int32)  &&
-          supported_sampleSize == sizeof(float),
-          "sanity check failed");
-
-    switch (sampleFormat) {
-    case 1: // unsigned int
-    case 2: // signed int
-    case 3: // IEEE float
-      break;
-    default:
-      throw Exceptions::FormatErrorException("TiffHandler: unexpected sample format");
-    }
-
+    assert(0 == m_bitsPerSample%8);
+    uint bytesPerSample = m_bitsPerSample/8;
     tmsize_t buf_size = TIFFScanlineSize(m_tiff);
-    tmsize_t expected_size = supported_sampleSize * m_width;
+    tmsize_t expected_size = bytesPerSample * m_width;
     if(buf_size != expected_size)
         throw Exceptions::FormatErrorException(
             "TiffHandler::read_data() -> Error. Wrong scanline size.");
@@ -139,8 +134,8 @@ void TiffHandler::read_data()
 
     create_output_data();
 
-    std::vector<int32> line_buf;
-    line_buf.resize(m_width, 0);
+    std::vector<int8> line_buf;
+    line_buf.resize(buf_size, 0);
 
     std::vector<int32> axes_indices(2);
 
@@ -151,20 +146,40 @@ void TiffHandler::read_data()
 
         memcpy(&line_buf[0], buf, buf_size);
 
-        for(size_t col=0; col<line_buf.size(); ++col) {
+        for(size_t col=0; col<m_width; ++col) {
             axes_indices[0] = col;
             axes_indices[1] = m_height - 1 - row;
             size_t global_index = m_data->toGlobalIndex(axes_indices);
 
-            void *incoming = &line_buf[col];
-            double sample;
+            void *incoming = &line_buf[col*bytesPerSample];
+            double sample = 0;
 
-            switch (sampleFormat) {
+            switch (m_sampleFormat) {
             case 1: // unsigned int
-              sample = *reinterpret_cast<uint32*>(incoming);
+              switch (m_bitsPerSample) {
+              case 8:
+                sample = *reinterpret_cast<uint8*>(incoming);
+                break;
+              case 16:
+                sample = *reinterpret_cast<uint16*>(incoming);
+                break;
+              case 32:
+                sample = *reinterpret_cast<uint32*>(incoming);
+                break;
+              }
               break;
             case 2: // signed int
-              sample = *reinterpret_cast<int32*>(incoming);
+              switch (m_bitsPerSample) {
+              case 8:
+                sample = *reinterpret_cast<int8*>(incoming);
+                break;
+              case 16:
+                sample = *reinterpret_cast<int16*>(incoming);
+                break;
+              case 32:
+                sample = *reinterpret_cast<int32*>(incoming);
+                break;
+              }
               break;
             case 3: // IEEE float
               sample = double(*reinterpret_cast<float*>(incoming));
@@ -193,8 +208,8 @@ void TiffHandler::write_header()
     TIFFSetField(m_tiff, TIFFTAG_IMAGEWIDTH, width);
     TIFFSetField(m_tiff, TIFFTAG_IMAGELENGTH, height);
 
-    uint16 bitPerSample(supported_bitPerSample);
-    uint16 samplesPerPixel(supported_samplesPerPixel);
+    // output format, hardcoded here
+    uint16 bitPerSample = 32, samplesPerPixel = 1;
     TIFFSetField(m_tiff, TIFFTAG_BITSPERSAMPLE, bitPerSample);
     TIFFSetField(m_tiff, TIFFTAG_SAMPLESPERPIXEL, samplesPerPixel);
 
@@ -203,13 +218,14 @@ void TiffHandler::write_header()
 
 void TiffHandler::write_data()
 {
-    tmsize_t buf_size = supported_sampleSize * m_width;;
+    typedef int sample_t;
+    tmsize_t buf_size = sizeof(sample_t) * m_width;
     tdata_t buf = _TIFFmalloc(buf_size);
     if(!buf)
         throw Exceptions::FormatErrorException(
             "TiffHandler::write_data() -> Error. Can't allocate buffer.");
 
-    std::vector<int> line_buf;
+    std::vector<sample_t> line_buf;
     line_buf.resize(m_width, 0);
     std::vector<int> axes_indices(2);
     for (uint32 row = 0; row < (uint32) m_height; row++) {
@@ -217,7 +233,7 @@ void TiffHandler::write_data()
             axes_indices[0] = col;
             axes_indices[1] = m_height - 1 - row;
             size_t global_index = m_data->toGlobalIndex(axes_indices);
-            line_buf[col] = static_cast<int>((*m_data)[global_index]);
+            line_buf[col] = static_cast<sample_t>((*m_data)[global_index]);
         }
         memcpy(buf, &line_buf[0], buf_size);
 

--- a/Core/InputOutput/TiffHandler.cpp
+++ b/Core/InputOutput/TiffHandler.cpp
@@ -120,7 +120,7 @@ void TiffHandler::read_data()
     assert(m_tiff);
 
     assert(0 == m_bitsPerSample%8);
-    uint bytesPerSample = m_bitsPerSample/8;
+    uint16 bytesPerSample = m_bitsPerSample/8;
     tmsize_t buf_size = TIFFScanlineSize(m_tiff);
     tmsize_t expected_size = bytesPerSample * m_width;
     if(buf_size != expected_size)

--- a/Core/InputOutput/TiffHandler.h
+++ b/Core/InputOutput/TiffHandler.h
@@ -47,8 +47,8 @@ private:
     void create_output_data();
 
     TIFF* m_tiff;
-    size_t m_width;
-    size_t m_height;
+    size_t m_width, m_height;
+    uint16 m_bitsPerSample, m_samplesPerPixel, m_sampleFormat;
     std::unique_ptr<OutputData<double>> m_data;
 };
 


### PR DESCRIPTION
The TIFF file from A. Nent has 16b samples. TiffHandler is modified to read 32b floats, and 8, 16, and 32b integer samples. 