### PR TITLE
GroupProperty refactoring

### DIFF
--- a/GUI/coregui/Models/BeamDistributionItem.cpp
+++ b/GUI/coregui/Models/BeamDistributionItem.cpp
@@ -125,7 +125,6 @@ double BeamDistributionItem::scaleFactor() const
 void BeamDistributionItem::register_distribution_group()
 {
     addGroupProperty(P_DISTRIBUTION, Constants::DistributionExtendedGroup);
-    setGroupProperty(P_DISTRIBUTION, Constants::DistributionNoneType);
 }
 
 std::unique_ptr<IDistribution1D> BeamDistributionItem::createDistribution1D() const

--- a/GUI/coregui/Models/DetectorItems.cpp
+++ b/GUI/coregui/Models/DetectorItems.cpp
@@ -22,8 +22,12 @@
 #include "ResolutionFunctionItems.h"
 #include "ResolutionFunction2DGaussian.h"
 
-const QString DetectorItem::T_MASKS = "Mask tag";
-const QString DetectorItem::P_RESOLUTION_FUNCTION = "Type";
+namespace {
+    const QString res_func_group_label = "Type";
+}
+
+const QString DetectorItem::T_MASKS = "Masks";
+const QString DetectorItem::P_RESOLUTION_FUNCTION = "ResolutionFunctions";
 
 DetectorItem::DetectorItem(const QString& modelType) : SessionItem(modelType)
 {
@@ -69,7 +73,8 @@ void DetectorItem::importMasks(MaskContainerItem* maskContainer)
 
 void DetectorItem::register_resolution_function()
 {
-    addGroupProperty(P_RESOLUTION_FUNCTION, Constants::ResolutionFunctionGroup);
+    addGroupProperty(P_RESOLUTION_FUNCTION, Constants::ResolutionFunctionGroup)
+            ->setDisplayName(res_func_group_label);
 }
 
 std::unique_ptr<IResolutionFunction2D> DetectorItem::createResolutionFunction() const

--- a/GUI/coregui/Models/DetectorItems.cpp
+++ b/GUI/coregui/Models/DetectorItems.cpp
@@ -74,11 +74,8 @@ void DetectorItem::register_resolution_function()
 
 std::unique_ptr<IResolutionFunction2D> DetectorItem::createResolutionFunction() const
 {
-    auto resfuncItem
-        = dynamic_cast<ResolutionFunctionItem*>(getGroupItem(DetectorItem::P_RESOLUTION_FUNCTION));
-    Q_ASSERT(resfuncItem);
-
-    return resfuncItem->createResolutionFunction(axesToDomainUnitsFactor());
+    auto& resfuncItem = groupItem<ResolutionFunctionItem>(DetectorItem::P_RESOLUTION_FUNCTION);
+    return resfuncItem.createResolutionFunction(axesToDomainUnitsFactor());
 }
 
 void DetectorItem::addMasksToDomain(IDetector2D* detector) const

--- a/GUI/coregui/Models/DetectorItems.cpp
+++ b/GUI/coregui/Models/DetectorItems.cpp
@@ -70,7 +70,6 @@ void DetectorItem::importMasks(MaskContainerItem* maskContainer)
 void DetectorItem::register_resolution_function()
 {
     addGroupProperty(P_RESOLUTION_FUNCTION, Constants::ResolutionFunctionGroup);
-    setGroupProperty(P_RESOLUTION_FUNCTION, Constants::ResolutionFunctionNoneType);
 }
 
 std::unique_ptr<IResolutionFunction2D> DetectorItem::createResolutionFunction() const

--- a/GUI/coregui/Models/GroupInfo.cpp
+++ b/GUI/coregui/Models/GroupInfo.cpp
@@ -9,7 +9,7 @@
 //! @license   GNU General Public License v3 or higher (see COPYING)
 //! @copyright Forschungszentrum Jülich GmbH 2017
 //! @authors   Scientific Computing Group at MLZ Garching
-//! @authors   J. Burle, J. M. Fisher, M. Ganeva, D. Li, G. Pospelov, W. Van Herck, J. Wuttke
+//! @authors   J. Burle, J. M. Fisher, M. Ganeva, G. Pospelov, W. Van Herck, J. Wuttke
 //
 // ************************************************************************** //
 

--- a/GUI/coregui/Models/GroupInfo.cpp
+++ b/GUI/coregui/Models/GroupInfo.cpp
@@ -17,30 +17,30 @@
 #include "GroupInfo.h"
 #include "GUIHelpers.h"
 
-GroupInfo::GroupInfo(const QString& groupName, bool is_sorted)
-    : m_groupName(groupName), is_sorted(is_sorted)
+GroupInfo::GroupInfo(const QString& groupType, bool is_sorted)
+    : m_groupType(groupType), is_sorted(is_sorted)
 {
 }
 
-void GroupInfo::add(const QString& modelType, const QString& label)
+void GroupInfo::add(const QString& itemType, const QString& itemLabel)
 {
-    if (groupName().isEmpty())
+    if (groupType().isEmpty())
         throw GUIHelpers::Error("GroupInfo::add() -> Error. Empty group name");
 
-    if (containsType(modelType))
+    if (containsType(itemType))
         throw GUIHelpers::Error("GroupInfo::add() -> Error. "
-                                "Model type '"  + modelType + "' already exists.");
+                                "Model type '"  + itemType + "' already exists.");
 
-    m_info.push_back({modelType, label});
+    m_info.push_back({itemType, itemLabel});
 
     if (is_sorted)
         std::sort(m_info.begin(), m_info.end(),
-                  [](TypeAndLabel a, TypeAndLabel b) { return a.m_modelType < b.m_modelType; });
+                  [](TypeAndLabel a, TypeAndLabel b) { return a.m_itemType < b.m_itemType; });
 }
 
 QString GroupInfo::defaultType() const
 {
-    return m_defaultType;
+    return m_defaultItemType;
 }
 
 void GroupInfo::setDefaultType(const QString& modelType)
@@ -48,37 +48,37 @@ void GroupInfo::setDefaultType(const QString& modelType)
     if (!containsType(modelType))
         throw GUIHelpers::Error("GroupInfo::add() -> Error. No such type '" + modelType + "'");
 
-    m_defaultType = modelType;
+    m_defaultItemType = modelType;
 }
 
-QString GroupInfo::groupName() const
+QString GroupInfo::groupType() const
 {
-    return m_groupName;
+    return m_groupType;
 }
 
-QStringList GroupInfo::types() const
+QStringList GroupInfo::itemTypes() const
 {
     QStringList result;
     for (auto& pair : m_info)
-        result.append(pair.m_modelType);
+        result.append(pair.m_itemType);
 
     return result;
 }
 
-QStringList GroupInfo::labels() const
+QStringList GroupInfo::itemLabels() const
 {
     QStringList result;
     for (auto& pair : m_info)
-        result.append(pair.m_label);
+        result.append(pair.m_itemLabel);
 
     return result;
 
 }
 
-bool GroupInfo::containsType(const QString& modelType) const
+bool GroupInfo::containsType(const QString& itemType) const
 {
     for (auto& pair : m_info)
-        if (modelType == pair.m_modelType)
+        if (itemType == pair.m_itemType)
             return true;
 
     return false;

--- a/GUI/coregui/Models/GroupInfo.cpp
+++ b/GUI/coregui/Models/GroupInfo.cpp
@@ -38,6 +38,11 @@ void GroupInfo::add(const QString& modelType, const QString& label)
                   [](TypeAndLabel a, TypeAndLabel b) { return a.m_modelType < b.m_modelType; });
 }
 
+QString GroupInfo::defaultType() const
+{
+    return m_defaultType;
+}
+
 void GroupInfo::setDefaultType(const QString& modelType)
 {
     if (!containsType(modelType))
@@ -46,7 +51,29 @@ void GroupInfo::setDefaultType(const QString& modelType)
     m_defaultType = modelType;
 }
 
-QString GroupInfo::groupName() const { return m_groupName; }
+QString GroupInfo::groupName() const
+{
+    return m_groupName;
+}
+
+QStringList GroupInfo::types() const
+{
+    QStringList result;
+    for (auto& pair : m_info)
+        result.append(pair.m_modelType);
+
+    return result;
+}
+
+QStringList GroupInfo::labels() const
+{
+    QStringList result;
+    for (auto& pair : m_info)
+        result.append(pair.m_label);
+
+    return result;
+
+}
 
 bool GroupInfo::containsType(const QString& modelType) const
 {

--- a/GUI/coregui/Models/GroupInfo.cpp
+++ b/GUI/coregui/Models/GroupInfo.cpp
@@ -1,0 +1,58 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Models/GroupInfo.h
+//! @brief     Defines class GroupInfo
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
+//! @authors   Walter Van Herck, Joachim Wuttke
+//
+// ************************************************************************** //
+
+#include "GroupInfo.h"
+#include "GUIHelpers.h"
+
+GroupInfo::GroupInfo(const QString& groupName, bool is_sorted)
+    : m_groupName(groupName), is_sorted(is_sorted)
+{
+}
+
+void GroupInfo::add(const QString& modelType, const QString& label)
+{
+    if (groupName().isEmpty())
+        throw GUIHelpers::Error("GroupInfo::add() -> Error. Empty group name");
+
+    if (containsType(modelType))
+        throw GUIHelpers::Error("GroupInfo::add() -> Error. "
+                                "Model type '"  + modelType + "' already exists.");
+
+    m_info.push_back({modelType, label});
+
+    if (is_sorted)
+        std::sort(m_info.begin(), m_info.end(),
+                  [](TypeAndLabel a, TypeAndLabel b) { return a.m_modelType < b.m_modelType; });
+}
+
+void GroupInfo::setDefaultType(const QString& modelType)
+{
+    if (!containsType(modelType))
+        throw GUIHelpers::Error("GroupInfo::add() -> Error. No such type '" + modelType + "'");
+
+    m_defaultType = modelType;
+}
+
+QString GroupInfo::groupName() const { return m_groupName; }
+
+bool GroupInfo::containsType(const QString& modelType) const
+{
+    for (auto& pair : m_info)
+        if (modelType == pair.m_modelType)
+            return true;
+
+    return false;
+}

--- a/GUI/coregui/Models/GroupInfo.cpp
+++ b/GUI/coregui/Models/GroupInfo.cpp
@@ -7,10 +7,9 @@
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
-//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @copyright Forschungszentrum Jülich GmbH 2017
 //! @authors   Scientific Computing Group at MLZ Garching
-//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
-//! @authors   Walter Van Herck, Joachim Wuttke
+//! @authors   J. Burle, J. M. Fisher, M. Ganeva, D. Li, G. Pospelov, W. Van Herck, J. Wuttke
 //
 // ************************************************************************** //
 

--- a/GUI/coregui/Models/GroupInfo.h
+++ b/GUI/coregui/Models/GroupInfo.h
@@ -9,7 +9,7 @@
 //! @license   GNU General Public License v3 or higher (see COPYING)
 //! @copyright Forschungszentrum Jülich GmbH 2017
 //! @authors   Scientific Computing Group at MLZ Garching
-//! @authors   J. Burle, J. M. Fisher, M. Ganeva, D. Li, G. Pospelov, W. Van Herck, J. Wuttke
+//! @authors   J. Burle, J. M. Fisher, M. Ganeva, G. Pospelov, W. Van Herck, J. Wuttke
 //
 // ************************************************************************** //
 

--- a/GUI/coregui/Models/GroupInfo.h
+++ b/GUI/coregui/Models/GroupInfo.h
@@ -28,31 +28,31 @@
 class BA_CORE_API_ GroupInfo
 {
 public:
-    explicit GroupInfo(const QString& groupName = QString(), bool is_sorted = true);
+    explicit GroupInfo(const QString& groupType = QString(), bool is_sorted = true);
 
-    void add(const QString& modelType, const QString& label);
+    void add(const QString& itemType, const QString& itemLabel);
 
     QString defaultType() const;
     void setDefaultType(const QString& modelType);
 
-    QString groupName() const;
+    QString groupType() const;
 
-    QStringList types() const;
+    QStringList itemTypes() const;
 
-    QStringList labels() const;
+    QStringList itemLabels() const;
 
 private:
     struct TypeAndLabel {
-        QString m_modelType;
-        QString m_label;
+        QString m_itemType;
+        QString m_itemLabel;
     };
 
-    bool containsType(const QString& modelType) const;
+    bool containsType(const QString& itemType) const;
 
     //!< Default model type for given group (i.e. FFCylinder for formfactor group)
-    QString m_defaultType;
+    QString m_defaultItemType;
     //!< Unique group name for GroupInfoCatalogue
-    QString m_groupName;
+    QString m_groupType;
     //!< Info will be sorted if true, otherwise order of insertion will be preserved
     bool is_sorted;
     QVector<TypeAndLabel> m_info;

--- a/GUI/coregui/Models/GroupInfo.h
+++ b/GUI/coregui/Models/GroupInfo.h
@@ -20,6 +20,7 @@
 #include "WinDllMacros.h"
 #include <QString>
 #include <QVector>
+#include <QStringList>
 
 //! Defines info for GroupProperty, i.e. collection of model types, their labels and
 //! the name of default item's modelType.
@@ -31,9 +32,14 @@ public:
 
     void add(const QString& modelType, const QString& label);
 
+    QString defaultType() const;
     void setDefaultType(const QString& modelType);
 
     QString groupName() const;
+
+    QStringList types() const;
+
+    QStringList labels() const;
 
 private:
     struct TypeAndLabel {

--- a/GUI/coregui/Models/GroupInfo.h
+++ b/GUI/coregui/Models/GroupInfo.h
@@ -1,0 +1,55 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Models/GroupInfo.h
+//! @brief     Defines class GroupInfo
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
+//! @authors   Walter Van Herck, Joachim Wuttke
+//
+// ************************************************************************** //
+
+#ifndef GROUPINFO_H
+#define GROUPINFO_H
+
+#include "WinDllMacros.h"
+#include <QString>
+#include <QVector>
+
+//! Defines info for GroupProperty, i.e. collection of model types, their labels and
+//! the name of default item's modelType.
+
+class BA_CORE_API_ GroupInfo
+{
+public:
+    explicit GroupInfo(const QString& groupName = QString(), bool is_sorted = true);
+
+    void add(const QString& modelType, const QString& label);
+
+    void setDefaultType(const QString& modelType);
+
+    QString groupName() const;
+
+private:
+    struct TypeAndLabel {
+        QString m_modelType;
+        QString m_label;
+    };
+
+    bool containsType(const QString& modelType) const;
+
+    //!< Default model type for given group (i.e. FFCylinder for formfactor group)
+    QString m_defaultType;
+    //!< Unique group name for GroupInfoCatalogue
+    QString m_groupName;
+    //!< Info will be sorted if true, otherwise order of insertion will be preserved
+    bool is_sorted;
+    QVector<TypeAndLabel> m_info;
+};
+
+#endif

--- a/GUI/coregui/Models/GroupInfo.h
+++ b/GUI/coregui/Models/GroupInfo.h
@@ -7,10 +7,9 @@
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
-//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @copyright Forschungszentrum Jülich GmbH 2017
 //! @authors   Scientific Computing Group at MLZ Garching
-//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
-//! @authors   Walter Van Herck, Joachim Wuttke
+//! @authors   J. Burle, J. M. Fisher, M. Ganeva, D. Li, G. Pospelov, W. Van Herck, J. Wuttke
 //
 // ************************************************************************** //
 

--- a/GUI/coregui/Models/GroupInfoCatalogue.cpp
+++ b/GUI/coregui/Models/GroupInfoCatalogue.cpp
@@ -9,7 +9,7 @@
 //! @license   GNU General Public License v3 or higher (see COPYING)
 //! @copyright Forschungszentrum Jülich GmbH 2017
 //! @authors   Scientific Computing Group at MLZ Garching
-//! @authors   J. Burle, J. M. Fisher, M. Ganeva, D. Li, G. Pospelov, W. Van Herck, J. Wuttke
+//! @authors   J. Burle, J. M. Fisher, M. Ganeva, G. Pospelov, W. Van Herck, J. Wuttke
 //
 // ************************************************************************** //
 

--- a/GUI/coregui/Models/GroupInfoCatalogue.cpp
+++ b/GUI/coregui/Models/GroupInfoCatalogue.cpp
@@ -152,6 +152,16 @@ GroupInfoCatalogue::GroupInfoCatalogue()
     addInfo(info);
 }
 
+GroupInfo GroupInfoCatalogue::groupInfo(const QString& groupType) const
+{
+    for (auto& info : m_groups)
+        if (info.groupType() == groupType)
+            return info;
+
+    throw GUIHelpers::Error("GroupInfoCatalogue::groupInfo() -> Error. No such group '"+
+                            groupType+"'");
+}
+
 bool GroupInfoCatalogue::containsGroup(const QString& groupType) const
 {
     for (auto& info : m_groups)

--- a/GUI/coregui/Models/GroupInfoCatalogue.cpp
+++ b/GUI/coregui/Models/GroupInfoCatalogue.cpp
@@ -1,0 +1,171 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Models/GroupInfoCatalogue.h
+//! @brief     Implements class GroupInfoCatalogue
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
+//! @authors   Walter Van Herck, Joachim Wuttke
+//
+// ************************************************************************** //
+
+#include "GroupInfoCatalogue.h"
+#include "item_constants.h"
+#include "GUIHelpers.h"
+
+GroupInfoCatalogue::GroupInfoCatalogue()
+{
+    GroupInfo info(Constants::FormFactorGroup);
+    info.add(Constants::AnisoPyramidType, "Aniso Pyramid");
+    info.add(Constants::BoxType, "Box");
+    info.add(Constants::ConeType, "Cone");
+    info.add(Constants::Cone6Type, "Cone6");
+    info.add(Constants::CuboctahedronType, "Cuboctahedron");
+    info.add(Constants::CylinderType, "Cylinder");
+    info.add(Constants::DodecahedronType, "Dodecahedron");
+    info.add(Constants::EllipsoidalCylinderType, "Ellipsoidal Cylinder");
+    info.add(Constants::FullSphereType, "Full Sphere");
+    info.add(Constants::FullSpheroidType, "Full Spheroid");
+    info.add(Constants::HemiEllipsoidType, "Hemi Ellipsoid");
+    info.add(Constants::IcosahedronType, "Icosahedron");
+    info.add(Constants::Prism3Type, "Prism3");
+    info.add(Constants::Prism6Type, "Prism6");
+    info.add(Constants::PyramidType, "Pyramid");
+    info.add(Constants::Ripple1Type, "Ripple1");
+    info.add(Constants::Ripple2Type, "Ripple2");
+    info.add(Constants::TetrahedronType, "Tetrahedron");
+    info.add(Constants::TruncatedCubeType, "Truncated Cube");
+    info.add(Constants::TruncatedSphereType, "Truncated Sphere");
+    info.add(Constants::TruncatedSpheroidType, "Truncated Spheroid");
+    info.setDefaultType(Constants::CylinderType);
+    addInfo(info);
+
+    info = GroupInfo(Constants::RotationGroup);
+    info.add(Constants::XRotationType, "X axis Rotation");
+    info.add(Constants::YRotationType, "Y axis Rotation");
+    info.add(Constants::ZRotationType, "Z axis Rotation");
+    info.add(Constants::EulerRotationType, "Euler Rotation");
+    info.setDefaultType(Constants::ZRotationType);
+    addInfo(info);
+
+    info = GroupInfo(Constants::LayerRoughnessGroup);
+    info.add(Constants::LayerBasicRoughnessType, "Basic");
+    info.add(Constants::LayerZeroRoughnessType, "No");
+    info.setDefaultType(Constants::LayerZeroRoughnessType);
+    addInfo(info);
+
+    info = GroupInfo(Constants::DetectorGroup);
+    info.add(Constants::SphericalDetectorType, "Spherical detector");
+    info.add(Constants::RectangularDetectorType, "Rectangular detector");
+    info.setDefaultType(Constants::SphericalDetectorType);
+    addInfo(info);
+
+    info = GroupInfo(Constants::DistributionGroup);
+    info.add(Constants::DistributionGateType, "Gate distribution");
+    info.add(Constants::DistributionLorentzType, "Lorentz distribution");
+    info.add(Constants::DistributionGaussianType, "Gaussian distribution");
+    info.add(Constants::DistributionLogNormalType, "Log Normal distribution");
+    info.add(Constants::DistributionCosineType, "Cosine distribution");
+    info.setDefaultType(Constants::DistributionGaussianType);
+    addInfo(info);
+
+    info = GroupInfo(Constants::DistributionExtendedGroup);
+    info.add(Constants::DistributionNoneType, "None");
+    info.add(Constants::DistributionGateType, "Gate");
+    info.add(Constants::DistributionLorentzType, "Lorentz");
+    info.add(Constants::DistributionGaussianType, "Gaussian");
+    info.add(Constants::DistributionLogNormalType, "Log Normal");
+    info.add(Constants::DistributionCosineType, "Cosine");
+    info.setDefaultType(Constants::DistributionNoneType);
+    addInfo(info);
+
+    info = GroupInfo(Constants::FTDistribution1DGroup);
+    info.add(Constants::FTDistribution1DCauchyType, "Cauchy 1D");
+    info.add(Constants::FTDistribution1DGaussType, "Gauss 1D");
+    info.add(Constants::FTDistribution1DGateType, "Gate 1D");
+    info.add(Constants::FTDistribution1DTriangleType, "Triangle 1D");
+    info.add(Constants::FTDistribution1DCosineType, "Cosine 1D");
+    info.add(Constants::FTDistribution1DVoigtType, "Voigt 1D");
+    info.setDefaultType(Constants::FTDistribution1DCauchyType);
+    addInfo(info);
+
+    info = GroupInfo(Constants::FTDistribution2DGroup);
+    info.add(Constants::FTDistribution2DCauchyType, "Cauchy 2D");
+    info.add(Constants::FTDistribution2DGaussType, "Gauss 2D");
+    info.add(Constants::FTDistribution2DGateType, "Gate 2D");
+    info.add(Constants::FTDistribution2DConeType, "Cone 2D");
+    info.add(Constants::FTDistribution2DVoigtType, "Voigt 2D");
+    info.setDefaultType(Constants::FTDistribution2DCauchyType);
+    addInfo(info);
+
+    info = GroupInfo(Constants::FTDecayFunction1DGroup);
+    info.add(Constants::FTDecayFunction1DCauchyType, "Cauchy 1D");
+    info.add(Constants::FTDecayFunction1DGaussType, "Gauss 1D");
+    info.add(Constants::FTDecayFunction1DTriangleType, "Triangle 1D");
+    info.add(Constants::FTDecayFunction1DVoigtType, "Voigt 1D");
+    info.setDefaultType(Constants::FTDecayFunction1DCauchyType);
+    addInfo(info);
+
+    info = GroupInfo(Constants::FTDecayFunction2DGroup);
+    info.add(Constants::FTDecayFunction2DCauchyType, "Cauchy 2D");
+    info.add(Constants::FTDecayFunction2DGaussType, "Gauss 2D");
+    info.add(Constants::FTDecayFunction2DVoigtType, "Voigt 2D");
+    info.setDefaultType(Constants::FTDecayFunction2DCauchyType);
+    addInfo(info);
+
+    info = GroupInfo(Constants::LatticeGroup);
+    info.add(Constants::BasicLatticeType, "Basic");
+    info.add(Constants::SquareLatticeType, "Square");
+    info.add(Constants::HexagonalLatticeType, "Hexagonal");
+    info.setDefaultType(Constants::HexagonalLatticeType);
+    addInfo(info);
+
+    info = GroupInfo(Constants::ResolutionFunctionGroup);
+    info.add(Constants::ResolutionFunctionNoneType, "None");
+    info.add(Constants::ResolutionFunction2DGaussianType, "2D Gaussian");
+    info.setDefaultType(Constants::ResolutionFunctionNoneType);
+    addInfo(info);
+
+    info = GroupInfo(Constants::MinimizerLibraryGroup);
+    info.add(Constants::MinuitMinimizerType, "Minuit2");
+    info.add(Constants::GSLMultiMinimizerType, "GSL MultiMin");
+    info.add(Constants::GeneticMinimizerType, "TMVA Genetic");
+    info.add(Constants::GSLSimAnMinimizerType, "GSL Simulated Annealing");
+    info.add(Constants::GSLLMAMinimizerType, "GSL Levenberg-Marquardt");
+    info.add(Constants::TestMinimizerType, "Test minimizer");
+    info.setDefaultType(Constants::MinuitMinimizerType);
+    addInfo(info);
+
+    info = GroupInfo(Constants::RealLimitsGroup);
+    info.add(Constants::RealLimitsLimitlessType, "Unlimited");
+    info.add(Constants::RealLimitsPositiveType, "Positive");
+    info.add(Constants::RealLimitsNonnegativeType, "Nonnegative");
+    info.add(Constants::RealLimitsLowerLimitedType, "LowerLimited");
+    info.add(Constants::RealLimitsUpperLimitedType, "UpperLimited");
+    info.add(Constants::RealLimitsLimitedType, "Limited");
+    info.setDefaultType(Constants::RealLimitsLimitlessType);
+    addInfo(info);
+}
+
+bool GroupInfoCatalogue::containsGroup(const QString& groupName) const
+{
+    for (auto& info : m_groups)
+        if (info.groupName() == groupName)
+            return true;
+
+    return false;
+}
+
+void GroupInfoCatalogue::addInfo(const GroupInfo& info)
+{
+    if (containsGroup(info.groupName()))
+        throw GUIHelpers::Error("GroupInfoCatalogue::addInfo -> Error. Already exists '"
+                                + info.groupName() + "'");
+
+    m_groups.push_back(info);
+}

--- a/GUI/coregui/Models/GroupInfoCatalogue.cpp
+++ b/GUI/coregui/Models/GroupInfoCatalogue.cpp
@@ -152,10 +152,10 @@ GroupInfoCatalogue::GroupInfoCatalogue()
     addInfo(info);
 }
 
-bool GroupInfoCatalogue::containsGroup(const QString& groupName) const
+bool GroupInfoCatalogue::containsGroup(const QString& groupType) const
 {
     for (auto& info : m_groups)
-        if (info.groupName() == groupName)
+        if (info.groupType() == groupType)
             return true;
 
     return false;
@@ -163,9 +163,9 @@ bool GroupInfoCatalogue::containsGroup(const QString& groupName) const
 
 void GroupInfoCatalogue::addInfo(const GroupInfo& info)
 {
-    if (containsGroup(info.groupName()))
+    if (containsGroup(info.groupType()))
         throw GUIHelpers::Error("GroupInfoCatalogue::addInfo -> Error. Already exists '"
-                                + info.groupName() + "'");
+                                + info.groupType() + "'");
 
     m_groups.push_back(info);
 }

--- a/GUI/coregui/Models/GroupInfoCatalogue.cpp
+++ b/GUI/coregui/Models/GroupInfoCatalogue.cpp
@@ -7,10 +7,9 @@
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
-//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @copyright Forschungszentrum Jülich GmbH 2017
 //! @authors   Scientific Computing Group at MLZ Garching
-//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
-//! @authors   Walter Van Herck, Joachim Wuttke
+//! @authors   J. Burle, J. M. Fisher, M. Ganeva, D. Li, G. Pospelov, W. Van Herck, J. Wuttke
 //
 // ************************************************************************** //
 

--- a/GUI/coregui/Models/GroupInfoCatalogue.h
+++ b/GUI/coregui/Models/GroupInfoCatalogue.h
@@ -26,8 +26,11 @@ class BA_CORE_API_ GroupInfoCatalogue
 public:
     GroupInfoCatalogue();
 
-private:
+    GroupInfo groupInfo(const QString& groupType) const;
+
     bool containsGroup(const QString& groupType) const;
+
+private:
     void addInfo(const GroupInfo& info);
     QVector<GroupInfo> m_groups;
 };

--- a/GUI/coregui/Models/GroupInfoCatalogue.h
+++ b/GUI/coregui/Models/GroupInfoCatalogue.h
@@ -9,7 +9,7 @@
 //! @license   GNU General Public License v3 or higher (see COPYING)
 //! @copyright Forschungszentrum Jülich GmbH 2017
 //! @authors   Scientific Computing Group at MLZ Garching
-//! @authors   J. Burle, J. M. Fisher, M. Ganeva, D. Li, G. Pospelov, W. Van Herck, J. Wuttke
+//! @authors   J. Burle, J. M. Fisher, M. Ganeva, G. Pospelov, W. Van Herck, J. Wuttke
 //
 // ************************************************************************** //
 

--- a/GUI/coregui/Models/GroupInfoCatalogue.h
+++ b/GUI/coregui/Models/GroupInfoCatalogue.h
@@ -27,7 +27,7 @@ public:
     GroupInfoCatalogue();
 
 private:
-    bool containsGroup(const QString& groupName) const;
+    bool containsGroup(const QString& groupType) const;
     void addInfo(const GroupInfo& info);
     QVector<GroupInfo> m_groups;
 };

--- a/GUI/coregui/Models/GroupInfoCatalogue.h
+++ b/GUI/coregui/Models/GroupInfoCatalogue.h
@@ -1,0 +1,35 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Models/GroupInfoCatalogue.h
+//! @brief     Defines class GroupInfoCatalogue
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
+//! @authors   Walter Van Herck, Joachim Wuttke
+//
+// ************************************************************************** //
+
+#ifndef GROUPINFOCATALOGUE_H
+#define GROUPINFOCATALOGUE_H
+
+#include "GroupInfo.h"
+
+//! Catalogue to hold info for GroupProperty creation.
+
+class BA_CORE_API_ GroupInfoCatalogue
+{
+public:
+    GroupInfoCatalogue();
+
+private:
+    bool containsGroup(const QString& groupName) const;
+    void addInfo(const GroupInfo& info);
+    QVector<GroupInfo> m_groups;
+};
+
+#endif // GROUPINFOCATALOGUE_H

--- a/GUI/coregui/Models/GroupInfoCatalogue.h
+++ b/GUI/coregui/Models/GroupInfoCatalogue.h
@@ -7,10 +7,9 @@
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
-//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @copyright Forschungszentrum Jülich GmbH 2017
 //! @authors   Scientific Computing Group at MLZ Garching
-//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
-//! @authors   Walter Van Herck, Joachim Wuttke
+//! @authors   J. Burle, J. M. Fisher, M. Ganeva, D. Li, G. Pospelov, W. Van Herck, J. Wuttke
 //
 // ************************************************************************** //
 

--- a/GUI/coregui/Models/GroupProperty.cpp
+++ b/GUI/coregui/Models/GroupProperty.cpp
@@ -66,40 +66,29 @@ void GroupProperty::setCurrentType(const QString& type)
     }
 }
 
-QString GroupProperty::getCurrentLabel() const
-{
-    auto labels = getLabels();
-    int ind = index();
-    return labels.at(ind);
-}
-
-QStringList GroupProperty::getTypes() const
-{
-    return m_groupInfo.itemTypes();
-}
-
-QStringList GroupProperty::getLabels() const
-{
-    return m_groupInfo.itemLabels();
-}
-
-int GroupProperty::index() const
+int GroupProperty::currentIndex() const
 {
     return toIndex(m_current_type);
 }
 
-int GroupProperty::toIndex(const QString& type) const
+void GroupProperty::setCurrentIndex(int index)
 {
-    return getTypes().indexOf(type);
+    setCurrentType(toString(index));
 }
 
-QString GroupProperty::toString(int index) const
+QString GroupProperty::currentLabel() const
 {
-    QStringList name_list = getTypes();
-    if (index < 0 || index >= name_list.size())
-        return QString();
+    return itemLabels().at(currentIndex());
+}
 
-    return name_list[index];
+QStringList GroupProperty::itemTypes() const
+{
+    return m_groupInfo.itemTypes();
+}
+
+QStringList GroupProperty::itemLabels() const
+{
+    return m_groupInfo.itemLabels();
 }
 
 void GroupProperty::setGroupInfo(GroupInfo groupInfo)
@@ -111,4 +100,14 @@ void GroupProperty::setGroupInfo(GroupInfo groupInfo)
 SessionItem* GroupProperty::createCorrespondingItem()
 {
     return ItemFactory::createItem(currentType());
+}
+
+int GroupProperty::toIndex(const QString& type) const
+{
+    return itemTypes().indexOf(type);
+}
+
+QString GroupProperty::toString(int index) const
+{
+    return itemTypes().at(index);
 }

--- a/GUI/coregui/Models/GroupProperty.cpp
+++ b/GUI/coregui/Models/GroupProperty.cpp
@@ -102,10 +102,10 @@ QString GroupProperty::toString(int index) const
     return name_list[index];
 }
 
-void GroupProperty::setGroupInfo(const GroupInfo& groupInfo)
+void GroupProperty::setGroupInfo(GroupInfo groupInfo)
 {
-    m_groupInfo = groupInfo;
-    setCurrentType(m_groupInfo.itemTypes().front());
+    m_groupInfo = std::move(groupInfo);
+    setCurrentType(m_groupInfo.defaultType());
 }
 
 SessionItem* GroupProperty::createCorrespondingItem()

--- a/GUI/coregui/Models/GroupProperty.cpp
+++ b/GUI/coregui/Models/GroupProperty.cpp
@@ -17,8 +17,8 @@
 #include "GroupProperty.h"
 #include "ItemFactory.h"
 
-GroupProperty::GroupProperty(QString group_name)
-    : m_group_name(std::move(group_name)), m_groupItem(0)
+GroupProperty::GroupProperty()
+    : m_groupItem(nullptr)
 {
 }
 

--- a/GUI/coregui/Models/GroupProperty.cpp
+++ b/GUI/coregui/Models/GroupProperty.cpp
@@ -68,25 +68,19 @@ void GroupProperty::setCurrentType(const QString& type)
 
 QString GroupProperty::getCurrentLabel() const
 {
-    return m_type_label_map.at(m_current_type);
+    auto labels = getLabels();
+    int ind = index();
+    return labels.at(ind);
 }
 
 QStringList GroupProperty::getTypes() const
 {
-    QStringList result;
-    for (const auto& key_value_pair : m_type_label_map)
-        result << key_value_pair.first;
-
-    return result;
+    return m_groupInfo.itemTypes();
 }
 
 QStringList GroupProperty::getLabels() const
 {
-    QStringList result;
-    for (const auto& key_value_pair : m_type_label_map)
-        result << key_value_pair.second;
-
-    return result;
+    return m_groupInfo.itemLabels();
 }
 
 int GroupProperty::index() const
@@ -96,12 +90,7 @@ int GroupProperty::index() const
 
 int GroupProperty::toIndex(const QString& type) const
 {
-    QStringList name_list = getTypes();
-    for (int i = 0; i < name_list.size(); ++i) {
-        if (type == name_list[i])
-            return i;
-    }
-    return -1;
+    return getTypes().indexOf(type);
 }
 
 QString GroupProperty::toString(int index) const
@@ -113,10 +102,10 @@ QString GroupProperty::toString(int index) const
     return name_list[index];
 }
 
-void GroupProperty::setGroupMap(std::map<QString, QString> group_map)
+void GroupProperty::setGroupInfo(const GroupInfo& groupInfo)
 {
-    m_type_label_map = std::move(group_map);
-    setCurrentType(m_type_label_map.begin()->first);
+    m_groupInfo = groupInfo;
+    setCurrentType(m_groupInfo.itemTypes().front());
 }
 
 SessionItem* GroupProperty::createCorrespondingItem()

--- a/GUI/coregui/Models/GroupProperty.h
+++ b/GUI/coregui/Models/GroupProperty.h
@@ -18,6 +18,7 @@
 #define GROUPPROPERTY_H
 
 #include "WinDllMacros.h"
+#include "GroupInfo.h"
 #include <QSharedPointer>
 #include <QStringList>
 
@@ -49,13 +50,13 @@ public:
 
 private:
     GroupProperty(QString group_name);
-    void setGroupMap(std::map<QString, QString> group_map);
+    void setGroupInfo(const GroupInfo& groupInfo);
     SessionItem* createCorrespondingItem();
 
     QString m_group_name;
     SessionItem* m_groupItem;
     QString m_current_type;
-    std::map<QString, QString> m_type_label_map;
+    GroupInfo m_groupInfo;
 };
 
 typedef QSharedPointer<GroupProperty> GroupProperty_t;

--- a/GUI/coregui/Models/GroupProperty.h
+++ b/GUI/coregui/Models/GroupProperty.h
@@ -17,16 +17,15 @@
 #ifndef GROUPPROPERTY_H
 #define GROUPPROPERTY_H
 
-#include "WinDllMacros.h"
 #include "GroupInfo.h"
 #include <QSharedPointer>
 #include <QStringList>
 
 class SessionItem;
 
-//! The GroupProperty class represents a composition of the basic properties
-//! corresponding to a SessionItem object.
+//! Provides logic for manipulating items belonging to GroupItem parent.
 //! Its construction is handled by a GroupPropertyRegistry object.
+
 class BA_CORE_API_ GroupProperty
 {
 public:
@@ -39,19 +38,21 @@ public:
     QString currentType() const;
     void setCurrentType(const QString& type);
 
-    QString getCurrentLabel() const;
+    int currentIndex() const;
+    void setCurrentIndex(int index);
 
-    QStringList getTypes() const;
-    QStringList getLabels() const;
+    QString currentLabel() const;
 
-    int index() const;
-    int toIndex(const QString& type) const;
-    QString toString(int index) const;
+    QStringList itemTypes() const;
+    QStringList itemLabels() const;
 
 private:
     GroupProperty();
+
     void setGroupInfo(GroupInfo groupInfo);
     SessionItem* createCorrespondingItem();
+    int toIndex(const QString& type) const;
+    QString toString(int currentIndex) const;
 
     SessionItem* m_groupItem;
     QString m_current_type;

--- a/GUI/coregui/Models/GroupProperty.h
+++ b/GUI/coregui/Models/GroupProperty.h
@@ -50,7 +50,7 @@ public:
 
 private:
     GroupProperty(QString group_name);
-    void setGroupInfo(const GroupInfo& groupInfo);
+    void setGroupInfo(GroupInfo groupInfo);
     SessionItem* createCorrespondingItem();
 
     QString m_group_name;

--- a/GUI/coregui/Models/GroupProperty.h
+++ b/GUI/coregui/Models/GroupProperty.h
@@ -30,6 +30,8 @@ class SessionItem;
 class BA_CORE_API_ GroupProperty
 {
 public:
+    friend class GroupPropertyRegistry;
+
     void setGroupItem(SessionItem* groupItem);
 
     SessionItem* currentItem();
@@ -46,14 +48,11 @@ public:
     int toIndex(const QString& type) const;
     QString toString(int index) const;
 
-    friend class GroupPropertyRegistry;
-
 private:
-    GroupProperty(QString group_name);
+    GroupProperty();
     void setGroupInfo(GroupInfo groupInfo);
     SessionItem* createCorrespondingItem();
 
-    QString m_group_name;
     SessionItem* m_groupItem;
     QString m_current_type;
     GroupInfo m_groupInfo;

--- a/GUI/coregui/Models/GroupPropertyRegistry.cpp
+++ b/GUI/coregui/Models/GroupPropertyRegistry.cpp
@@ -15,152 +15,23 @@
 // ************************************************************************** //
 
 #include "GroupPropertyRegistry.h"
+#include "GroupInfoCatalogue.h"
 
-namespace
+bool GroupPropertyRegistry::isValidGroup(const QString& group_type)
 {
-
-// Correspondance of SessionItem's types to their labels
-GroupPropertyRegistry::SelectableGroupMap_t initializeSelectableGroupMap()
-{
-    GroupPropertyRegistry::SelectableGroupMap_t result;
-
-    std::map<QString, QString> formfactors;
-    formfactors[Constants::AnisoPyramidType] = "Aniso Pyramid";
-    formfactors[Constants::BoxType] = "Box";
-    formfactors[Constants::ConeType] = "Cone";
-    formfactors[Constants::Cone6Type] = "Cone6";
-    formfactors[Constants::CuboctahedronType] = "Cuboctahedron";
-    formfactors[Constants::CylinderType] = "Cylinder";
-    formfactors[Constants::DodecahedronType] = "Dodecahedron";
-    formfactors[Constants::EllipsoidalCylinderType] = "Ellipsoidal Cylinder";
-    formfactors[Constants::FullSphereType] = "Full Sphere";
-    formfactors[Constants::FullSpheroidType] = "Full Spheroid";
-    formfactors[Constants::HemiEllipsoidType] = "Hemi Ellipsoid";
-    formfactors[Constants::IcosahedronType] = "Icosahedron";
-    formfactors[Constants::Prism3Type] = "Prism3";
-    formfactors[Constants::Prism6Type] = "Prism6";
-    formfactors[Constants::PyramidType] = "Pyramid";
-    formfactors[Constants::Ripple1Type] = "Ripple1";
-    formfactors[Constants::Ripple2Type] = "Ripple2";
-    formfactors[Constants::TetrahedronType] = "Tetrahedron";
-    formfactors[Constants::TruncatedCubeType] = "Truncated Cube";
-    formfactors[Constants::TruncatedSphereType] = "Truncated Sphere";
-    formfactors[Constants::TruncatedSpheroidType] = "Truncated Spheroid";
-    result[Constants::FormFactorGroup] = formfactors;
-
-    std::map<QString, QString> rotations;
-    rotations[Constants::XRotationType] = "X axis Rotation";
-    rotations[Constants::YRotationType] = "Y axis Rotation";
-    rotations[Constants::ZRotationType] = "Z axis Rotation";
-    rotations[Constants::EulerRotationType] = "Euler Rotation";
-    result[Constants::RotationGroup] = rotations;
-
-    std::map<QString, QString> roughnesses;
-    roughnesses[Constants::LayerBasicRoughnessType] = "Basic";
-    roughnesses[Constants::LayerZeroRoughnessType] = "No";
-    result[Constants::LayerRoughnessGroup] = roughnesses;
-
-    std::map<QString, QString> detectors;
-    detectors[Constants::SphericalDetectorType] = "Spherical detector";
-    detectors[Constants::RectangularDetectorType] = "Rectangular detector";
-    result[Constants::DetectorGroup] = detectors;
-
-    std::map<QString, QString> distributions;
-    distributions[Constants::DistributionGateType] = "Gate distribution";
-    distributions[Constants::DistributionLorentzType] = "Lorentz distribution";
-    distributions[Constants::DistributionGaussianType] = "Gaussian distribution";
-    distributions[Constants::DistributionLogNormalType] = "Log Normal distribution";
-    distributions[Constants::DistributionCosineType] = "Cosine distribution";
-    result[Constants::DistributionGroup] = distributions;
-
-    std::map<QString, QString> distributions_ext;
-    distributions_ext[Constants::DistributionNoneType] = "None";
-    distributions_ext[Constants::DistributionGateType] = "Gate";
-    distributions_ext[Constants::DistributionLorentzType] = "Lorentz";
-    distributions_ext[Constants::DistributionGaussianType] = "Gaussian";
-    distributions_ext[Constants::DistributionLogNormalType] = "Log Normal";
-    distributions_ext[Constants::DistributionCosineType] = "Cosine";
-    result[Constants::DistributionExtendedGroup] = distributions_ext;
-
-    std::map<QString, QString> pdfs_1d;
-    pdfs_1d[Constants::FTDistribution1DCauchyType] = "Cauchy 1D";
-    pdfs_1d[Constants::FTDistribution1DGaussType] = "Gauss 1D";
-    pdfs_1d[Constants::FTDistribution1DGateType] = "Gate 1D";
-    pdfs_1d[Constants::FTDistribution1DTriangleType] = "Triangle 1D";
-    pdfs_1d[Constants::FTDistribution1DCosineType] = "Cosine 1D";
-    pdfs_1d[Constants::FTDistribution1DVoigtType] = "Voigt 1D";
-    result[Constants::FTDistribution1DGroup] = pdfs_1d;
-
-    std::map<QString, QString> pdfs_2d;
-    pdfs_2d[Constants::FTDistribution2DCauchyType] = "Cauchy 2D";
-    pdfs_2d[Constants::FTDistribution2DGaussType] = "Gauss 2D";
-    pdfs_2d[Constants::FTDistribution2DGateType] = "Gate 2D";
-    pdfs_2d[Constants::FTDistribution2DConeType] = "Cone 2D";
-    pdfs_2d[Constants::FTDistribution2DVoigtType] = "Voigt 2D";
-    result[Constants::FTDistribution2DGroup] = pdfs_2d;
-
-    std::map<QString, QString> pdecay_1d;
-    pdecay_1d[Constants::FTDecayFunction1DCauchyType] = "Cauchy 1D";
-    pdecay_1d[Constants::FTDecayFunction1DGaussType] = "Gauss 1D";
-    pdecay_1d[Constants::FTDecayFunction1DTriangleType] = "Triangle 1D";
-    pdecay_1d[Constants::FTDecayFunction1DVoigtType] = "Voigt 1D";
-    result[Constants::FTDecayFunction1DGroup] = pdecay_1d;
-
-    std::map<QString, QString> pdecay_2d;
-    pdecay_2d[Constants::FTDecayFunction2DCauchyType] = "Cauchy 2D";
-    pdecay_2d[Constants::FTDecayFunction2DGaussType] = "Gauss 2D";
-    pdecay_2d[Constants::FTDecayFunction2DVoigtType] = "Voigt 2D";
-    result[Constants::FTDecayFunction2DGroup] = pdecay_2d;
-
-    std::map<QString, QString> lattices;
-    lattices[Constants::BasicLatticeType] = "Basic";
-    lattices[Constants::SquareLatticeType] = "Square";
-    lattices[Constants::HexagonalLatticeType] = "Hexagonal";
-    result[Constants::LatticeGroup] = lattices;
-
-    std::map<QString, QString> resolution_functions;
-    resolution_functions[Constants::ResolutionFunctionNoneType] = "None";
-    resolution_functions[Constants::ResolutionFunction2DGaussianType] = "2D Gaussian";
-    result[Constants::ResolutionFunctionGroup] = resolution_functions;
-
-    std::map<QString, QString> minimizers;
-    minimizers[Constants::MinuitMinimizerType] = "Minuit2";
-    minimizers[Constants::GSLMultiMinimizerType] = "GSL MultiMin";
-    minimizers[Constants::GeneticMinimizerType] = "TMVA Genetic";
-    minimizers[Constants::GSLSimAnMinimizerType] = "GSL Simulated Annealing";
-    minimizers[Constants::GSLLMAMinimizerType] = "GSL Levenberg-Marquardt";
-    minimizers[Constants::TestMinimizerType] = "Test minimizer";
-    result[Constants::MinimizerLibraryGroup] = minimizers;
-
-    std::map<QString, QString> limits;
-    limits[Constants::RealLimitsLimitlessType] = "Unlimited";
-    limits[Constants::RealLimitsPositiveType] = "Positive";
-    limits[Constants::RealLimitsNonnegativeType] = "Nonnegative";
-    limits[Constants::RealLimitsLowerLimitedType] = "LowerLimited";
-    limits[Constants::RealLimitsUpperLimitedType] = "UpperLimited";
-    limits[Constants::RealLimitsLimitedType] = "Limited";
-    result[Constants::RealLimitsGroup] = limits;
-
-    return result;
-}
+    return catalogue().containsGroup(group_type);
 }
 
-GroupPropertyRegistry::SelectableGroupMap_t GroupPropertyRegistry::m_selectable_group_map
-    = initializeSelectableGroupMap();
-
-bool GroupPropertyRegistry::isValidGroup(const QString &group_type)
+GroupProperty_t GroupPropertyRegistry::createGroupProperty(const QString& group_name,
+                                                           const Constants::ModelType& group_type)
 {
-    auto it = m_selectable_group_map.find(group_type);
-    return it==m_selectable_group_map.end() ? false : true;
-}
-
-GroupProperty_t
-GroupPropertyRegistry::createGroupProperty(const QString &group_name,
-                                           const Constants::ModelType &group_type)
-{
-    Q_ASSERT(isValidGroup(group_type));
     GroupProperty_t result(new GroupProperty(group_name));
-    result->setGroupMap(m_selectable_group_map[group_type]);
-
+    result->setGroupInfo(catalogue().groupInfo(group_type));
     return result;
+}
+
+const GroupInfoCatalogue& GroupPropertyRegistry::catalogue()
+{
+    static GroupInfoCatalogue s_catalogue = GroupInfoCatalogue();
+    return s_catalogue;
 }

--- a/GUI/coregui/Models/GroupPropertyRegistry.cpp
+++ b/GUI/coregui/Models/GroupPropertyRegistry.cpp
@@ -22,10 +22,9 @@ bool GroupPropertyRegistry::isValidGroup(const QString& group_type)
     return catalogue().containsGroup(group_type);
 }
 
-GroupProperty_t GroupPropertyRegistry::createGroupProperty(const QString& group_name,
-                                                           const Constants::ModelType& group_type)
+GroupProperty_t GroupPropertyRegistry::createGroupProperty(const Constants::ModelType& group_type)
 {
-    GroupProperty_t result(new GroupProperty(group_name));
+    GroupProperty_t result(new GroupProperty);
     result->setGroupInfo(catalogue().groupInfo(group_type));
     return result;
 }

--- a/GUI/coregui/Models/GroupPropertyRegistry.h
+++ b/GUI/coregui/Models/GroupPropertyRegistry.h
@@ -18,27 +18,21 @@
 #define GROUPPROPERTYREGISTRY_H
 
 #include "GroupProperty.h"
+#include "GroupInfoCatalogue.h"
 #include "item_constants.h"
 
+//! Constructs GroupProperty objects according to the given group type.
 
-
-//! The GroupPropertyRegistry is responsible for constructing GroupProperty objects
-//! according to the given name of the group.
 class BA_CORE_API_ GroupPropertyRegistry
 {
 public:
-    using SelectableGroupMap_t = std::map<QString, std::map<QString, QString>>;
+    static bool isValidGroup(const QString& group_type);
 
-    static bool isValidGroup(const QString &group_type);
-
-    static GroupProperty_t createGroupProperty(const QString &group_name,
-            const Constants::ModelType &group_type);
+    static GroupProperty_t createGroupProperty(const QString& group_name,
+                                               const Constants::ModelType& group_type);
 
 private:
-    static SelectableGroupMap_t m_selectable_group_map;
-    //!< Contains correspondance of selectable group names to their content,
-    //!< which is a map between item types and item labels
+    static const GroupInfoCatalogue& catalogue();
 };
-
 
 #endif // GROUPPROPERTYREGISTRY_H

--- a/GUI/coregui/Models/GroupPropertyRegistry.h
+++ b/GUI/coregui/Models/GroupPropertyRegistry.h
@@ -28,8 +28,7 @@ class BA_CORE_API_ GroupPropertyRegistry
 public:
     static bool isValidGroup(const QString& group_type);
 
-    static GroupProperty_t createGroupProperty(const QString& group_name,
-                                               const Constants::ModelType& group_type);
+    static GroupProperty_t createGroupProperty(const Constants::ModelType& group_type);
 
 private:
     static const GroupInfoCatalogue& catalogue();

--- a/GUI/coregui/Models/InstrumentItem.cpp
+++ b/GUI/coregui/Models/InstrumentItem.cpp
@@ -36,7 +36,6 @@ InstrumentItem::InstrumentItem()
     addGroupProperty(P_BEAM, Constants::BeamType);
 
     addGroupProperty(P_DETECTOR, Constants::DetectorGroup);
-    setGroupProperty(P_DETECTOR, Constants::SphericalDetectorType);
 
     setDefaultTag(P_DETECTOR);
 }

--- a/GUI/coregui/Models/InstrumentItem.cpp
+++ b/GUI/coregui/Models/InstrumentItem.cpp
@@ -47,9 +47,7 @@ BeamItem *InstrumentItem::beamItem() const
 
 DetectorItem* InstrumentItem::detectorItem() const
 {
-    DetectorItem* result = dynamic_cast<DetectorItem*>(getGroupItem(P_DETECTOR));
-    Q_ASSERT(result);
-    return result;
+    return &groupItem<DetectorItem>(P_DETECTOR);
 }
 
 GroupItem* InstrumentItem::detectorGroup()

--- a/GUI/coregui/Models/InterferenceFunctionItems.cpp
+++ b/GUI/coregui/Models/InterferenceFunctionItems.cpp
@@ -68,8 +68,8 @@ InterferenceFunctionRadialParaCrystalItem::createInterferenceFunction() const
     result->setDomainSize(getItemValue(P_DOMAIN_SIZE).toDouble());
     result->setKappa(getItemValue(P_KAPPA).toDouble());
 
-    auto pdfItem = dynamic_cast<FTDistribution1DItem*>(getGroupItem(P_PDF));
-    result->setProbabilityDistribution(*pdfItem->createFTDistribution());
+    auto& pdfItem = groupItem<FTDistribution1DItem>(P_PDF);
+    result->setProbabilityDistribution(*pdfItem.createFTDistribution());
     return std::move(result);
 }
 
@@ -121,23 +121,20 @@ InterferenceFunction2DParaCrystalItem::InterferenceFunction2DParaCrystalItem()
 std::unique_ptr<IInterferenceFunction>
 InterferenceFunction2DParaCrystalItem::createInterferenceFunction() const
 {
-    auto latticeItem = dynamic_cast<Lattice2DItem*>(
-        getGroupItem(InterferenceFunction2DLatticeItem::P_LATTICE_TYPE));
+    auto& latticeItem = groupItem<Lattice2DItem>(InterferenceFunction2DLatticeItem::P_LATTICE_TYPE);
 
     std::unique_ptr<InterferenceFunction2DParaCrystal> result(
-        new InterferenceFunction2DParaCrystal(*latticeItem->createLattice()));
+        new InterferenceFunction2DParaCrystal(*latticeItem.createLattice()));
 
     result->setDampingLength(getItemValue(P_DAMPING_LENGTH).toDouble());
     result->setDomainSizes(getItemValue(P_DOMAIN_SIZE1).toDouble(),
                            getItemValue(P_DOMAIN_SIZE2).toDouble());
     result->setIntegrationOverXi(getItemValue(P_XI_INTEGRATION).toBool());
 
-    auto pdf1Item = dynamic_cast<FTDistribution2DItem*>(
-        getGroupItem(InterferenceFunction2DParaCrystalItem::P_PDF1));
-    auto pdf2Item = dynamic_cast<FTDistribution2DItem*>(
-        getGroupItem(InterferenceFunction2DParaCrystalItem::P_PDF2));
-    result->setProbabilityDistributions(*pdf1Item->createFTDistribution(),
-                                        *pdf2Item->createFTDistribution());
+    auto& pdf1Item = groupItem<FTDistribution2DItem>(InterferenceFunction2DParaCrystalItem::P_PDF1);
+    auto& pdf2Item = groupItem<FTDistribution2DItem>(InterferenceFunction2DParaCrystalItem::P_PDF2);
+    result->setProbabilityDistributions(*pdf1Item.createFTDistribution(),
+                                        *pdf2Item.createFTDistribution());
 
     return std::move(result);
 }
@@ -217,12 +214,12 @@ InterferenceFunction2DLatticeItem::InterferenceFunction2DLatticeItem()
 std::unique_ptr<IInterferenceFunction>
 InterferenceFunction2DLatticeItem::createInterferenceFunction() const
 {
-    auto latticeItem = dynamic_cast<Lattice2DItem*>(getGroupItem(P_LATTICE_TYPE));
+    auto& latticeItem = groupItem<Lattice2DItem>(P_LATTICE_TYPE);
     std::unique_ptr<InterferenceFunction2DLattice> result(
-        new InterferenceFunction2DLattice(*latticeItem->createLattice()));
+        new InterferenceFunction2DLattice(*latticeItem.createLattice()));
 
-    auto pdfItem = dynamic_cast<FTDecayFunction2DItem*>(getGroupItem(P_DECAY_FUNCTION));
-    result->setDecayFunction(*pdfItem->createFTDecayFunction());
+    auto& pdfItem = groupItem<FTDecayFunction2DItem>(P_DECAY_FUNCTION);
+    result->setDecayFunction(*pdfItem.createFTDecayFunction());
 
     return std::move(result);
 }

--- a/GUI/coregui/Models/LayerItem.cpp
+++ b/GUI/coregui/Models/LayerItem.cpp
@@ -31,7 +31,6 @@ LayerItem::LayerItem()
     addProperty(P_MATERIAL, MaterialUtils::getDefaultMaterialProperty().getVariant());
 
     addGroupProperty(P_ROUGHNESS, Constants::LayerRoughnessGroup);
-    setGroupProperty(P_ROUGHNESS, Constants::LayerZeroRoughnessType);
     registerTag(T_LAYOUTS, 0, -1, QStringList() << Constants::ParticleLayoutType);
     setDefaultTag(T_LAYOUTS);
 }

--- a/GUI/coregui/Models/MinimizerItem.cpp
+++ b/GUI/coregui/Models/MinimizerItem.cpp
@@ -38,7 +38,6 @@ MinimizerContainerItem::MinimizerContainerItem() : MinimizerItem(Constants::Mini
 {
     addGroupProperty(P_MINIMIZERS, Constants::MinimizerLibraryGroup)
         ->setToolTip(QStringLiteral("Minimizer library"));
-    setGroupProperty(P_MINIMIZERS, Constants::MinuitMinimizerType);
 }
 
 std::unique_ptr<IMinimizer> MinimizerContainerItem::createMinimizer() const

--- a/GUI/coregui/Models/MinimizerItem.cpp
+++ b/GUI/coregui/Models/MinimizerItem.cpp
@@ -42,9 +42,7 @@ MinimizerContainerItem::MinimizerContainerItem() : MinimizerItem(Constants::Mini
 
 std::unique_ptr<IMinimizer> MinimizerContainerItem::createMinimizer() const
 {
-    auto minimizer = static_cast<MinimizerItem *>(getGroupItem(P_MINIMIZERS));
-    Q_ASSERT(minimizer);
-    return minimizer->createMinimizer();
+    return groupItem<MinimizerItem>(P_MINIMIZERS).createMinimizer();
 }
 
 // ----------------------------------------------------------------------------

--- a/GUI/coregui/Models/ParticleDistributionItem.cpp
+++ b/GUI/coregui/Models/ParticleDistributionItem.cpp
@@ -72,18 +72,15 @@ std::unique_ptr<ParticleDistribution> ParticleDistributionItem::createParticleDi
     if (!P_particle)
         throw GUIHelpers::Error("DomainObjectBuilder::buildParticleDistribution()"
                                 " -> Error! No correct particle defined");
-    auto distr_item = dynamic_cast<DistributionItem*>(
-                getGroupItem(ParticleDistributionItem::P_DISTRIBUTION));
-    Q_ASSERT(distr_item);
+    auto& distr_item = groupItem<DistributionItem>(ParticleDistributionItem::P_DISTRIBUTION);
 
     RealLimits limits = RealLimits::limitless();
-    if(distr_item->isTag(DistributionItem::P_LIMITS)) {
-        auto limitsItem = dynamic_cast<RealLimitsItem*>(
-                    distr_item->getGroupItem(DistributionItem::P_LIMITS));
-        limits = limitsItem->createRealLimits();
+    if(distr_item.isTag(DistributionItem::P_LIMITS)) {
+        auto& limitsItem = distr_item.groupItem<RealLimitsItem>(DistributionItem::P_LIMITS);
+        limits = limitsItem.createRealLimits();
     }
 
-    auto P_distribution = distr_item->createDistribution();
+    auto P_distribution = distr_item.createDistribution();
 
     auto prop
         = getItemValue(ParticleDistributionItem::P_DISTRIBUTED_PARAMETER).value<ComboProperty>();
@@ -92,8 +89,8 @@ std::unique_ptr<ParticleDistribution> ParticleDistributionItem::createParticleDi
     std::string domain_par
         = ParameterTreeUtils::parameterNameToDomainName(par_name, childParticle()).toStdString();
 
-    int nbr_samples = distr_item->getItemValue(DistributionItem::P_NUMBER_OF_SAMPLES).toInt();
-    double sigma_factor = distr_item->getItemValue(DistributionItem::P_SIGMA_FACTOR).toDouble();
+    int nbr_samples = distr_item.getItemValue(DistributionItem::P_NUMBER_OF_SAMPLES).toInt();
+    double sigma_factor = distr_item.getItemValue(DistributionItem::P_SIGMA_FACTOR).toDouble();
     ParameterDistribution par_distr(domain_par, *P_distribution, nbr_samples, sigma_factor, limits);
     auto result = GUIHelpers::make_unique<ParticleDistribution>(*P_particle, par_distr);
     double abundance = getItemValue(ParticleItem::P_ABUNDANCE).toDouble();

--- a/GUI/coregui/Models/ParticleItem.cpp
+++ b/GUI/coregui/Models/ParticleItem.cpp
@@ -80,10 +80,8 @@ std::unique_ptr<Particle> ParticleItem::createParticle() const
     double abundance = getItemValue(ParticleItem::P_ABUNDANCE).toDouble();
     P_particle->setAbundance(abundance);
 
-    auto ffItem = static_cast<FormFactorItem*>(getGroupItem(ParticleItem::P_FORM_FACTOR));
-    Q_ASSERT(ffItem);
-    auto P_ff = ffItem->createFormFactor();
-    P_particle->setFormFactor(*P_ff);
+    auto& ffItem = groupItem<FormFactorItem>(ParticleItem::P_FORM_FACTOR);
+    P_particle->setFormFactor(*ffItem.createFormFactor());
 
     TransformToDomain::setTransformationInfo(P_particle.get(), *this);
 

--- a/GUI/coregui/Models/SessionItem.cpp
+++ b/GUI/coregui/Models/SessionItem.cpp
@@ -500,10 +500,7 @@ SessionItem *SessionItem::getGroupItem(const QString &name, const QString &type)
 
 SessionItem *SessionItem::setGroupProperty(const QString &name, const QString &value) const
 {
-    if (GroupItem *item = dynamic_cast<GroupItem *>(getItem(name)))
-        return item->setCurrentType(value);
-
-    return nullptr;
+    return item<GroupItem>(name).setCurrentType(value);
 }
 
 //! Returns corresponding variant under given role, invalid variant when role is not present.

--- a/GUI/coregui/Models/SessionItem.cpp
+++ b/GUI/coregui/Models/SessionItem.cpp
@@ -452,8 +452,7 @@ SessionItem *SessionItem::addGroupProperty(const QString &groupName, const QStri
 
     if(GroupPropertyRegistry::isValidGroup(groupType)) {
         // create group item
-        GroupProperty_t group_property
-            = GroupPropertyRegistry::createGroupProperty(groupName, groupType);
+        GroupProperty_t group_property = GroupPropertyRegistry::createGroupProperty(groupType);
         GroupItem *groupItem = dynamic_cast<GroupItem *>(
                     ItemFactory::createItem(Constants::GroupItemType));
         Q_ASSERT(groupItem);

--- a/GUI/coregui/Models/SessionItem.cpp
+++ b/GUI/coregui/Models/SessionItem.cpp
@@ -477,23 +477,11 @@ SessionItem *SessionItem::addGroupProperty(const QString &groupName, const QStri
     return result;
 }
 
-//! Access subitem of group item. If not existing, new item will be created by group property.
-//! Returns new item, but preserves current type of GroupItem (where it used FIXME?).
+//! Access subitem of group item.
 
-SessionItem *SessionItem::getGroupItem(const QString &name, const QString &type) const
+SessionItem *SessionItem::getGroupItem(const QString &groupName) const
 {
-    if (GroupItem *item = dynamic_cast<GroupItem *>(getItem(name))) {
-        GroupProperty_t group_property = item->groupProperty();
-        if (type.isEmpty()) {
-            return group_property->currentItem();
-        }
-        QString backup = group_property->currentType();
-        group_property->setCurrentType(type);
-        SessionItem *value = group_property->currentItem();
-        group_property->setCurrentType(backup);
-        return value;
-    }
-    return nullptr;
+    return item<GroupItem>(groupName).currentItem();
 }
 
 //! Set the current type of group item.

--- a/GUI/coregui/Models/SessionItem.h
+++ b/GUI/coregui/Models/SessionItem.h
@@ -96,7 +96,7 @@ public:
     SessionItem *addGroupProperty(const QString &groupName, const QString &groupType);
 
     SessionItem *setGroupProperty(const QString &name, const QString &value) const;
-    SessionItem *getGroupItem(const QString &name, const QString &type = QString()) const;
+    SessionItem *getGroupItem(const QString &groupName) const;
 
     // access data stored in roles
     virtual QVariant data(int role) const;

--- a/GUI/coregui/Models/SessionItem.h
+++ b/GUI/coregui/Models/SessionItem.h
@@ -97,6 +97,7 @@ public:
 
     SessionItem *setGroupProperty(const QString &name, const QString &value) const;
     SessionItem *getGroupItem(const QString &groupName) const;
+    template<typename T> T& groupItem(const QString &groupName) const;
 
     // access data stored in roles
     virtual QVariant data(int role) const;
@@ -167,6 +168,14 @@ template<typename T>
 T& SessionItem::item(const QString& tag) const
 {
     T* t = dynamic_cast<T*>(getItem(tag));
+    Q_ASSERT(t);
+    return *t;
+}
+
+template<typename T>
+T& SessionItem::groupItem(const QString& groupName) const
+{
+    T* t = dynamic_cast<T*>(getGroupItem(groupName));
     Q_ASSERT(t);
     return *t;
 }

--- a/GUI/coregui/Models/SessionXML.cpp
+++ b/GUI/coregui/Models/SessionXML.cpp
@@ -181,7 +181,7 @@ void SessionReader::readItems(QXmlStreamReader *reader, SessionItem *item, const
                     item = newItem;
 
                 } else if (item->modelType() == Constants::GroupItemType) {
-                    SessionItem *newItem = item->parent()->getGroupItem(item->parent()
+                    SessionItem *newItem = item->parent()->setGroupProperty(item->parent()
                                                 ->tagFromItem(item), model_type);
                     if (!newItem) {
                         QString message = QString("Unrecoverable read error for model '%1', "

--- a/GUI/coregui/Models/TransformToDomain.cpp
+++ b/GUI/coregui/Models/TransformToDomain.cpp
@@ -214,17 +214,10 @@ void TransformToDomain::setRotationInfo(IParticle* result, const SessionItem& it
     QVector<SessionItem*> children = item.childItems();
     for (int i = 0; i < children.size(); ++i) {
         if (children[i]->modelType() == Constants::TransformationType) {
-            RotationItem* rot_item = dynamic_cast<RotationItem*>(
-                children[i]->getGroupItem(TransformationItem::P_ROT));
-            if (!rot_item) {
-                throw GUIHelpers::Error("DomainObjectBuilder::setRotationInfo() "
-                                        "-> Error! ParticleItem's child is"
-                                        " not a rotation.");
-            }
-            std::unique_ptr<IRotation> P_rotation(rot_item->createRotation());
-            if (P_rotation.get()) {
+            auto& rot_item = children[i]->groupItem<RotationItem>(TransformationItem::P_ROT);
+            std::unique_ptr<IRotation> P_rotation(rot_item.createRotation());
+            if (P_rotation)
                 result->setRotation(*P_rotation);
-            }
             break;
         }
     }

--- a/GUI/coregui/Views/InfoWidgets/DistributionWidget.cpp
+++ b/GUI/coregui/Views/InfoWidgets/DistributionWidget.cpp
@@ -210,9 +210,8 @@ void DistributionWidget::plot_multiple_values()
 
     RealLimits limits;
     if (m_item->isTag(DistributionItem::P_LIMITS)) {
-        auto limitsItem
-            = dynamic_cast<RealLimitsItem*>(m_item->getGroupItem(DistributionItem::P_LIMITS));
-        limits = limitsItem->createRealLimits();
+        auto& limitsItem = m_item->groupItem<RealLimitsItem>(DistributionItem::P_LIMITS);
+        limits = limitsItem.createRealLimits();
     }
     plotLimits(limits);
 

--- a/GUI/coregui/Views/PropertyEditor/PropertyBrowserUtils.cpp
+++ b/GUI/coregui/Views/PropertyEditor/PropertyBrowserUtils.cpp
@@ -108,8 +108,7 @@ GroupPropertyEdit::~GroupPropertyEdit()
 {
 }
 
-void GroupPropertyEdit::setGroupProperty(
-        GroupProperty_t groupProperty)
+void GroupPropertyEdit::setGroupProperty(GroupProperty_t groupProperty)
 {
     if(groupProperty) {
         m_groupProperty = groupProperty;
@@ -122,11 +121,11 @@ void GroupPropertyEdit::processGroup()
     disconnect(m_box, SIGNAL(currentIndexChanged(int)),
             this, SLOT(indexChanged(int)));
 
-    if(m_box->count() != m_groupProperty->getLabels().size()) {
+    if(m_box->count() != m_groupProperty->itemLabels().size()) {
         m_box->clear();
-        m_box->insertItems(0, m_groupProperty->getLabels());
+        m_box->insertItems(0, m_groupProperty->itemLabels());
     }
-    m_box->setCurrentIndex(m_groupProperty->index());
+    m_box->setCurrentIndex(m_groupProperty->currentIndex());
 
     connect(m_box, SIGNAL(currentIndexChanged(int)),
             this, SLOT(indexChanged(int)), Qt::UniqueConnection);
@@ -134,7 +133,7 @@ void GroupPropertyEdit::processGroup()
 
 void GroupPropertyEdit::indexChanged(int index)
 {
-    m_groupProperty->setCurrentType(m_groupProperty->toString(index));
+    m_groupProperty->setCurrentIndex(index);
 }
 
 QSize GroupPropertyEdit::sizeHint() const

--- a/GUI/coregui/Views/PropertyEditor/PropertyVariantManager.cpp
+++ b/GUI/coregui/Views/PropertyEditor/PropertyVariantManager.cpp
@@ -131,7 +131,7 @@ QString PropertyVariantManager::valueText(const QtProperty *property) const
         return m_theScientificDoubleValues[property].getText();
     }
     if (m_theFancyGroupValues.contains(property)) {
-        return m_theFancyGroupValues[property]->getCurrentLabel();
+        return m_theFancyGroupValues[property]->currentLabel();
     }
     if (m_theComboValues.contains(property)) {
         return m_theComboValues[property].getValue();

--- a/GUI/coregui/Views/SampleDesigner/ParticleView.cpp
+++ b/GUI/coregui/Views/SampleDesigner/ParticleView.cpp
@@ -98,12 +98,7 @@ void ParticleView::update_appearance()
 
 void ParticleView::updatePixmap()
 {
-    GroupProperty_t group_property
-        = dynamic_cast<GroupItem *>(
-              getItem()->getItem(ParticleItem::P_FORM_FACTOR))
-              ->groupProperty();
-    QString current_ff_type = group_property->currentType();
-    QString filename
-        = QString(":/widgetbox/images/ff_%1_32.png").arg(current_ff_type);
+    QString ff_type = getItem()->item<GroupItem>(ParticleItem::P_FORM_FACTOR).currentType();
+    QString filename = QString(":/widgetbox/images/ff_%1_32.png").arg(ff_type);
     m_pixmap = QPixmap(filename);
 }

--- a/Tests/UnitTests/GUI/TestGroupProperty.h
+++ b/Tests/UnitTests/GUI/TestGroupProperty.h
@@ -51,7 +51,7 @@ inline void TestGroupProperty::test_groupProperty()
     GroupProperty_t property = GroupPropertyRegistry::createGroupProperty(
         "MyGroupProperty", Constants::DistributionGroup);
 
-    QCOMPARE(property->currentType(), Constants::DistributionCosineType);
+    QCOMPARE(property->currentType(), Constants::DistributionGaussianType);
     QVERIFY(property->currentItem() == nullptr);
 
 }
@@ -62,7 +62,7 @@ inline void TestGroupProperty::test_CreateGroup()
     GroupProperty_t property = GroupPropertyRegistry::createGroupProperty(
         "MyGroupProperty", Constants::DistributionGroup);
 
-    QCOMPARE(property->currentType(), Constants::DistributionCosineType);
+    QCOMPARE(property->currentType(), Constants::DistributionGaussianType);
 
     GroupItem groupItem;
     QCOMPARE(groupItem.childItems().size(), 0);
@@ -73,7 +73,7 @@ inline void TestGroupProperty::test_CreateGroup()
     QCOMPARE(groupItem.childItems().size(), 1);
     QCOMPARE(groupItem.childItems()[0], groupItem.currentItem());
     SessionItem *cosineItem = groupItem.currentItem();
-    QCOMPARE(cosineItem->modelType(), Constants::DistributionCosineType);
+    QCOMPARE(cosineItem->modelType(), Constants::DistributionGaussianType);
     QCOMPARE(property->currentItem(), cosineItem);
 
     // setting group property twice
@@ -86,7 +86,7 @@ inline void TestGroupProperty::test_CreateGroup()
     QCOMPARE(groupItem.childItems().size(), 2);
 
     // returning back to previous item
-    QCOMPARE(groupItem.setCurrentType(Constants::DistributionCosineType), cosineItem);
+    QCOMPARE(groupItem.setCurrentType(Constants::DistributionGaussianType), cosineItem);
     QCOMPARE(groupItem.currentItem(), cosineItem);
     QCOMPARE(groupItem.childItems().size(), 2);
 }

--- a/Tests/UnitTests/GUI/TestGroupProperty.h
+++ b/Tests/UnitTests/GUI/TestGroupProperty.h
@@ -48,6 +48,11 @@ inline void TestGroupProperty::test_groupInfo()
 
 inline void TestGroupProperty::test_groupProperty()
 {
+    GroupProperty_t property = GroupPropertyRegistry::createGroupProperty(
+        "MyGroupProperty", Constants::DistributionGroup);
+
+    QCOMPARE(property->currentType(), Constants::DistributionCosineType);
+    QVERIFY(property->currentItem() == nullptr);
 
 }
 

--- a/Tests/UnitTests/GUI/TestGroupProperty.h
+++ b/Tests/UnitTests/GUI/TestGroupProperty.h
@@ -1,4 +1,5 @@
 #include <QtTest>
+#include "GroupInfo.h"
 #include "GroupItem.h"
 #include "GroupPropertyRegistry.h"
 #include "GUIHelpers.h"
@@ -8,9 +9,42 @@ class TestGroupProperty : public QObject {
     Q_OBJECT
 
 private slots:
+    void test_groupInfo();
     void test_CreateGroup();
     void test_groupPropertyWithDisplayNames();
 };
+
+inline void TestGroupProperty::test_groupInfo()
+{
+    GroupInfo info("Group");
+    info.add("BBB", "b_label");
+    info.add("AAA", "a_label");
+    info.add("CCC", "c_label");
+    info.setDefaultType("AAA");
+
+    // sorted group (default behavior)
+    QCOMPARE(info.groupName(), QString("Group"));
+    QCOMPARE(info.defaultType(), QString("AAA"));
+    QCOMPARE(info.types(), QStringList() << "AAA" << "BBB" << "CCC");
+    QCOMPARE(info.labels(), QStringList() << "a_label" << "b_label" << "c_label");
+
+    // unsorted group
+    info = GroupInfo("Group2", false);
+    info.add("BBB2", "b_label2");
+    info.add("AAA2", "a_label2");
+    info.add("CCC2", "c_label2");
+    info.setDefaultType("AAA2");
+    QCOMPARE(info.defaultType(), QString("AAA2"));
+    QCOMPARE(info.types(), QStringList() << "BBB2" << "AAA2" << "CCC2");
+    QCOMPARE(info.labels(), QStringList() << "b_label2" << "a_label2" << "c_label2");
+
+    // attempt to set non-existing default type
+    QVERIFY_THROW(info.setDefaultType("XXX"), GUIHelpers::Error);
+
+    // attempt to add same group twice
+    QVERIFY_THROW(info.add("CCC2", "c_label2"), GUIHelpers::Error);
+}
+
 
 inline void TestGroupProperty::test_CreateGroup()
 {

--- a/Tests/UnitTests/GUI/TestGroupProperty.h
+++ b/Tests/UnitTests/GUI/TestGroupProperty.h
@@ -49,7 +49,7 @@ inline void TestGroupProperty::test_groupInfo()
 inline void TestGroupProperty::test_groupProperty()
 {
     GroupProperty_t property = GroupPropertyRegistry::createGroupProperty(
-        "MyGroupProperty", Constants::DistributionGroup);
+        Constants::DistributionGroup);
 
     QCOMPARE(property->currentType(), Constants::DistributionGaussianType);
     QVERIFY(property->currentItem() == nullptr);
@@ -60,7 +60,7 @@ inline void TestGroupProperty::test_groupProperty()
 inline void TestGroupProperty::test_CreateGroup()
 {
     GroupProperty_t property = GroupPropertyRegistry::createGroupProperty(
-        "MyGroupProperty", Constants::DistributionGroup);
+        Constants::DistributionGroup);
 
     QCOMPARE(property->currentType(), Constants::DistributionGaussianType);
 
@@ -96,7 +96,7 @@ inline void TestGroupProperty::test_CreateGroup()
 inline void TestGroupProperty::test_groupPropertyWithDisplayNames()
 {
     GroupProperty_t property = GroupPropertyRegistry::createGroupProperty(
-        "MyGroupProperty", Constants::DistributionGroup);
+        Constants::DistributionGroup);
 
     GroupItem groupItem;
     groupItem.setGroup(property);

--- a/Tests/UnitTests/GUI/TestGroupProperty.h
+++ b/Tests/UnitTests/GUI/TestGroupProperty.h
@@ -10,6 +10,7 @@ class TestGroupProperty : public QObject {
 
 private slots:
     void test_groupInfo();
+    void test_groupProperty();
     void test_CreateGroup();
     void test_groupPropertyWithDisplayNames();
 };
@@ -23,10 +24,10 @@ inline void TestGroupProperty::test_groupInfo()
     info.setDefaultType("AAA");
 
     // sorted group (default behavior)
-    QCOMPARE(info.groupName(), QString("Group"));
+    QCOMPARE(info.groupType(), QString("Group"));
     QCOMPARE(info.defaultType(), QString("AAA"));
-    QCOMPARE(info.types(), QStringList() << "AAA" << "BBB" << "CCC");
-    QCOMPARE(info.labels(), QStringList() << "a_label" << "b_label" << "c_label");
+    QCOMPARE(info.itemTypes(), QStringList() << "AAA" << "BBB" << "CCC");
+    QCOMPARE(info.itemLabels(), QStringList() << "a_label" << "b_label" << "c_label");
 
     // unsorted group
     info = GroupInfo("Group2", false);
@@ -35,14 +36,19 @@ inline void TestGroupProperty::test_groupInfo()
     info.add("CCC2", "c_label2");
     info.setDefaultType("AAA2");
     QCOMPARE(info.defaultType(), QString("AAA2"));
-    QCOMPARE(info.types(), QStringList() << "BBB2" << "AAA2" << "CCC2");
-    QCOMPARE(info.labels(), QStringList() << "b_label2" << "a_label2" << "c_label2");
+    QCOMPARE(info.itemTypes(), QStringList() << "BBB2" << "AAA2" << "CCC2");
+    QCOMPARE(info.itemLabels(), QStringList() << "b_label2" << "a_label2" << "c_label2");
 
     // attempt to set non-existing default type
     QVERIFY_THROW(info.setDefaultType("XXX"), GUIHelpers::Error);
 
-    // attempt to add same group twice
+    // attempt to add same info twice
     QVERIFY_THROW(info.add("CCC2", "c_label2"), GUIHelpers::Error);
+}
+
+inline void TestGroupProperty::test_groupProperty()
+{
+
 }
 
 

--- a/Tests/UnitTests/GUI/TestParameterTreeUtils.h
+++ b/Tests/UnitTests/GUI/TestParameterTreeUtils.h
@@ -9,16 +9,13 @@
 
 namespace {
     const QStringList expectedParticleParameterNames = {
-        "Particle/AnisoPyramid/Length", "Particle/AnisoPyramid/Width",
-        "Particle/AnisoPyramid/Height", "Particle/AnisoPyramid/Alpha",
-        "Particle/Abundance", "Particle/Position Offset/X",
-        "Particle/Position Offset/Y", "Particle/Position Offset/Z"};
+        "Particle/Cylinder/Radius", "Particle/Cylinder/Height", "Particle/Abundance",
+        "Particle/Position Offset/X", "Particle/Position Offset/Y", "Particle/Position Offset/Z"};
 
     const QStringList expectedParticleParameterTranslations = {
-        "Particle/AnisoPyramid/Length", "Particle/AnisoPyramid/Width",
-        "Particle/AnisoPyramid/Height", "Particle/AnisoPyramid/Alpha",
-        "Particle/Abundance", "Particle/PositionX",
-        "Particle/PositionY", "Particle/PositionZ"};
+        "Particle/Cylinder/Radius", "Particle/Cylinder/Height", "Particle/Abundance",
+        "Particle/PositionX", "Particle/PositionY", "Particle/PositionZ"};
+
 }
 
 class TestParameterTreeUtils : public QObject {
@@ -65,14 +62,14 @@ inline void TestParameterTreeUtils::test_linkItemFromParameterName()
 
     auto ffItem = static_cast<FormFactorItem*>(particle->getGroupItem(ParticleItem::P_FORM_FACTOR));
     Q_ASSERT(ffItem);
-    QCOMPARE(ffItem->modelType(), Constants::AnisoPyramidType);
+    QCOMPARE(ffItem->modelType(), Constants::CylinderType);
 
     QCOMPARE(
-        ffItem->getItem(AnisoPyramidItem::P_LENGTH),
-        ParameterTreeUtils::parameterNameToLinkedItem("Particle/AnisoPyramid/Length", particle));
+        ffItem->getItem(CylinderItem::P_RADIUS),
+        ParameterTreeUtils::parameterNameToLinkedItem("Particle/Cylinder/Radius", particle));
     QCOMPARE(
-        ffItem->getItem(AnisoPyramidItem::P_WIDTH),
-        ParameterTreeUtils::parameterNameToLinkedItem("Particle/AnisoPyramid/Width", particle));
+        ffItem->getItem(CylinderItem::P_HEIGHT),
+        ParameterTreeUtils::parameterNameToLinkedItem("Particle/Cylinder/Height", particle));
     QCOMPARE(particle->getItem(ParticleItem::P_POSITION)->getItem(VectorItem::P_X),
              ParameterTreeUtils::parameterNameToLinkedItem("Particle/Position Offset/X", particle));
 }

--- a/Tests/UnitTests/GUI/TestParticleDistributionItem.h
+++ b/Tests/UnitTests/GUI/TestParticleDistributionItem.h
@@ -15,9 +15,8 @@
 #include "MaterialSvc.h"
 
 namespace {
-    const QStringList expectedAnisoParams = {
-        "None", "Particle/AnisoPyramid/Length", "Particle/AnisoPyramid/Width",
-        "Particle/AnisoPyramid/Height", "Particle/AnisoPyramid/Alpha",
+    const QStringList expectedCylinderParams = {
+        "None", "Particle/Cylinder/Radius", "Particle/Cylinder/Height",
         "Particle/Position Offset/X", "Particle/Position Offset/Y", "Particle/Position Offset/Z"};
 
     const QStringList expectedBoxParams = {
@@ -75,7 +74,7 @@ inline void TestParticleDistributionItem::test_AddParticle()
     ComboProperty prop = dist->getItemValue(ParticleDistributionItem::P_DISTRIBUTED_PARAMETER)
                     .value<ComboProperty>();
 
-    QCOMPARE(prop.getValues(), expectedAnisoParams);
+    QCOMPARE(prop.getValues(), expectedCylinderParams);
     QCOMPARE(prop.getValue(), ParticleDistributionItem::NO_SELECTION);
 
     // changing formfactor of the particle
@@ -145,6 +144,8 @@ inline void TestParticleDistributionItem::test_FromDomain()
     SampleModel model;
     SessionItem *distItem = model.insertNewItem(Constants::ParticleDistributionType);
     SessionItem *particleItem = model.insertNewItem(Constants::ParticleType, distItem->index());
+
+    particleItem->setGroupProperty(ParticleItem::P_FORM_FACTOR, Constants::AnisoPyramidType);
 
     // Sets it from domain
     TransformFromDomain::setItemFromSample(distItem, &particle_collection);

--- a/dev-tools/log/perf_history.txt
+++ b/dev-tools/log/perf_history.txt
@@ -593,3 +593,6 @@
 | 2017-03-16 15:53:02 | scgsun   | Linux x86_64 | 2.7    | 93.3001   | 18.0506    | 0.7573     | 0.6264          | 3.9816          | 0.4498    | 2.7937        | 0.6295            | 2.9224         | 1.0736 | 1.9965      | 2.0363    | 0.7836    |
 
 16.03.2017 17:17:08 | domain2gui 1415 msec | gui2domain 1431 msec | realTime 1018 msec | 
+
+# after groupProperty refactoring
+17.03.2017 14:11:39 | domain2gui 1290 msec | gui2domain 1392 msec | realTime 983 msec |


### PR DESCRIPTION
New GroupInfo and GroupInfoCatalogue are introduced to provide default type for group item construction (instead of previous alphabetical one).