### PR TITLE
Phase 1 of sliced form factors

### DIFF
--- a/Core/Multilayer/MultiLayer.cpp
+++ b/Core/Multilayer/MultiLayer.cpp
@@ -356,6 +356,18 @@ double MultiLayer::getLayerThickness(size_t i_layer) const
     return m_layers[ check_layer_index(i_layer) ]->getThickness();
 }
 
+ZLimits MultiLayer::getZLimits(size_t i_layer) const
+{
+    size_t N = getNumberOfLayers();
+    if (N<2)
+        return ZLimits(ZLimits::INFINITE);
+    if (i_layer==0)
+        return ZLimits(ZLimits::POS_INFINITE, 0.0);
+    if (i_layer==N-1)
+        return ZLimits(ZLimits::NEG_INFINITE, 0.0);
+    return ZLimits(-getLayerThickness(i_layer), 0.0);
+}
+
 void MultiLayer::setCrossCorrLength(double crossCorrLength)
 {
     if (crossCorrLength<0.0)

--- a/Core/Multilayer/MultiLayer.cpp
+++ b/Core/Multilayer/MultiLayer.cpp
@@ -334,8 +334,8 @@ size_t MultiLayer::topZToLayerIndex(double z_value) const
     if (n_layers < 2)
         return 0;
     if (z_value < m_layers_z[n_layers-2]) return m_layers_z.size()-1;
-    auto bottom_limit = std::lower_bound(m_layers_z.begin(), m_layers_z.end(), z_value);
-    size_t nbin = static_cast<size_t>(bottom_limit - m_layers_z.begin());
+    auto bottom_limit = std::lower_bound(m_layers_z.rbegin()+1, m_layers_z.rend(), z_value);
+    size_t nbin = static_cast<size_t>(m_layers_z.rend() - bottom_limit);
     return nbin;
 }
 

--- a/Core/Multilayer/MultiLayer.cpp
+++ b/Core/Multilayer/MultiLayer.cpp
@@ -356,18 +356,6 @@ double MultiLayer::getLayerThickness(size_t i_layer) const
     return m_layers[ check_layer_index(i_layer) ]->getThickness();
 }
 
-ZLimits MultiLayer::getZLimits(size_t i_layer) const
-{
-    size_t N = getNumberOfLayers();
-    if (N<2)
-        return ZLimits(ZLimits::INFINITE);
-    if (i_layer==0)
-        return ZLimits(ZLimits::POS_INFINITE, 0.0);
-    if (i_layer==N-1)
-        return ZLimits(ZLimits::NEG_INFINITE, 0.0);
-    return ZLimits(-getLayerThickness(i_layer), 0.0);
-}
-
 void MultiLayer::setCrossCorrLength(double crossCorrLength)
 {
     if (crossCorrLength<0.0)

--- a/Core/Multilayer/MultiLayer.h
+++ b/Core/Multilayer/MultiLayer.h
@@ -73,9 +73,6 @@ public:
     //! Returns thickness of layer
     double getLayerThickness(size_t i_layer) const;
 
-    //! Returns limits of z-coordinates inside the given layer
-    ZLimits getZLimits(size_t i_layer) const;
-
     //! Returns top interface of layer
     const LayerInterface* getLayerTopInterface(size_t i_layer) const;
 

--- a/Core/Multilayer/MultiLayer.h
+++ b/Core/Multilayer/MultiLayer.h
@@ -19,7 +19,6 @@
 #include "ISample.h"
 #include "SafePointerVector.h"
 #include "Vectors3D.h"
-#include "ZLimits.h"
 
 class ILayout;
 class Layer;

--- a/Core/Multilayer/MultiLayer.h
+++ b/Core/Multilayer/MultiLayer.h
@@ -19,6 +19,7 @@
 #include "ISample.h"
 #include "SafePointerVector.h"
 #include "Vectors3D.h"
+#include "ZLimits.h"
 
 class ILayout;
 class Layer;
@@ -71,6 +72,9 @@ public:
 
     //! Returns thickness of layer
     double getLayerThickness(size_t i_layer) const;
+
+    //! Returns limits of z-coordinates inside the given layer
+    ZLimits getZLimits(size_t i_layer) const;
 
     //! Returns top interface of layer
     const LayerInterface* getLayerTopInterface(size_t i_layer) const;

--- a/Core/Particle/IParticle.cpp
+++ b/Core/Particle/IParticle.cpp
@@ -24,6 +24,12 @@ IFormFactor* IParticle::createFormFactor() const
     return createTransformedFormFactor(nullptr, kvector_t());
 }
 
+IFormFactor* IParticle::createSlicedFormFactor(ZLimits /*limits*/) const
+{
+    throw std::runtime_error("IParticle::createSlicedFormFactor error: "
+                             "not implemented!");
+}
+
 void IParticle::applyTranslation(kvector_t displacement)
 {
     m_position += displacement;

--- a/Core/Particle/IParticle.cpp
+++ b/Core/Particle/IParticle.cpp
@@ -21,7 +21,7 @@
 
 IFormFactor* IParticle::createFormFactor() const
 {
-    return createTransformedFormFactor(nullptr, kvector_t());
+    return createSlicedFormFactor(ZLimits {});
 }
 
 IFormFactor* IParticle::createSlicedFormFactor(ZLimits /*limits*/) const

--- a/Core/Particle/IParticle.h
+++ b/Core/Particle/IParticle.h
@@ -20,6 +20,7 @@
 #include "Rotations.h"
 #include "SafePointerVector.h"
 #include "Vectors3D.h"
+#include "ZLimits.h"
 #include <memory>
 
 
@@ -40,6 +41,9 @@ public:
 
     //! Create a form factor for this particle
     IFormFactor* createFormFactor() const;
+
+    //! Create a sliced form factor for this particle
+    IFormFactor* createSlicedFormFactor(ZLimits limits) const;
 
     //! Create a form factor for this particle with an extra transformation
     virtual IFormFactor* createTransformedFormFactor(

--- a/Core/Particle/IParticle.h
+++ b/Core/Particle/IParticle.h
@@ -43,7 +43,7 @@ public:
     IFormFactor* createFormFactor() const;
 
     //! Create a sliced form factor for this particle
-    IFormFactor* createSlicedFormFactor(ZLimits limits) const;
+    virtual IFormFactor* createSlicedFormFactor(ZLimits limits) const;
 
     //! Create a form factor for this particle with an extra transformation
     virtual IFormFactor* createTransformedFormFactor(

--- a/Core/Particle/IParticle.h
+++ b/Core/Particle/IParticle.h
@@ -45,10 +45,6 @@ public:
     //! Create a sliced form factor for this particle
     virtual IFormFactor* createSlicedFormFactor(ZLimits limits) const;
 
-    //! Create a form factor for this particle with an extra transformation
-    virtual IFormFactor* createTransformedFormFactor(
-        const IRotation* p_rotation, kvector_t translation) const =0;
-
     //! Returns particle position.
     kvector_t getPosition() const { return m_position; }
 

--- a/Core/Particle/MesoCrystal.cpp
+++ b/Core/Particle/MesoCrystal.cpp
@@ -56,11 +56,25 @@ void MesoCrystal::accept(INodeVisitor* visitor) const
     visitor->visit(this);
 }
 
+IFormFactor*MesoCrystal::createSlicedFormFactor(ZLimits limits) const
+{
+    if (!mp_particle_structure || !mp_meso_form_factor)
+        return nullptr;
+    std::unique_ptr<IRotation> P_rotation(IRotation::createIdentity());
+    if (mP_rotation)
+        P_rotation.reset(mP_rotation->clone());
+    std::unique_ptr<IFormFactor> P_temp_ff(
+                mp_meso_form_factor->createSlicedFormFactor(limits, *P_rotation, m_position));
+    IFormFactor* p_result = mp_particle_structure->createTotalFormFactor(
+                                *P_temp_ff, P_rotation.get(), m_position);
+    return p_result;
+}
+
 IFormFactor* MesoCrystal::createTransformedFormFactor(
     const IRotation* p_rotation, kvector_t translation) const
 {
     if (!mp_particle_structure || !mp_meso_form_factor)
-        return 0;
+        return nullptr;
     std::unique_ptr<IRotation> P_total_rotation(createComposedRotation(p_rotation));
     kvector_t total_position = getComposedTranslation(p_rotation, translation);
     std::unique_ptr<IFormFactor> P_transformed_meso(createTransformationDecoratedFormFactor(

--- a/Core/Particle/MesoCrystal.cpp
+++ b/Core/Particle/MesoCrystal.cpp
@@ -70,20 +70,6 @@ IFormFactor*MesoCrystal::createSlicedFormFactor(ZLimits limits) const
     return p_result;
 }
 
-IFormFactor* MesoCrystal::createTransformedFormFactor(
-    const IRotation* p_rotation, kvector_t translation) const
-{
-    if (!mp_particle_structure || !mp_meso_form_factor)
-        return nullptr;
-    std::unique_ptr<IRotation> P_total_rotation(createComposedRotation(p_rotation));
-    kvector_t total_position = getComposedTranslation(p_rotation, translation);
-    std::unique_ptr<IFormFactor> P_transformed_meso(createTransformationDecoratedFormFactor(
-        *mp_meso_form_factor, P_total_rotation.get(), total_position));
-    IFormFactor* p_result = mp_particle_structure->createTotalFormFactor(
-        *P_transformed_meso, P_total_rotation.get(), total_position);
-    return p_result;
-}
-
 std::vector<const INode*> MesoCrystal::getChildren() const
 {
     return std::vector<const INode*>() <<  IParticle::getChildren()

--- a/Core/Particle/MesoCrystal.h
+++ b/Core/Particle/MesoCrystal.h
@@ -29,23 +29,24 @@ class BA_CORE_API_ MesoCrystal : public IParticle
 public:
     MesoCrystal(const IClusteredParticles& particle_structure, const IFormFactor& form_factor);
 
-    virtual ~MesoCrystal();
-    virtual MesoCrystal* clone() const;
+    ~MesoCrystal();
+    MesoCrystal* clone() const override final;
 
     //! Returns a clone with inverted magnetic fields
-    virtual MesoCrystal* cloneInvertB() const;
+    MesoCrystal* cloneInvertB() const override final;
 
-    virtual void accept(INodeVisitor* visitor) const;
+    void accept(INodeVisitor* visitor) const override final;
 
-    //! Create a form factor for this particle with an extra scattering factor
-    virtual IFormFactor* createTransformedFormFactor(
-        const IRotation* p_rotation, kvector_t translation) const;
+    IFormFactor* createSlicedFormFactor(ZLimits limits) const override final;
+
+    IFormFactor* createTransformedFormFactor(
+        const IRotation* p_rotation, kvector_t translation) const override final;
 
     //! @brief get the internal structure, which is in principle unbounded in
     //! space (e.g. an infinite crystal)
     const IClusteredParticles* getClusteredParticles() const { return mp_particle_structure.get(); }
 
-    std::vector<const INode*> getChildren() const;
+    std::vector<const INode*> getChildren() const override final;
 
 private:
     MesoCrystal(IClusteredParticles* p_particle_structure, IFormFactor* p_form_factor);

--- a/Core/Particle/MesoCrystal.h
+++ b/Core/Particle/MesoCrystal.h
@@ -39,9 +39,6 @@ public:
 
     IFormFactor* createSlicedFormFactor(ZLimits limits) const override final;
 
-    IFormFactor* createTransformedFormFactor(
-        const IRotation* p_rotation, kvector_t translation) const override final;
-
     //! @brief get the internal structure, which is in principle unbounded in
     //! space (e.g. an infinite crystal)
     const IClusteredParticles* getClusteredParticles() const { return mp_particle_structure.get(); }

--- a/Core/Particle/Particle.cpp
+++ b/Core/Particle/Particle.cpp
@@ -88,12 +88,9 @@ IFormFactor* Particle::createSlicedFormFactor(ZLimits limits) const
                 mP_form_factor->createSlicedFormFactor(limits, *P_rotation, m_position));
     FormFactorDecoratorMaterial* p_ff = new FormFactorDecoratorMaterial(*P_temp_ff);
     if (mP_material) {
-        if (mP_rotation) {
-            const std::unique_ptr<const IMaterial> P_transformed_material(
-                mP_material->createTransformedMaterial(P_rotation->getTransform3D()));
-            p_ff->setMaterial(*P_transformed_material);
-        } else
-            p_ff->setMaterial(*mP_material);
+        const std::unique_ptr<const IMaterial> P_transformed_material(
+                    mP_material->createTransformedMaterial(P_rotation->getTransform3D()));
+        p_ff->setMaterial(*P_transformed_material);
     }
     return p_ff;
 }
@@ -111,12 +108,9 @@ IFormFactor* Particle::createTransformedFormFactor(const IRotation* p_rotation,
                 CreateTransformedFormFactor(*mP_form_factor, *P_total_rotation, total_position));
     FormFactorDecoratorMaterial* p_ff = new FormFactorDecoratorMaterial(*P_temp_ff);
     if (mP_material) {
-        if (mP_rotation) {
-            const std::unique_ptr<const IMaterial> P_transformed_material(
-                mP_material->createTransformedMaterial(P_total_rotation->getTransform3D()));
-            p_ff->setMaterial(*P_transformed_material);
-        } else
-            p_ff->setMaterial(*mP_material);
+        const std::unique_ptr<const IMaterial> P_transformed_material(
+                    mP_material->createTransformedMaterial(P_total_rotation->getTransform3D()));
+        p_ff->setMaterial(*P_transformed_material);
     }
     return p_ff;
 }

--- a/Core/Particle/Particle.cpp
+++ b/Core/Particle/Particle.cpp
@@ -82,19 +82,13 @@ IFormFactor* Particle::createTransformedFormFactor(const IRotation* p_rotation,
 {
     if (!mP_form_factor)
         return nullptr;
-    const std::unique_ptr<IRotation> P_total_rotation(createComposedRotation(p_rotation));
+    std::unique_ptr<IRotation> P_total_rotation(createComposedRotation(p_rotation));
+    if (!P_total_rotation)
+        P_total_rotation.reset(IRotation::createIdentity());
     kvector_t total_position = getComposedTranslation(p_rotation, translation);
-    std::unique_ptr<IFormFactor> P_temp_ff1;
-    if (P_total_rotation)
-        P_temp_ff1.reset(new FormFactorDecoratorRotation(*mP_form_factor, *P_total_rotation));
-    else
-        P_temp_ff1.reset(mP_form_factor->clone());
-    std::unique_ptr<IFormFactor> P_temp_ff2;
-    if (total_position != kvector_t())
-        P_temp_ff2.reset(new FormFactorDecoratorPositionFactor(*P_temp_ff1, total_position));
-    else
-        P_temp_ff2.swap(P_temp_ff1);
-    FormFactorDecoratorMaterial* p_ff = new FormFactorDecoratorMaterial(*P_temp_ff2);
+    std::unique_ptr<IFormFactor> P_temp_ff(
+                CreateTransformedFormFactor(*mP_form_factor, *P_total_rotation, total_position));
+    FormFactorDecoratorMaterial* p_ff = new FormFactorDecoratorMaterial(*P_temp_ff);
     if (mP_material) {
         if (mP_rotation) {
             const std::unique_ptr<const IMaterial> P_transformed_material(

--- a/Core/Particle/Particle.cpp
+++ b/Core/Particle/Particle.cpp
@@ -95,26 +95,6 @@ IFormFactor* Particle::createSlicedFormFactor(ZLimits limits) const
     return p_ff;
 }
 
-IFormFactor* Particle::createTransformedFormFactor(const IRotation* p_rotation,
-                                                   kvector_t translation) const
-{
-    if (!mP_form_factor)
-        return nullptr;
-    std::unique_ptr<IRotation> P_total_rotation(createComposedRotation(p_rotation));
-    if (!P_total_rotation)
-        P_total_rotation.reset(IRotation::createIdentity());
-    kvector_t total_position = getComposedTranslation(p_rotation, translation);
-    std::unique_ptr<IFormFactor> P_temp_ff(
-                CreateTransformedFormFactor(*mP_form_factor, *P_total_rotation, total_position));
-    FormFactorDecoratorMaterial* p_ff = new FormFactorDecoratorMaterial(*P_temp_ff);
-    if (mP_material) {
-        const std::unique_ptr<const IMaterial> P_transformed_material(
-                    mP_material->createTransformedMaterial(P_total_rotation->getTransform3D()));
-        p_ff->setMaterial(*P_transformed_material);
-    }
-    return p_ff;
-}
-
 void Particle::setMaterial(const IMaterial& material)
 {
     if(mP_material.get() != &material)

--- a/Core/Particle/Particle.cpp
+++ b/Core/Particle/Particle.cpp
@@ -77,6 +77,27 @@ Particle* Particle::cloneInvertB() const
     return p_result;
 }
 
+IFormFactor* Particle::createSlicedFormFactor(ZLimits limits) const
+{
+    if (!mP_form_factor)
+        return nullptr;
+    std::unique_ptr<IRotation> P_rotation(IRotation::createIdentity());
+    if (mP_rotation)
+        P_rotation.reset(mP_rotation->clone());
+    std::unique_ptr<IFormFactor> P_temp_ff(
+                mP_form_factor->createSlicedFormFactor(limits, *P_rotation, m_position));
+    FormFactorDecoratorMaterial* p_ff = new FormFactorDecoratorMaterial(*P_temp_ff);
+    if (mP_material) {
+        if (mP_rotation) {
+            const std::unique_ptr<const IMaterial> P_transformed_material(
+                mP_material->createTransformedMaterial(P_rotation->getTransform3D()));
+            p_ff->setMaterial(*P_transformed_material);
+        } else
+            p_ff->setMaterial(*mP_material);
+    }
+    return p_ff;
+}
+
 IFormFactor* Particle::createTransformedFormFactor(const IRotation* p_rotation,
                                                    kvector_t translation) const
 {

--- a/Core/Particle/Particle.h
+++ b/Core/Particle/Particle.h
@@ -42,9 +42,6 @@ public:
 
     IFormFactor* createSlicedFormFactor(ZLimits limits) const override final;
 
-    IFormFactor* createTransformedFormFactor(
-        const IRotation* p_rotation, kvector_t translation) const override final;
-
     void setMaterial(const IMaterial& material);
     const IMaterial* getMaterial() const override final { return mP_material.get(); }
 

--- a/Core/Particle/Particle.h
+++ b/Core/Particle/Particle.h
@@ -33,26 +33,27 @@ public:
     Particle(const IMaterial& p_material, const IFormFactor& form_factor,
              const IRotation& rotation);
 
-    virtual Particle* clone() const;
+    Particle* clone() const override;
 
     //! Returns a clone with inverted magnetic fields
-    virtual Particle* cloneInvertB() const;
+    Particle* cloneInvertB() const override;
 
-    virtual void accept(INodeVisitor* visitor) const { visitor->visit(this); }
+    void accept(INodeVisitor* visitor) const override { visitor->visit(this); }
 
-    //! Create a form factor for this particle with an extra scattering factor
-    virtual IFormFactor* createTransformedFormFactor(
-        const IRotation* p_rotation, kvector_t translation) const;
+    IFormFactor* createSlicedFormFactor(ZLimits limits) const override;
+
+    IFormFactor* createTransformedFormFactor(
+        const IRotation* p_rotation, kvector_t translation) const override;
 
     void setMaterial(const IMaterial& material);
-    const IMaterial* getMaterial() const { return mP_material.get(); }
+    const IMaterial* getMaterial() const override { return mP_material.get(); }
 
     complex_t getRefractiveIndex() const;
 
     void setFormFactor(const IFormFactor& form_factor);
     const IFormFactor* getFormFactor() const { return mP_form_factor.get(); }
 
-    std::vector<const INode*> getChildren() const;
+    std::vector<const INode*> getChildren() const override;
 
 protected:
     std::unique_ptr<IMaterial> mP_material;

--- a/Core/Particle/Particle.h
+++ b/Core/Particle/Particle.h
@@ -33,27 +33,27 @@ public:
     Particle(const IMaterial& p_material, const IFormFactor& form_factor,
              const IRotation& rotation);
 
-    Particle* clone() const override;
+    Particle* clone() const override final;
 
     //! Returns a clone with inverted magnetic fields
-    Particle* cloneInvertB() const override;
+    Particle* cloneInvertB() const override final;
 
-    void accept(INodeVisitor* visitor) const override { visitor->visit(this); }
+    void accept(INodeVisitor* visitor) const override final { visitor->visit(this); }
 
-    IFormFactor* createSlicedFormFactor(ZLimits limits) const override;
+    IFormFactor* createSlicedFormFactor(ZLimits limits) const override final;
 
     IFormFactor* createTransformedFormFactor(
-        const IRotation* p_rotation, kvector_t translation) const override;
+        const IRotation* p_rotation, kvector_t translation) const override final;
 
     void setMaterial(const IMaterial& material);
-    const IMaterial* getMaterial() const override { return mP_material.get(); }
+    const IMaterial* getMaterial() const override final { return mP_material.get(); }
 
     complex_t getRefractiveIndex() const;
 
     void setFormFactor(const IFormFactor& form_factor);
     const IFormFactor* getFormFactor() const { return mP_form_factor.get(); }
 
-    std::vector<const INode*> getChildren() const override;
+    std::vector<const INode*> getChildren() const override final;
 
 protected:
     std::unique_ptr<IMaterial> mP_material;

--- a/Core/Particle/ParticleComposition.cpp
+++ b/Core/Particle/ParticleComposition.cpp
@@ -88,13 +88,13 @@ IFormFactor* ParticleComposition::createTransformedFormFactor(
 {
     if (m_particles.size() == 0)
         return 0;
-    const std::unique_ptr<IRotation> P_total_rotation(createComposedRotation(p_rotation));
-    kvector_t total_position = getComposedTranslation(p_rotation, translation);
     FormFactorWeighted* p_result = new FormFactorWeighted();
-    for (size_t index = 0; index < m_particles.size(); ++index) {
-        const std::unique_ptr<IFormFactor> P_particle_ff(
-            m_particles[index]->createTransformedFormFactor(P_total_rotation.get(),
-                                                            total_position));
+    auto particles = decompose();
+    for (auto p_particle : particles) {
+        if (p_rotation)
+            p_particle->applyRotation(*p_rotation);
+        p_particle->applyTranslation(translation);
+        const std::unique_ptr<IFormFactor> P_particle_ff(p_particle->createFormFactor());
         p_result->addFormFactor(*P_particle_ff);
     }
     return p_result;

--- a/Core/Particle/ParticleComposition.h
+++ b/Core/Particle/ParticleComposition.h
@@ -42,7 +42,7 @@ public:
     void addParticles(const IParticle& particle, std::vector<kvector_t > positions);
 
     IFormFactor* createTransformedFormFactor(const IRotation* p_rotation,
-                                                     kvector_t translation) const override;
+                                             kvector_t translation) const;
 
     //! Returns number of different particles
     size_t getNbrParticles() const { return m_particles.size(); }

--- a/Core/Particle/ParticleCoreShell.cpp
+++ b/Core/Particle/ParticleCoreShell.cpp
@@ -90,30 +90,6 @@ IFormFactor* ParticleCoreShell::createSlicedFormFactor(ZLimits limits) const
     return new FormFactorCoreShell(P_ff_core.release(), P_ff_shell.release());
 }
 
-IFormFactor* ParticleCoreShell::createTransformedFormFactor(
-    const IRotation* p_rotation, kvector_t translation) const
-{
-    if (!mp_core || !mp_shell)
-        return nullptr;
-    std::unique_ptr<IRotation> P_total_rotation { createComposedRotation(p_rotation) };
-    kvector_t total_position = getComposedTranslation(p_rotation, translation);
-
-    // core form factor
-    std::unique_ptr<IFormFactor> P_ff_core{ mp_core->createTransformedFormFactor(
-        P_total_rotation.get(), total_position) };
-    if (!P_ff_core)
-        return nullptr;
-    P_ff_core->setAmbientMaterial(*mp_shell->getMaterial());
-
-    // shell form factor
-    std::unique_ptr<IFormFactor> P_ff_shell{ mp_shell->createTransformedFormFactor(
-        P_total_rotation.get(), total_position) };
-    if (!P_ff_shell)
-        return nullptr;
-
-    return new FormFactorCoreShell(P_ff_core.release(), P_ff_shell.release());
-}
-
 std::vector<const INode*> ParticleCoreShell::getChildren() const
 {
     return std::vector<const INode*>() << IParticle::getChildren() << mp_core << mp_shell;

--- a/Core/Particle/ParticleCoreShell.h
+++ b/Core/Particle/ParticleCoreShell.h
@@ -38,9 +38,6 @@ public:
 
     IFormFactor* createSlicedFormFactor(ZLimits limits) const override final;
 
-    IFormFactor* createTransformedFormFactor(
-        const IRotation* p_rotation, kvector_t translation) const override final;
-
     const Particle* coreParticle() const;
 
     const Particle* shellParticle() const;

--- a/Core/Particle/ParticleCoreShell.h
+++ b/Core/Particle/ParticleCoreShell.h
@@ -29,22 +29,23 @@ class BA_CORE_API_ ParticleCoreShell : public IParticle
 public:
     ParticleCoreShell(const Particle& shell, const Particle& core,
                       kvector_t relative_core_position=kvector_t(0.0, 0.0, 0.0));
-    virtual ~ParticleCoreShell();
+    ~ParticleCoreShell();
 
-    ParticleCoreShell* clone() const final;
-    ParticleCoreShell* cloneInvertB() const final;
+    ParticleCoreShell* clone() const override final;
+    ParticleCoreShell* cloneInvertB() const override final;
 
-    void accept(INodeVisitor* visitor) const final { visitor->visit(this); }
+    void accept(INodeVisitor* visitor) const override final { visitor->visit(this); }
 
-    //! Create a form factor for this particle with an extra scattering factor
+    IFormFactor* createSlicedFormFactor(ZLimits limits) const override final;
+
     IFormFactor* createTransformedFormFactor(
-        const IRotation* p_rotation, kvector_t translation) const final;
+        const IRotation* p_rotation, kvector_t translation) const override final;
 
     const Particle* coreParticle() const;
 
     const Particle* shellParticle() const;
 
-    std::vector<const INode*> getChildren() const;
+    std::vector<const INode*> getChildren() const override final;
 
 protected:
     void addAndRegisterCore(const Particle& core, kvector_t relative_core_position);

--- a/Core/Particle/SlicedFormFactorList.cpp
+++ b/Core/Particle/SlicedFormFactorList.cpp
@@ -36,11 +36,11 @@ void SlicedFormFactorList::addParticle(IParticle& particle,
 //    for (size_t i=top_layer_index; i<bottom_layer_index+1; ++i)
 //    {
 //        kvector_t translation(0.0, 0.0, -ZDifference(multilayer, i, ref_layer_index));
-//        ref_layer_index = i;
 //        particle.applyTranslation(translation);
 //        ZLimits limits = LayerZLimits(multilayer, i);
 //        m_ff_list.emplace_back(std::unique_ptr<IFormFactor>(
 //                                   particle.createSlicedFormFactor(limits)), i);
+//        ref_layer_index = i;  // particle now has coordinates relative to layer i
 //    }
     kvector_t translation(0.0, 0.0, -ZDifference(multilayer, bottom_layer_index, ref_layer_index));
     particle.applyTranslation(translation);

--- a/Core/Particle/SlicedFormFactorList.cpp
+++ b/Core/Particle/SlicedFormFactorList.cpp
@@ -30,10 +30,18 @@ double ZDifference(const MultiLayer& multilayer, size_t layer_index, size_t ref_
 void SlicedFormFactorList::addParticle(IParticle& particle,
                                        const MultiLayer& multilayer, size_t ref_layer_index)
 {
-    size_t layer_index = LayerIndexBottom(particle, multilayer, ref_layer_index);
-    kvector_t translation(0.0, 0.0, -ZDifference(multilayer, layer_index, ref_layer_index));
+    size_t bottom_layer_index = LayerIndexBottom(particle, multilayer, ref_layer_index);
+//    size_t top_layer_index = LayerIndexTop(particle, multilayer, ref_layer_index);
+//    for (size_t i=top_layer_index; i<bottom_layer_index+1; ++i)
+//    {
+//        kvector_t translation(0.0, 0.0, -ZDifference(multilayer, i, ref_layer_index));
+//        particle.applyTranslation(translation);
+//        m_ff_list.emplace_back(std::unique_ptr<IFormFactor>(particle.createFormFactor()), i);
+//    }
+    kvector_t translation(0.0, 0.0, -ZDifference(multilayer, bottom_layer_index, ref_layer_index));
     particle.applyTranslation(translation);
-    m_ff_list.emplace_back(std::unique_ptr<IFormFactor>(particle.createFormFactor()), layer_index);
+    m_ff_list.emplace_back(std::unique_ptr<IFormFactor>(particle.createFormFactor()),
+                           bottom_layer_index);
 }
 
 size_t SlicedFormFactorList::size() const

--- a/Core/Particle/SlicedFormFactorList.cpp
+++ b/Core/Particle/SlicedFormFactorList.cpp
@@ -25,6 +25,7 @@ size_t LayerIndexBottom(const IParticle& particle, const MultiLayer& multilayer,
 size_t LayerIndexTop(const IParticle& particle, const MultiLayer& multilayer,
                         size_t ref_layer_index);
 double ZDifference(const MultiLayer& multilayer, size_t layer_index, size_t ref_layer_index);
+ZLimits LayerZLimits(const MultiLayer& multilayer, size_t layer_index);
 }
 
 void SlicedFormFactorList::addParticle(IParticle& particle,
@@ -35,8 +36,11 @@ void SlicedFormFactorList::addParticle(IParticle& particle,
 //    for (size_t i=top_layer_index; i<bottom_layer_index+1; ++i)
 //    {
 //        kvector_t translation(0.0, 0.0, -ZDifference(multilayer, i, ref_layer_index));
+//        ref_layer_index = i;
 //        particle.applyTranslation(translation);
-//        m_ff_list.emplace_back(std::unique_ptr<IFormFactor>(particle.createFormFactor()), i);
+//        ZLimits limits = LayerZLimits(multilayer, i);
+//        m_ff_list.emplace_back(std::unique_ptr<IFormFactor>(
+//                                   particle.createSlicedFormFactor(limits)), i);
 //    }
     kvector_t translation(0.0, 0.0, -ZDifference(multilayer, bottom_layer_index, ref_layer_index));
     particle.applyTranslation(translation);
@@ -92,6 +96,18 @@ size_t LayerIndexTop(const IParticle& particle, const MultiLayer& multilayer,
 double ZDifference(const MultiLayer& multilayer, size_t layer_index, size_t ref_layer_index)
 {
     return multilayer.getLayerTopZ(layer_index) - multilayer.getLayerTopZ(ref_layer_index);
+}
+
+ZLimits LayerZLimits(const MultiLayer& multilayer, size_t layer_index)
+{
+    size_t N = multilayer.getNumberOfLayers();
+    if (N<2)
+        return ZLimits(ZLimits::INFINITE);
+    if (layer_index==0)
+        return ZLimits(ZLimits::POS_INFINITE, 0.0);
+    if (layer_index==N-1)
+        return ZLimits(ZLimits::NEG_INFINITE, 0.0);
+    return ZLimits(-multilayer.getLayerThickness(layer_index), 0.0);
 }
 }
 

--- a/Core/Particle/SlicedFormFactorList.cpp
+++ b/Core/Particle/SlicedFormFactorList.cpp
@@ -32,20 +32,21 @@ void SlicedFormFactorList::addParticle(IParticle& particle,
                                        const MultiLayer& multilayer, size_t ref_layer_index)
 {
     size_t bottom_layer_index = LayerIndexBottom(particle, multilayer, ref_layer_index);
-//    size_t top_layer_index = LayerIndexTop(particle, multilayer, ref_layer_index);
-//    for (size_t i=top_layer_index; i<bottom_layer_index+1; ++i)
-//    {
-//        kvector_t translation(0.0, 0.0, -ZDifference(multilayer, i, ref_layer_index));
-//        particle.applyTranslation(translation);
-//        ZLimits limits = LayerZLimits(multilayer, i);
-//        m_ff_list.emplace_back(std::unique_ptr<IFormFactor>(
-//                                   particle.createSlicedFormFactor(limits)), i);
-//        ref_layer_index = i;  // particle now has coordinates relative to layer i
-//    }
-    kvector_t translation(0.0, 0.0, -ZDifference(multilayer, bottom_layer_index, ref_layer_index));
-    particle.applyTranslation(translation);
-    m_ff_list.emplace_back(std::unique_ptr<IFormFactor>(particle.createFormFactor()),
-                           bottom_layer_index);
+    size_t top_layer_index = LayerIndexTop(particle, multilayer, ref_layer_index);
+    top_layer_index = std::min(bottom_layer_index, top_layer_index);  // Handle zero size shapes
+    for (size_t i=top_layer_index; i<bottom_layer_index+1; ++i)
+    {
+        kvector_t translation(0.0, 0.0, -ZDifference(multilayer, i, ref_layer_index));
+        particle.applyTranslation(translation);
+        ZLimits limits = LayerZLimits(multilayer, i);
+        m_ff_list.emplace_back(std::unique_ptr<IFormFactor>(
+                                   particle.createSlicedFormFactor(limits)), i);
+        ref_layer_index = i;  // particle now has coordinates relative to layer i
+    }
+//    kvector_t translation(0.0, 0.0, -ZDifference(multilayer, bottom_layer_index, ref_layer_index));
+//    particle.applyTranslation(translation);
+//    m_ff_list.emplace_back(std::unique_ptr<IFormFactor>(particle.createFormFactor()),
+//                           bottom_layer_index);
 }
 
 size_t SlicedFormFactorList::size() const
@@ -89,8 +90,8 @@ size_t LayerIndexTop(const IParticle& particle, const MultiLayer& multilayer,
     std::unique_ptr<IFormFactor> P_ff(particle.createFormFactor());
     std::unique_ptr<IRotation> P_rot(IRotation::createIdentity());
     double position_offset = multilayer.getLayerTopZ(ref_layer_index);
-    double zmin = P_ff->topZ(*P_rot) + position_offset;
-    return multilayer.topZToLayerIndex(zmin);
+    double zmax = P_ff->topZ(*P_rot) + position_offset;
+    return multilayer.topZToLayerIndex(zmax);
 }
 
 double ZDifference(const MultiLayer& multilayer, size_t layer_index, size_t ref_layer_index)

--- a/Core/Particle/ZLimits.cpp
+++ b/Core/Particle/ZLimits.cpp
@@ -1,0 +1,30 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Core/Shapes/ZLimits.cpp
+//! @brief     Defines class ZLimits.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2017
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   J. Burle, J. M. Fisher, M. Ganeva, G. Pospelov, W. Van Herck, J. Wuttke
+//
+// ************************************************************************** //
+
+
+#include "ZLimits.h"
+
+
+ZLimits::ZLimits(ZLimits::Type type, double ref)
+    : m_type(type)
+    , m_min(ref)
+    , m_max {}
+{}
+
+ZLimits::ZLimits(double min, double max)
+    : m_type(FINITE)
+    , m_min(min)
+    , m_max(max)
+{}

--- a/Core/Particle/ZLimits.h
+++ b/Core/Particle/ZLimits.h
@@ -1,0 +1,40 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Core/Shapes/ZLimits.h
+//! @brief     Defines class ZLimits.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2017
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   J. Burle, J. M. Fisher, M. Ganeva, G. Pospelov, W. Van Herck, J. Wuttke
+//
+// ************************************************************************** //
+
+#ifndef ZLIMITS_H
+#define ZLIMITS_H
+
+//! Class that contains upper and lower limits of the z-coordinate for the slicing of
+//! form factors.
+//!
+//! @ingroup intern
+
+class ZLimits
+{
+public:
+    enum Type { FINITE, INFINITE, POS_INFINITE, NEG_INFINITE };
+    ZLimits(Type type, double ref=0.0);
+    ZLimits(double min, double max);
+
+    Type type() const { return m_type; }
+    double zmin() const { return m_min; }
+    double zmax() const { return m_max; }
+private:
+    Type m_type;
+    double m_min;
+    double m_max;
+};
+
+#endif // ZLIMITS_H

--- a/Core/Particle/ZLimits.h
+++ b/Core/Particle/ZLimits.h
@@ -25,7 +25,7 @@ class ZLimits
 {
 public:
     enum Type { FINITE, INFINITE, POS_INFINITE, NEG_INFINITE };
-    ZLimits(Type type, double ref=0.0);
+    ZLimits(Type type=INFINITE, double ref=0.0);
     ZLimits(double min, double max);
 
     Type type() const { return m_type; }

--- a/Core/Scattering/IFormFactor.h
+++ b/Core/Scattering/IFormFactor.h
@@ -19,6 +19,8 @@
 #include "ISample.h"
 #include "Complex.h"
 #include "EigenCore.h"
+#include "Vectors3D.h"
+#include "ZLimits.h"
 
 class IMaterial;
 class ILayerRTCoefficients;
@@ -42,6 +44,10 @@ public:
     IFormFactor() {}
     ~IFormFactor() override;
     IFormFactor* clone() const override=0;
+
+    //! Creates a sliced form factor with the given rotation and translation
+    virtual IFormFactor* createSlicedFormFactor(ZLimits limits, const IRotation& rot,
+                                                kvector_t translation) const;
 
     //! Passes the refractive index of the ambient material in which this particle is embedded.
     virtual void setAmbientMaterial(const IMaterial&) =0;
@@ -70,5 +76,11 @@ public:
     //! Sets reflection/transmission info
     virtual void setSpecularInfo(const ILayerRTCoefficients*, const ILayerRTCoefficients*) {}
 };
+
+bool ShapeIsContainedInLimits(const IFormFactor& formfactor, ZLimits limits,
+                              const IRotation& rot, kvector_t translation);
+
+IFormFactor* CreateTransformedFormFactor(const IFormFactor& formfactor, const IRotation& rot,
+                                         kvector_t translation);
 
 #endif // IFORMFACTOR_H

--- a/auto/Wrap/doxygen_core.i
+++ b/auto/Wrap/doxygen_core.i
@@ -6318,6 +6318,11 @@ C++ includes: IFormFactor.h
 Returns a clone of this  ISample object. 
 ";
 
+%feature("docstring")  IFormFactor::createSlicedFormFactor "IFormFactor * IFormFactor::createSlicedFormFactor(ZLimits limits, const IRotation &rot, kvector_t translation) const
+
+Creates a sliced form factor with the given rotation and translation. 
+";
+
 %feature("docstring")  IFormFactor::setAmbientMaterial "virtual void IFormFactor::setAmbientMaterial(const IMaterial &)=0
 
 Passes the refractive index of the ambient material in which this particle is embedded. 
@@ -8573,9 +8578,9 @@ Calls the  INodeVisitor's visit method.
 Create a form factor for this particle. 
 ";
 
-%feature("docstring")  IParticle::createTransformedFormFactor "virtual IFormFactor* IParticle::createTransformedFormFactor(const IRotation *p_rotation, kvector_t translation) const =0
+%feature("docstring")  IParticle::createSlicedFormFactor "IFormFactor * IParticle::createSlicedFormFactor(ZLimits limits) const
 
-Create a form factor for this particle with an extra transformation. 
+Create a sliced form factor for this particle. 
 ";
 
 %feature("docstring")  IParticle::getPosition "kvector_t IParticle::getPosition() const
@@ -8593,6 +8598,11 @@ Sets particle position.
 Sets particle position. 
 ";
 
+%feature("docstring")  IParticle::applyTranslation "void IParticle::applyTranslation(kvector_t displacement)
+
+Applies extra translation by adding it to the current one. 
+";
+
 %feature("docstring")  IParticle::getRotation "const IRotation * IParticle::getRotation() const
 
 Returns rotation object. 
@@ -8608,11 +8618,6 @@ Sets transformation.
 Applies transformation by composing it with the existing one. 
 ";
 
-%feature("docstring")  IParticle::applyTranslation "void IParticle::applyTranslation(kvector_t displacement)
-
-Applies extra translation by adding it to the current one. 
-";
-
 %feature("docstring")  IParticle::getChildren "std::vector< const INode * > IParticle::getChildren() const
 
 Returns a vector of children (const). 
@@ -8624,6 +8629,11 @@ Returns a vector of children (const).
 %feature("docstring")  IParticle::registerPosition "void IParticle::registerPosition(bool make_registered=true)
 
 Registers the three components of its position. 
+";
+
+%feature("docstring")  IParticle::decompose "SafePointerVector< IParticle > IParticle::decompose() const
+
+Decompose in constituent  IParticle objects. 
 ";
 
 
@@ -9662,24 +9672,24 @@ C++ includes: MesoCrystal.h
 %feature("docstring")  MesoCrystal::~MesoCrystal "MesoCrystal::~MesoCrystal()
 ";
 
-%feature("docstring")  MesoCrystal::clone "MesoCrystal * MesoCrystal::clone() const
+%feature("docstring")  MesoCrystal::clone "MesoCrystal * MesoCrystal::clone() const overridefinal
 
 Returns a clone of this  ISample object. 
 ";
 
-%feature("docstring")  MesoCrystal::cloneInvertB "MesoCrystal * MesoCrystal::cloneInvertB() const
+%feature("docstring")  MesoCrystal::cloneInvertB "MesoCrystal * MesoCrystal::cloneInvertB() const overridefinal
 
 Returns a clone with inverted magnetic fields. 
 ";
 
-%feature("docstring")  MesoCrystal::accept "void MesoCrystal::accept(INodeVisitor *visitor) const
+%feature("docstring")  MesoCrystal::accept "void MesoCrystal::accept(INodeVisitor *visitor) const overridefinal
 
 Calls the  INodeVisitor's visit method. 
 ";
 
-%feature("docstring")  MesoCrystal::createTransformedFormFactor "IFormFactor * MesoCrystal::createTransformedFormFactor(const IRotation *p_rotation, kvector_t translation) const
+%feature("docstring")  MesoCrystal::createSlicedFormFactor "IFormFactor * MesoCrystal::createSlicedFormFactor(ZLimits limits) const overridefinal
 
-Create a form factor for this particle with an extra scattering factor. 
+Create a sliced form factor for this particle. 
 ";
 
 %feature("docstring")  MesoCrystal::getClusteredParticles "const IClusteredParticles* MesoCrystal::getClusteredParticles() const
@@ -9687,7 +9697,7 @@ Create a form factor for this particle with an extra scattering factor.
 get the internal structure, which is in principle unbounded in space (e.g. an infinite crystal) 
 ";
 
-%feature("docstring")  MesoCrystal::getChildren "std::vector< const INode * > MesoCrystal::getChildren() const
+%feature("docstring")  MesoCrystal::getChildren "std::vector< const INode * > MesoCrystal::getChildren() const overridefinal
 
 Returns a vector of children (const). 
 ";
@@ -9849,9 +9859,14 @@ returns layer index
 returns true if contains magnetic materials and matrix calculations are required 
 ";
 
-%feature("docstring")  MultiLayer::zToLayerIndex "size_t MultiLayer::zToLayerIndex(double z_value) const
+%feature("docstring")  MultiLayer::bottomZToLayerIndex "size_t MultiLayer::bottomZToLayerIndex(double z_value) const
 
 returns layer index corresponding to given global z coordinate The top interface position of a layer is considered to belong to the layer above 
+";
+
+%feature("docstring")  MultiLayer::topZToLayerIndex "size_t MultiLayer::topZToLayerIndex(double z_value) const
+
+returns layer index corresponding to given global z coordinate The top interface position of a layer is considered to belong to the layer beneath 
 ";
 
 %feature("docstring")  MultiLayer::containsMagneticMaterial "bool MultiLayer::containsMagneticMaterial() const 
@@ -10648,30 +10663,30 @@ C++ includes: Particle.h
 %feature("docstring")  Particle::Particle "Particle::Particle(const IMaterial &p_material, const IFormFactor &form_factor, const IRotation &rotation)
 ";
 
-%feature("docstring")  Particle::clone "Particle * Particle::clone() const
+%feature("docstring")  Particle::clone "Particle * Particle::clone() const overridefinal
 
 Returns a clone of this  ISample object. 
 ";
 
-%feature("docstring")  Particle::cloneInvertB "Particle * Particle::cloneInvertB() const
+%feature("docstring")  Particle::cloneInvertB "Particle * Particle::cloneInvertB() const overridefinal
 
 Returns a clone with inverted magnetic fields. 
 ";
 
-%feature("docstring")  Particle::accept "virtual void Particle::accept(INodeVisitor *visitor) const
+%feature("docstring")  Particle::accept "void Particle::accept(INodeVisitor *visitor) const overridefinal
 
 Calls the  INodeVisitor's visit method. 
 ";
 
-%feature("docstring")  Particle::createTransformedFormFactor "IFormFactor * Particle::createTransformedFormFactor(const IRotation *p_rotation, kvector_t translation) const
+%feature("docstring")  Particle::createSlicedFormFactor "IFormFactor * Particle::createSlicedFormFactor(ZLimits limits) const overridefinal
 
-Create a form factor for this particle with an extra scattering factor. 
+Create a sliced form factor for this particle. 
 ";
 
 %feature("docstring")  Particle::setMaterial "void Particle::setMaterial(const IMaterial &material)
 ";
 
-%feature("docstring")  Particle::getMaterial "const IMaterial* Particle::getMaterial() const
+%feature("docstring")  Particle::getMaterial "const IMaterial* Particle::getMaterial() const overridefinal
 
 Returns nullptr, unless overwritten to return a specific material. 
 ";
@@ -10685,7 +10700,7 @@ Returns nullptr, unless overwritten to return a specific material.
 %feature("docstring")  Particle::getFormFactor "const IFormFactor* Particle::getFormFactor() const 
 ";
 
-%feature("docstring")  Particle::getChildren "std::vector< const INode * > Particle::getChildren() const
+%feature("docstring")  Particle::getChildren "std::vector< const INode * > Particle::getChildren() const overridefinal
 
 Returns a vector of children (const). 
 ";
@@ -10702,29 +10717,23 @@ C++ includes: ParticleComposition.h
 %feature("docstring")  ParticleComposition::ParticleComposition "ParticleComposition::ParticleComposition()
 ";
 
-%feature("docstring")  ParticleComposition::ParticleComposition "ParticleComposition::ParticleComposition(const IParticle &particle)
-";
-
-%feature("docstring")  ParticleComposition::ParticleComposition "ParticleComposition::ParticleComposition(const IParticle &particle, kvector_t position)
-";
-
 %feature("docstring")  ParticleComposition::ParticleComposition "ParticleComposition::ParticleComposition(const IParticle &particle, std::vector< kvector_t > positions)
 ";
 
 %feature("docstring")  ParticleComposition::~ParticleComposition "ParticleComposition::~ParticleComposition()
 ";
 
-%feature("docstring")  ParticleComposition::clone "ParticleComposition * ParticleComposition::clone() const
+%feature("docstring")  ParticleComposition::clone "ParticleComposition * ParticleComposition::clone() const override
 
 Returns a clone of this  ISample object. 
 ";
 
-%feature("docstring")  ParticleComposition::cloneInvertB "ParticleComposition * ParticleComposition::cloneInvertB() const
+%feature("docstring")  ParticleComposition::cloneInvertB "ParticleComposition * ParticleComposition::cloneInvertB() const override
 
 Returns a clone with inverted magnetic fields. 
 ";
 
-%feature("docstring")  ParticleComposition::accept "virtual void ParticleComposition::accept(INodeVisitor *visitor) const
+%feature("docstring")  ParticleComposition::accept "void ParticleComposition::accept(INodeVisitor *visitor) const override
 
 Calls the  INodeVisitor's visit method. 
 ";
@@ -10738,9 +10747,7 @@ Calls the  INodeVisitor's visit method.
 %feature("docstring")  ParticleComposition::addParticles "void ParticleComposition::addParticles(const IParticle &particle, std::vector< kvector_t > positions)
 ";
 
-%feature("docstring")  ParticleComposition::createTransformedFormFactor "IFormFactor * ParticleComposition::createTransformedFormFactor(const IRotation *p_rotation, kvector_t translation) const
-
-Create a form factor for this particle with an extra scattering factor. 
+%feature("docstring")  ParticleComposition::createTransformedFormFactor "IFormFactor * ParticleComposition::createTransformedFormFactor(const IRotation *p_rotation, kvector_t translation) const 
 ";
 
 %feature("docstring")  ParticleComposition::getNbrParticles "size_t ParticleComposition::getNbrParticles() const
@@ -10756,9 +10763,14 @@ Returns particle with given index.
 %feature("docstring")  ParticleComposition::getParticlePosition "kvector_t ParticleComposition::getParticlePosition(size_t index) const 
 ";
 
-%feature("docstring")  ParticleComposition::getChildren "std::vector< const INode * > ParticleComposition::getChildren() const
+%feature("docstring")  ParticleComposition::getChildren "std::vector< const INode * > ParticleComposition::getChildren() const override
 
 Returns a vector of children (const). 
+";
+
+%feature("docstring")  ParticleComposition::decompose "SafePointerVector< IParticle > ParticleComposition::decompose() const override
+
+Decompose in constituent  IParticle objects. 
 ";
 
 
@@ -10791,24 +10803,24 @@ C++ includes: ParticleCoreShell.h
 %feature("docstring")  ParticleCoreShell::~ParticleCoreShell "ParticleCoreShell::~ParticleCoreShell()
 ";
 
-%feature("docstring")  ParticleCoreShell::clone "ParticleCoreShell * ParticleCoreShell::clone() const final
+%feature("docstring")  ParticleCoreShell::clone "ParticleCoreShell * ParticleCoreShell::clone() const overridefinal
 
 Returns a clone of this  ISample object. 
 ";
 
-%feature("docstring")  ParticleCoreShell::cloneInvertB "ParticleCoreShell * ParticleCoreShell::cloneInvertB() const final
+%feature("docstring")  ParticleCoreShell::cloneInvertB "ParticleCoreShell * ParticleCoreShell::cloneInvertB() const overridefinal
 
 Returns a clone with inverted magnetic fields. 
 ";
 
-%feature("docstring")  ParticleCoreShell::accept "void ParticleCoreShell::accept(INodeVisitor *visitor) const final
+%feature("docstring")  ParticleCoreShell::accept "void ParticleCoreShell::accept(INodeVisitor *visitor) const overridefinal
 
 Calls the  INodeVisitor's visit method. 
 ";
 
-%feature("docstring")  ParticleCoreShell::createTransformedFormFactor "IFormFactor * ParticleCoreShell::createTransformedFormFactor(const IRotation *p_rotation, kvector_t translation) const final
+%feature("docstring")  ParticleCoreShell::createSlicedFormFactor "IFormFactor * ParticleCoreShell::createSlicedFormFactor(ZLimits limits) const overridefinal
 
-Create a form factor for this particle with an extra scattering factor. 
+Create a sliced form factor for this particle. 
 ";
 
 %feature("docstring")  ParticleCoreShell::coreParticle "const Particle * ParticleCoreShell::coreParticle() const 
@@ -10817,7 +10829,7 @@ Create a form factor for this particle with an extra scattering factor.
 %feature("docstring")  ParticleCoreShell::shellParticle "const Particle * ParticleCoreShell::shellParticle() const 
 ";
 
-%feature("docstring")  ParticleCoreShell::getChildren "std::vector< const INode * > ParticleCoreShell::getChildren() const
+%feature("docstring")  ParticleCoreShell::getChildren "std::vector< const INode * > ParticleCoreShell::getChildren() const overridefinal
 
 Returns a vector of children (const). 
 ";
@@ -12658,6 +12670,30 @@ C++ includes: Slice.h
 ";
 
 
+// File: classSlicedFormFactorList.xml
+%feature("docstring") SlicedFormFactorList "
+
+Class that contains and owns a list of form factors and the index of their containing layer. This class also handles the slicing of form factors if they cross layer interfaces.
+
+C++ includes: SlicedFormFactorList.h
+";
+
+%feature("docstring")  SlicedFormFactorList::SlicedFormFactorList "SlicedFormFactorList::SlicedFormFactorList()=default
+";
+
+%feature("docstring")  SlicedFormFactorList::SlicedFormFactorList "SlicedFormFactorList::SlicedFormFactorList(SlicedFormFactorList &&other)=default
+";
+
+%feature("docstring")  SlicedFormFactorList::~SlicedFormFactorList "SlicedFormFactorList::~SlicedFormFactorList()=default
+";
+
+%feature("docstring")  SlicedFormFactorList::addParticle "void SlicedFormFactorList::addParticle(IParticle &particle, const MultiLayer &multilayer, size_t ref_layer_index)
+";
+
+%feature("docstring")  SlicedFormFactorList::size "size_t SlicedFormFactorList::size() const 
+";
+
+
 // File: classSpecularComputation.xml
 %feature("docstring") SpecularComputation "
 
@@ -13428,6 +13464,30 @@ C++ includes: WavevectorInfo.h
 // File: classConvolve_1_1Workspace.xml
 
 
+// File: classZLimits.xml
+%feature("docstring") ZLimits "
+
+Class that contains upper and lower limits of the z-coordinate for the slicing of form factors.
+
+C++ includes: ZLimits.h
+";
+
+%feature("docstring")  ZLimits::ZLimits "ZLimits::ZLimits(Type type=INFINITE, double ref=0.0)
+";
+
+%feature("docstring")  ZLimits::ZLimits "ZLimits::ZLimits(double min, double max)
+";
+
+%feature("docstring")  ZLimits::type "Type ZLimits::type() const 
+";
+
+%feature("docstring")  ZLimits::zmin "double ZLimits::zmin() const 
+";
+
+%feature("docstring")  ZLimits::zmax "double ZLimits::zmax() const 
+";
+
+
 // File: namespace_0D144.xml
 
 
@@ -13452,7 +13512,10 @@ C++ includes: WavevectorInfo.h
 // File: namespace_0D324.xml
 
 
-// File: namespace_0D469.xml
+// File: namespace_0D363.xml
+
+
+// File: namespace_0D473.xml
 
 
 // File: namespace_0D60.xml
@@ -15126,13 +15189,43 @@ Recursive bisection to determine the number of the deepest layer where RT comput
 // File: ParticleDistribution_8h.xml
 
 
+// File: SlicedFormFactorList_8cpp.xml
+%feature("docstring")  CreateSlicedFormFactors "SlicedFormFactorList CreateSlicedFormFactors(const IParticle &particle, const MultiLayer &multilayer, size_t ref_layer_index)
+
+Global function that creates a  SlicedFormFactorList from an  IParticle in a multilayer 
+";
+
+
+// File: SlicedFormFactorList_8h.xml
+%feature("docstring")  CreateSlicedFormFactors "SlicedFormFactorList CreateSlicedFormFactors(const IParticle &particle, const MultiLayer &multilayer, size_t ref_layer_index)
+
+Global function that creates a  SlicedFormFactorList from an  IParticle in a multilayer 
+";
+
+
 // File: TRange_8h.xml
 
 
+// File: ZLimits_8cpp.xml
+
+
+// File: ZLimits_8h.xml
+
+
 // File: IFormFactor_8cpp.xml
+%feature("docstring")  ShapeIsContainedInLimits "bool ShapeIsContainedInLimits(const IFormFactor &formfactor, ZLimits limits, const IRotation &rot, kvector_t translation)
+";
+
+%feature("docstring")  CreateTransformedFormFactor "IFormFactor* CreateTransformedFormFactor(const IFormFactor &formfactor, const IRotation &rot, kvector_t translation)
+";
 
 
 // File: IFormFactor_8h.xml
+%feature("docstring")  ShapeIsContainedInLimits "bool ShapeIsContainedInLimits(const IFormFactor &formfactor, ZLimits limits, const IRotation &rot, kvector_t translation)
+";
+
+%feature("docstring")  CreateTransformedFormFactor "IFormFactor* CreateTransformedFormFactor(const IFormFactor &formfactor, const IRotation &rot, kvector_t translation)
+";
 
 
 // File: IFormFactorBorn_8cpp.xml

--- a/auto/Wrap/libBornAgainCore.py
+++ b/auto/Wrap/libBornAgainCore.py
@@ -10681,6 +10681,11 @@ class IFormFactor(ISample):
         return _libBornAgainCore.IFormFactor_clone(self)
 
 
+    def createSlicedFormFactor(self, limits, rot, translation):
+        """createSlicedFormFactor(IFormFactor self, ZLimits limits, IRotation rot, kvector_t translation) -> IFormFactor"""
+        return _libBornAgainCore.IFormFactor_createSlicedFormFactor(self, limits, rot, translation)
+
+
     def setAmbientMaterial(self, arg0):
         """
         setAmbientMaterial(IFormFactor self, IMaterial arg0)
@@ -10771,6 +10776,14 @@ class IFormFactor(ISample):
 IFormFactor_swigregister = _libBornAgainCore.IFormFactor_swigregister
 IFormFactor_swigregister(IFormFactor)
 
+
+def ShapeIsContainedInLimits(formfactor, limits, rot, translation):
+    """ShapeIsContainedInLimits(IFormFactor formfactor, ZLimits limits, IRotation rot, kvector_t translation) -> bool"""
+    return _libBornAgainCore.ShapeIsContainedInLimits(formfactor, limits, rot, translation)
+
+def CreateTransformedFormFactor(formfactor, rot, translation):
+    """CreateTransformedFormFactor(IFormFactor formfactor, IRotation rot, kvector_t translation) -> IFormFactor"""
+    return _libBornAgainCore.CreateTransformedFormFactor(formfactor, rot, translation)
 class vector_IFormFactorPtr_t(_object):
     """Proxy of C++ std::vector<(p.IFormFactor)> class."""
 
@@ -18592,6 +18605,11 @@ class IParticle(IAbstractParticle):
 
         """
         return _libBornAgainCore.IParticle_createFormFactor(self)
+
+
+    def createSlicedFormFactor(self, limits):
+        """createSlicedFormFactor(IParticle self, ZLimits limits) -> IFormFactor"""
+        return _libBornAgainCore.IParticle_createSlicedFormFactor(self, limits)
 
 
     def createTransformedFormFactor(self, p_rotation, translation):

--- a/auto/Wrap/libBornAgainCore.py
+++ b/auto/Wrap/libBornAgainCore.py
@@ -10682,7 +10682,14 @@ class IFormFactor(ISample):
 
 
     def createSlicedFormFactor(self, limits, rot, translation):
-        """createSlicedFormFactor(IFormFactor self, ZLimits limits, IRotation rot, kvector_t translation) -> IFormFactor"""
+        """
+        createSlicedFormFactor(IFormFactor self, ZLimits limits, IRotation rot, kvector_t translation) -> IFormFactor
+
+        IFormFactor * IFormFactor::createSlicedFormFactor(ZLimits limits, const IRotation &rot, kvector_t translation) const
+
+        Creates a sliced form factor with the given rotation and translation. 
+
+        """
         return _libBornAgainCore.IFormFactor_createSlicedFormFactor(self, limits, rot, translation)
 
 
@@ -10778,11 +10785,21 @@ IFormFactor_swigregister(IFormFactor)
 
 
 def ShapeIsContainedInLimits(formfactor, limits, rot, translation):
-    """ShapeIsContainedInLimits(IFormFactor formfactor, ZLimits limits, IRotation rot, kvector_t translation) -> bool"""
+    """
+    ShapeIsContainedInLimits(IFormFactor formfactor, ZLimits limits, IRotation rot, kvector_t translation) -> bool
+
+    bool ShapeIsContainedInLimits(const IFormFactor &formfactor, ZLimits limits, const IRotation &rot, kvector_t translation)
+
+    """
     return _libBornAgainCore.ShapeIsContainedInLimits(formfactor, limits, rot, translation)
 
 def CreateTransformedFormFactor(formfactor, rot, translation):
-    """CreateTransformedFormFactor(IFormFactor formfactor, IRotation rot, kvector_t translation) -> IFormFactor"""
+    """
+    CreateTransformedFormFactor(IFormFactor formfactor, IRotation rot, kvector_t translation) -> IFormFactor
+
+    IFormFactor* CreateTransformedFormFactor(const IFormFactor &formfactor, const IRotation &rot, kvector_t translation)
+
+    """
     return _libBornAgainCore.CreateTransformedFormFactor(formfactor, rot, translation)
 class vector_IFormFactorPtr_t(_object):
     """Proxy of C++ std::vector<(p.IFormFactor)> class."""
@@ -18608,20 +18625,15 @@ class IParticle(IAbstractParticle):
 
 
     def createSlicedFormFactor(self, limits):
-        """createSlicedFormFactor(IParticle self, ZLimits limits) -> IFormFactor"""
+        """
+        createSlicedFormFactor(IParticle self, ZLimits limits) -> IFormFactor
+
+        IFormFactor * IParticle::createSlicedFormFactor(ZLimits limits) const
+
+        Create a sliced form factor for this particle. 
+
+        """
         return _libBornAgainCore.IParticle_createSlicedFormFactor(self, limits)
-
-
-    def createTransformedFormFactor(self, p_rotation, translation):
-        """
-        createTransformedFormFactor(IParticle self, IRotation p_rotation, kvector_t translation) -> IFormFactor
-
-        virtual IFormFactor* IParticle::createTransformedFormFactor(const IRotation *p_rotation, kvector_t translation) const =0
-
-        Create a form factor for this particle with an extra transformation. 
-
-        """
-        return _libBornAgainCore.IParticle_createTransformedFormFactor(self, p_rotation, translation)
 
 
     def getPosition(self):
@@ -18734,7 +18746,14 @@ class IParticle(IAbstractParticle):
 
 
     def decompose(self):
-        """decompose(IParticle self) -> SafePointerVector< IParticle >"""
+        """
+        decompose(IParticle self) -> SafePointerVector< IParticle >
+
+        SafePointerVector< IParticle > IParticle::decompose() const
+
+        Decompose in constituent  IParticle objects. 
+
+        """
         return _libBornAgainCore.IParticle_decompose(self)
 
 IParticle_swigregister = _libBornAgainCore.IParticle_swigregister
@@ -22127,7 +22146,7 @@ class MesoCrystal(IParticle):
         """
         clone(MesoCrystal self) -> MesoCrystal
 
-        MesoCrystal * MesoCrystal::clone() const
+        MesoCrystal * MesoCrystal::clone() const overridefinal
 
         Returns a clone of this  ISample object. 
 
@@ -22139,7 +22158,7 @@ class MesoCrystal(IParticle):
         """
         cloneInvertB(MesoCrystal self) -> MesoCrystal
 
-        MesoCrystal * MesoCrystal::cloneInvertB() const
+        MesoCrystal * MesoCrystal::cloneInvertB() const overridefinal
 
         Returns a clone with inverted magnetic fields. 
 
@@ -22151,7 +22170,7 @@ class MesoCrystal(IParticle):
         """
         accept(MesoCrystal self, INodeVisitor visitor)
 
-        void MesoCrystal::accept(INodeVisitor *visitor) const
+        void MesoCrystal::accept(INodeVisitor *visitor) const overridefinal
 
         Calls the  INodeVisitor's visit method. 
 
@@ -22160,20 +22179,15 @@ class MesoCrystal(IParticle):
 
 
     def createSlicedFormFactor(self, limits):
-        """createSlicedFormFactor(MesoCrystal self, ZLimits limits) -> IFormFactor"""
+        """
+        createSlicedFormFactor(MesoCrystal self, ZLimits limits) -> IFormFactor
+
+        IFormFactor * MesoCrystal::createSlicedFormFactor(ZLimits limits) const overridefinal
+
+        Create a sliced form factor for this particle. 
+
+        """
         return _libBornAgainCore.MesoCrystal_createSlicedFormFactor(self, limits)
-
-
-    def createTransformedFormFactor(self, p_rotation, translation):
-        """
-        createTransformedFormFactor(MesoCrystal self, IRotation p_rotation, kvector_t translation) -> IFormFactor
-
-        IFormFactor * MesoCrystal::createTransformedFormFactor(const IRotation *p_rotation, kvector_t translation) const
-
-        Create a form factor for this particle with an extra scattering factor. 
-
-        """
-        return _libBornAgainCore.MesoCrystal_createTransformedFormFactor(self, p_rotation, translation)
 
 
     def getClusteredParticles(self):
@@ -22192,7 +22206,7 @@ class MesoCrystal(IParticle):
         """
         getChildren(MesoCrystal self) -> swig_dummy_type_const_inode_vector
 
-        std::vector< const INode * > MesoCrystal::getChildren() const
+        std::vector< const INode * > MesoCrystal::getChildren() const overridefinal
 
         Returns a vector of children (const). 
 
@@ -22530,12 +22544,26 @@ class MultiLayer(ISample):
 
 
     def bottomZToLayerIndex(self, z_value):
-        """bottomZToLayerIndex(MultiLayer self, double z_value) -> size_t"""
+        """
+        bottomZToLayerIndex(MultiLayer self, double z_value) -> size_t
+
+        size_t MultiLayer::bottomZToLayerIndex(double z_value) const
+
+        returns layer index corresponding to given global z coordinate The top interface position of a layer is considered to belong to the layer above 
+
+        """
         return _libBornAgainCore.MultiLayer_bottomZToLayerIndex(self, z_value)
 
 
     def topZToLayerIndex(self, z_value):
-        """topZToLayerIndex(MultiLayer self, double z_value) -> size_t"""
+        """
+        topZToLayerIndex(MultiLayer self, double z_value) -> size_t
+
+        size_t MultiLayer::topZToLayerIndex(double z_value) const
+
+        returns layer index corresponding to given global z coordinate The top interface position of a layer is considered to belong to the layer beneath 
+
+        """
         return _libBornAgainCore.MultiLayer_topZToLayerIndex(self, z_value)
 
 
@@ -23847,7 +23875,7 @@ class Particle(IParticle):
         """
         clone(Particle self) -> Particle
 
-        Particle * Particle::clone() const
+        Particle * Particle::clone() const overridefinal
 
         Returns a clone of this  ISample object. 
 
@@ -23859,7 +23887,7 @@ class Particle(IParticle):
         """
         cloneInvertB(Particle self) -> Particle
 
-        Particle * Particle::cloneInvertB() const
+        Particle * Particle::cloneInvertB() const overridefinal
 
         Returns a clone with inverted magnetic fields. 
 
@@ -23871,7 +23899,7 @@ class Particle(IParticle):
         """
         accept(Particle self, INodeVisitor visitor)
 
-        virtual void Particle::accept(INodeVisitor *visitor) const
+        void Particle::accept(INodeVisitor *visitor) const overridefinal
 
         Calls the  INodeVisitor's visit method. 
 
@@ -23880,20 +23908,15 @@ class Particle(IParticle):
 
 
     def createSlicedFormFactor(self, limits):
-        """createSlicedFormFactor(Particle self, ZLimits limits) -> IFormFactor"""
+        """
+        createSlicedFormFactor(Particle self, ZLimits limits) -> IFormFactor
+
+        IFormFactor * Particle::createSlicedFormFactor(ZLimits limits) const overridefinal
+
+        Create a sliced form factor for this particle. 
+
+        """
         return _libBornAgainCore.Particle_createSlicedFormFactor(self, limits)
-
-
-    def createTransformedFormFactor(self, p_rotation, translation):
-        """
-        createTransformedFormFactor(Particle self, IRotation p_rotation, kvector_t translation) -> IFormFactor
-
-        IFormFactor * Particle::createTransformedFormFactor(const IRotation *p_rotation, kvector_t translation) const
-
-        Create a form factor for this particle with an extra scattering factor. 
-
-        """
-        return _libBornAgainCore.Particle_createTransformedFormFactor(self, p_rotation, translation)
 
 
     def setMaterial(self, material):
@@ -23910,7 +23933,7 @@ class Particle(IParticle):
         """
         getMaterial(Particle self) -> IMaterial
 
-        const IMaterial* Particle::getMaterial() const
+        const IMaterial* Particle::getMaterial() const overridefinal
 
         Returns nullptr, unless overwritten to return a specific material. 
 
@@ -23952,7 +23975,7 @@ class Particle(IParticle):
         """
         getChildren(Particle self) -> swig_dummy_type_const_inode_vector
 
-        std::vector< const INode * > Particle::getChildren() const
+        std::vector< const INode * > Particle::getChildren() const overridefinal
 
         Returns a vector of children (const). 
 
@@ -24004,7 +24027,7 @@ class ParticleComposition(IParticle):
         """
         clone(ParticleComposition self) -> ParticleComposition
 
-        ParticleComposition * ParticleComposition::clone() const
+        ParticleComposition * ParticleComposition::clone() const override
 
         Returns a clone of this  ISample object. 
 
@@ -24016,7 +24039,7 @@ class ParticleComposition(IParticle):
         """
         cloneInvertB(ParticleComposition self) -> ParticleComposition
 
-        ParticleComposition * ParticleComposition::cloneInvertB() const
+        ParticleComposition * ParticleComposition::cloneInvertB() const override
 
         Returns a clone with inverted magnetic fields. 
 
@@ -24028,7 +24051,7 @@ class ParticleComposition(IParticle):
         """
         accept(ParticleComposition self, INodeVisitor visitor)
 
-        virtual void ParticleComposition::accept(INodeVisitor *visitor) const
+        void ParticleComposition::accept(INodeVisitor *visitor) const override
 
         Calls the  INodeVisitor's visit method. 
 
@@ -24061,9 +24084,7 @@ class ParticleComposition(IParticle):
         """
         createTransformedFormFactor(ParticleComposition self, IRotation p_rotation, kvector_t translation) -> IFormFactor
 
-        IFormFactor * ParticleComposition::createTransformedFormFactor(const IRotation *p_rotation, kvector_t translation) const
-
-        Create a form factor for this particle with an extra scattering factor. 
+        IFormFactor * ParticleComposition::createTransformedFormFactor(const IRotation *p_rotation, kvector_t translation) const 
 
         """
         return _libBornAgainCore.ParticleComposition_createTransformedFormFactor(self, p_rotation, translation)
@@ -24107,7 +24128,7 @@ class ParticleComposition(IParticle):
         """
         getChildren(ParticleComposition self) -> swig_dummy_type_const_inode_vector
 
-        std::vector< const INode * > ParticleComposition::getChildren() const
+        std::vector< const INode * > ParticleComposition::getChildren() const override
 
         Returns a vector of children (const). 
 
@@ -24116,7 +24137,14 @@ class ParticleComposition(IParticle):
 
 
     def decompose(self):
-        """decompose(ParticleComposition self) -> SafePointerVector< IParticle >"""
+        """
+        decompose(ParticleComposition self) -> SafePointerVector< IParticle >
+
+        SafePointerVector< IParticle > ParticleComposition::decompose() const override
+
+        Decompose in constituent  IParticle objects. 
+
+        """
         return _libBornAgainCore.ParticleComposition_decompose(self)
 
 ParticleComposition_swigregister = _libBornAgainCore.ParticleComposition_swigregister
@@ -24162,7 +24190,7 @@ class ParticleCoreShell(IParticle):
         """
         clone(ParticleCoreShell self) -> ParticleCoreShell
 
-        ParticleCoreShell * ParticleCoreShell::clone() const final
+        ParticleCoreShell * ParticleCoreShell::clone() const overridefinal
 
         Returns a clone of this  ISample object. 
 
@@ -24174,7 +24202,7 @@ class ParticleCoreShell(IParticle):
         """
         cloneInvertB(ParticleCoreShell self) -> ParticleCoreShell
 
-        ParticleCoreShell * ParticleCoreShell::cloneInvertB() const final
+        ParticleCoreShell * ParticleCoreShell::cloneInvertB() const overridefinal
 
         Returns a clone with inverted magnetic fields. 
 
@@ -24186,7 +24214,7 @@ class ParticleCoreShell(IParticle):
         """
         accept(ParticleCoreShell self, INodeVisitor visitor)
 
-        void ParticleCoreShell::accept(INodeVisitor *visitor) const final
+        void ParticleCoreShell::accept(INodeVisitor *visitor) const overridefinal
 
         Calls the  INodeVisitor's visit method. 
 
@@ -24195,20 +24223,15 @@ class ParticleCoreShell(IParticle):
 
 
     def createSlicedFormFactor(self, limits):
-        """createSlicedFormFactor(ParticleCoreShell self, ZLimits limits) -> IFormFactor"""
+        """
+        createSlicedFormFactor(ParticleCoreShell self, ZLimits limits) -> IFormFactor
+
+        IFormFactor * ParticleCoreShell::createSlicedFormFactor(ZLimits limits) const overridefinal
+
+        Create a sliced form factor for this particle. 
+
+        """
         return _libBornAgainCore.ParticleCoreShell_createSlicedFormFactor(self, limits)
-
-
-    def createTransformedFormFactor(self, p_rotation, translation):
-        """
-        createTransformedFormFactor(ParticleCoreShell self, IRotation p_rotation, kvector_t translation) -> IFormFactor
-
-        IFormFactor * ParticleCoreShell::createTransformedFormFactor(const IRotation *p_rotation, kvector_t translation) const final
-
-        Create a form factor for this particle with an extra scattering factor. 
-
-        """
-        return _libBornAgainCore.ParticleCoreShell_createTransformedFormFactor(self, p_rotation, translation)
 
 
     def coreParticle(self):
@@ -24235,7 +24258,7 @@ class ParticleCoreShell(IParticle):
         """
         getChildren(ParticleCoreShell self) -> swig_dummy_type_const_inode_vector
 
-        std::vector< const INode * > ParticleCoreShell::getChildren() const
+        std::vector< const INode * > ParticleCoreShell::getChildren() const overridefinal
 
         Returns a vector of children (const). 
 

--- a/auto/Wrap/libBornAgainCore.py
+++ b/auto/Wrap/libBornAgainCore.py
@@ -22352,11 +22352,6 @@ class MultiLayer(ISample):
         return _libBornAgainCore.MultiLayer_getLayerThickness(self, i_layer)
 
 
-    def getZLimits(self, i_layer):
-        """getZLimits(MultiLayer self, size_t i_layer) -> ZLimits"""
-        return _libBornAgainCore.MultiLayer_getZLimits(self, i_layer)
-
-
     def getLayerTopInterface(self, i_layer):
         """
         getLayerTopInterface(MultiLayer self, size_t i_layer) -> LayerInterface const *
@@ -23877,6 +23872,11 @@ class Particle(IParticle):
 
         """
         return _libBornAgainCore.Particle_accept(self, visitor)
+
+
+    def createSlicedFormFactor(self, limits):
+        """createSlicedFormFactor(Particle self, ZLimits limits) -> IFormFactor"""
+        return _libBornAgainCore.Particle_createSlicedFormFactor(self, limits)
 
 
     def createTransformedFormFactor(self, p_rotation, translation):

--- a/auto/Wrap/libBornAgainCore.py
+++ b/auto/Wrap/libBornAgainCore.py
@@ -22352,6 +22352,11 @@ class MultiLayer(ISample):
         return _libBornAgainCore.MultiLayer_getLayerThickness(self, i_layer)
 
 
+    def getZLimits(self, i_layer):
+        """getZLimits(MultiLayer self, size_t i_layer) -> ZLimits"""
+        return _libBornAgainCore.MultiLayer_getZLimits(self, i_layer)
+
+
     def getLayerTopInterface(self, i_layer):
         """
         getLayerTopInterface(MultiLayer self, size_t i_layer) -> LayerInterface const *

--- a/auto/Wrap/libBornAgainCore.py
+++ b/auto/Wrap/libBornAgainCore.py
@@ -22159,6 +22159,11 @@ class MesoCrystal(IParticle):
         return _libBornAgainCore.MesoCrystal_accept(self, visitor)
 
 
+    def createSlicedFormFactor(self, limits):
+        """createSlicedFormFactor(MesoCrystal self, ZLimits limits) -> IFormFactor"""
+        return _libBornAgainCore.MesoCrystal_createSlicedFormFactor(self, limits)
+
+
     def createTransformedFormFactor(self, p_rotation, translation):
         """
         createTransformedFormFactor(MesoCrystal self, IRotation p_rotation, kvector_t translation) -> IFormFactor
@@ -24187,6 +24192,11 @@ class ParticleCoreShell(IParticle):
 
         """
         return _libBornAgainCore.ParticleCoreShell_accept(self, visitor)
+
+
+    def createSlicedFormFactor(self, limits):
+        """createSlicedFormFactor(ParticleCoreShell self, ZLimits limits) -> IFormFactor"""
+        return _libBornAgainCore.ParticleCoreShell_createSlicedFormFactor(self, limits)
 
 
     def createTransformedFormFactor(self, p_rotation, translation):

--- a/auto/Wrap/libBornAgainCore_wrap.h
+++ b/auto/Wrap/libBornAgainCore_wrap.h
@@ -325,6 +325,7 @@ public:
     virtual ISample *cloneInvertB() const;
     virtual IMaterial const *getMaterial() const;
     virtual IMaterial const *getAmbientMaterial() const;
+    virtual IFormFactor *createSlicedFormFactor(ZLimits limits, IRotation const &rot, kvector_t translation) const;
     virtual void setAmbientMaterial(IMaterial const &arg0);
     virtual complex_t evaluate(WavevectorInfo const &wavevectors) const;
     virtual double getVolume() const;
@@ -362,7 +363,7 @@ private:
       return method;
     }
 private:
-    mutable swig::SwigVar_PyObject vtable[17];
+    mutable swig::SwigVar_PyObject vtable[18];
 #endif
 
 };
@@ -383,6 +384,7 @@ public:
     virtual ISample *cloneInvertB() const;
     virtual IMaterial const *getMaterial() const;
     virtual IMaterial const *getAmbientMaterial() const;
+    virtual IFormFactor *createSlicedFormFactor(ZLimits limits, IRotation const &rot, kvector_t translation) const;
     virtual void setAmbientMaterial(IMaterial const &arg0);
     virtual complex_t evaluate(WavevectorInfo const &wavevectors) const;
     virtual double getVolume() const;
@@ -421,7 +423,7 @@ private:
       return method;
     }
 private:
-    mutable swig::SwigVar_PyObject vtable[18];
+    mutable swig::SwigVar_PyObject vtable[19];
 #endif
 
 };

--- a/auto/Wrap/libBornAgainFit_wrap.cpp
+++ b/auto/Wrap/libBornAgainFit_wrap.cpp
@@ -5627,7 +5627,7 @@ SWIG_AsVal_std_complex_Sl_double_Sg_  (PyObject *o, std::complex<double>* val)
 
 
 SWIGINTERNINLINE PyObject*
-SWIG_From_std_complex_Sl_double_Sg_  (/*@SWIG:/home/pospelov/software/local/share/swig/3.0.8/typemaps/swigmacros.swg,104,%ifcplusplus@*/
+SWIG_From_std_complex_Sl_double_Sg_  (/*@SWIG:/usr/share/swig3.0/typemaps/swigmacros.swg,104,%ifcplusplus@*/
 
 const std::complex<double>&
 


### PR DESCRIPTION
During the collection of form factors, the software now generates a sliced form factor for each layer that contains (part of) the shapes. For the moment, only when the elementary shape, i.e. not a composition, is completely contained in a layer, will the form factor be generated. Otherwise, an exception is thrown.