### PR TITLE
Redmine issue 1858: implementation of material class embracing wavelength-independent data

### DIFF
--- a/Core/Material/BaseMaterialImpl.cpp
+++ b/Core/Material/BaseMaterialImpl.cpp
@@ -1,0 +1,58 @@
+#include "BaseMaterialImpl.h"
+#include "WavevectorInfo.h"
+#include "Transform3D.h"
+#include "MaterialUtils.h"
+#include "PhysicalConstants.h"
+#include <memory>
+
+using PhysConsts::mu_B;
+using PhysConsts::gamma_n;
+using PhysConsts::r_e;
+ // The factor 1e-18 is here to have unit: m/A*nm^-2
+constexpr double magnetization_prefactor
+    = (gamma_n * r_e / 2.0 / mu_B) * 1e-18;
+
+namespace {
+// Used in experimental calculation of scattering matrix:
+cvector_t OrthogonalToBaseVector(cvector_t base, const kvector_t vector)
+{
+    if (base.mag2()==0.0) return cvector_t {};
+    cvector_t projection = (base.dot(vector)/base.mag2())*base;
+    return vector.complex() - projection;
+}
+}
+
+BaseMaterialImpl::BaseMaterialImpl(const std::string& name, kvector_t magnetization)
+    : INamed(name)
+    , m_magnetization(magnetization)
+{}
+
+BaseMaterialImpl::~BaseMaterialImpl()
+{}
+
+BaseMaterialImpl* BaseMaterialImpl::inverted() const
+{
+    std::string name = isScalarMaterial() ? getName()
+                                          : getName()+"_inv";
+    std::unique_ptr<BaseMaterialImpl> result(this->clone());
+    result->setName(name);
+    result->setMagnetization(-magnetization());
+    return result.release();
+}
+
+Eigen::Matrix2cd BaseMaterialImpl::polarizedSubtrSLD(const WavevectorInfo& wavevectors) const
+{
+    cvector_t mag_ortho = OrthogonalToBaseVector(wavevectors.getQ(), m_magnetization);
+    complex_t unit_factor = scalarSubtrSLD(wavevectors);
+    return MagnetizationCorrection(unit_factor, magnetization_prefactor, mag_ortho);
+}
+
+BaseMaterialImpl* BaseMaterialImpl::transformedMaterial(const Transform3D& transform) const
+{
+    kvector_t transformed_field = transform.transformed(m_magnetization);
+    std::unique_ptr<BaseMaterialImpl> result(this->clone());
+    result->setName(this->getName());
+    result->setMagnetization(transformed_field);
+    return result.release();
+}
+

--- a/Core/Material/BaseMaterialImpl.cpp
+++ b/Core/Material/BaseMaterialImpl.cpp
@@ -13,7 +13,6 @@ constexpr double magnetization_prefactor
     = (gamma_n * r_e / 2.0 / mu_B) * 1e-18;
 
 namespace {
-// Used in experimental calculation of scattering matrix:
 cvector_t OrthogonalToBaseVector(cvector_t base, const kvector_t vector)
 {
     if (base.mag2()==0.0) return cvector_t {};

--- a/Core/Material/BaseMaterialImpl.h
+++ b/Core/Material/BaseMaterialImpl.h
@@ -24,7 +24,8 @@
 class Transform3D;
 class WavevectorInfo;
 
-//! A wrapper for homogeneous and wavelength-independent materials
+//! A basic implementation for homogeneous and wavelength-independent materials.
+//! Incorporates data and methods required to handle material magnetization.
 //! @ingroup materials
 
 class BA_CORE_API_ BaseMaterialImpl : public INamed
@@ -56,11 +57,11 @@ public:
     //! Returns underlying material data
     virtual complex_t materialData() const = 0;
 
-    //! Returns \pi/(wl*wl) - sld, with wl being the wavelength
+    //! Returns (\f$ \pi/\lambda^2 \f$ - sld), sld being the scattering length density
     virtual complex_t scalarSubtrSLD(const WavevectorInfo& wavevectors) const = 0;
 
 #ifndef SWIG
-    //! Returns \pi/(wl*wl) - sld matrix with magnetization corrections. wl denotes the wavelength
+    //! Returns (\f$ \pi/\lambda^2 \f$ - sld) matrix with magnetization corrections
     Eigen::Matrix2cd polarizedSubtrSLD(const WavevectorInfo& wavevectors) const;
 #endif
 
@@ -70,7 +71,6 @@ public:
     virtual void print(std::ostream &ostr) const = 0;
 
 private:
-    //! Sets the magnetization (in A/m)
     void setMagnetization(kvector_t magnetization)
     {
         m_magnetization = magnetization;

--- a/Core/Material/BaseMaterialImpl.h
+++ b/Core/Material/BaseMaterialImpl.h
@@ -1,0 +1,82 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Core/Material/IMaterialImpl.h
+//! @brief     Defines and implements material implementation interface.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2015
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   C. Durniak, M. Ganeva, G. Pospelov, W. Van Herck, J. Wuttke
+//
+// ************************************************************************** //
+
+#ifndef IMATERIALIMPL_H_
+#define IMATERIALIMPL_H_
+
+#include "INamed.h"
+#include "Vectors3D.h"
+#include "Complex.h"
+#include "EigenCore.h"
+
+class Transform3D;
+class WavevectorInfo;
+
+//! A wrapper for homogeneous and wavelength-independent materials
+//! @ingroup materials
+
+class BA_CORE_API_ BaseMaterialImpl : public INamed
+{
+public:
+    //! Constructs basic material with name and magnetization
+    BaseMaterialImpl(const std::string& name, kvector_t magnetization);
+
+    virtual ~BaseMaterialImpl();
+
+    //! Returns pointer to a copy of material
+    virtual BaseMaterialImpl* clone() const = 0;
+
+    //! Constructs a material with inverted magnetization
+    BaseMaterialImpl* inverted() const;
+
+    virtual complex_t refractiveIndex(double wavelength) const = 0;
+    virtual complex_t refractiveIndex2(double wavelength) const = 0;
+
+    //! Indicates whether the interaction with the material is scalar.
+    //! This means that different polarization states will be diffracted equally
+    bool isScalarMaterial() const {return m_magnetization == kvector_t {};}
+
+    bool isMagneticMaterial() const {return !isScalarMaterial();}
+
+    //! Returns the magnetization (in A/m)
+    kvector_t magnetization() const {return m_magnetization;}
+
+    //! Returns underlying material data
+    virtual complex_t materialData() const = 0;
+
+    //! Returns \pi/(wl*wl) - sld, with wl being the wavelength
+    virtual complex_t scalarSubtrSLD(const WavevectorInfo& wavevectors) const = 0;
+
+#ifndef SWIG
+    //! Returns \pi/(wl*wl) - sld matrix with magnetization corrections. wl denotes the wavelength
+    Eigen::Matrix2cd polarizedSubtrSLD(const WavevectorInfo& wavevectors) const;
+#endif
+
+    BaseMaterialImpl* transformedMaterial(const Transform3D& transform) const;
+
+    //! Prints object data
+    virtual void print(std::ostream &ostr) const = 0;
+
+private:
+    //! Sets the magnetization (in A/m)
+    void setMagnetization(kvector_t magnetization)
+    {
+        m_magnetization = magnetization;
+    }
+
+    kvector_t m_magnetization; //!< magnetization
+};
+
+#endif /* IMATERIALIMPL_H_ */

--- a/Core/Material/Material.cpp
+++ b/Core/Material/Material.cpp
@@ -1,0 +1,87 @@
+#include "Material.h"
+#include "BaseMaterialImpl.h"
+#include "WavevectorInfo.h"
+#include "Transform3D.h"
+#include <typeinfo>
+
+Material::Material(const Material& material)
+    : m_material_impl(material.m_material_impl->clone())
+{}
+
+Material::Material(std::unique_ptr<BaseMaterialImpl> material_impl)
+    : m_material_impl(std::move(material_impl))
+{}
+
+Material Material::inverted() const
+{
+    std::unique_ptr<BaseMaterialImpl> material_impl(m_material_impl->inverted());
+    return Material(std::move(material_impl));
+}
+
+complex_t Material::refractiveIndex(double wavelength) const
+{
+    return m_material_impl->refractiveIndex(wavelength);
+}
+
+complex_t Material::refractiveIndex2(double wavelength) const
+{
+    return m_material_impl->refractiveIndex2(wavelength);
+}
+
+bool Material::isScalarMaterial() const
+{
+    return m_material_impl->isScalarMaterial();
+}
+
+std::string Material::getName() const
+{
+    return m_material_impl->getName();
+}
+
+size_t Material::dataType() const
+{
+    //TODO: reimplement using CRTP or just static type identifiers in material implementations
+    return typeid(*m_material_impl).hash_code();
+}
+
+kvector_t Material::magnetization() const
+{
+    return m_material_impl->magnetization();
+}
+
+complex_t Material::materialData() const
+{
+    return m_material_impl->materialData();
+}
+
+complex_t Material::scalarSubtrSLD(const WavevectorInfo& wavevectors) const
+{
+    return m_material_impl->scalarSubtrSLD(wavevectors);
+}
+
+Eigen::Matrix2cd Material::polarizedSubtrSLD(const WavevectorInfo& wavevectors) const
+{
+    return m_material_impl->polarizedSubtrSLD(wavevectors);
+}
+
+Material Material::transformedMaterial(const Transform3D& transform) const
+{
+    std::unique_ptr<BaseMaterialImpl> material_impl(m_material_impl->transformedMaterial(transform));
+    return Material(std::move(material_impl));
+}
+
+std::ostream& operator<<(std::ostream& ostr, const Material& m)
+{
+    m.m_material_impl->print(ostr);
+    return ostr;
+}
+
+bool operator==(const Material& left, const Material& right)
+{
+    if (left.getName() != right.getName()) return false;
+    if (left.magnetization() != right.magnetization()) return false;
+    if (left.materialData() != right.materialData()) return false;
+    if (left.dataType() != right.dataType()) return false;
+    return true;
+}
+

--- a/Core/Material/Material.h
+++ b/Core/Material/Material.h
@@ -26,7 +26,7 @@
 class Transform3D;
 class WavevectorInfo;
 
-//! A wrapper for homogeneous and wavelength-independent materials
+//! A wrapper for underlying material implementation
 //! @ingroup materials
 
 class BA_CORE_API_ Material
@@ -46,7 +46,10 @@ public:
     //! Constructs a material with inverted magnetization
     Material inverted() const;
 
+    //! Returns refractive index
     complex_t refractiveIndex(double wavelength) const;
+
+    //! Returns squared refractive index
     complex_t refractiveIndex2(double wavelength) const;
 
     //! Indicates whether the interaction with the material is scalar.
@@ -67,13 +70,14 @@ public:
     //! Returns underlying material data
     complex_t materialData() const;
 
+    //! Returns true if material underlying data is nullptr
     bool isEmpty() {return !m_material_impl;}
 
-    //! Returns \pi/(wl*wl) - sld, with wl being the wavelength
+    //! Returns (\f$ \pi/\lambda^2 \f$ - sld), sld (in \f$nm^{-2}\f$) being the scattering length density
     complex_t scalarSubtrSLD(const WavevectorInfo& wavevectors) const;
 
 #ifndef SWIG
-    //! Returns \pi/(wl*wl) - sld matrix with magnetization corrections. wl denotes the wavelength
+    //! Returns (\f$ \pi/\lambda^2 \f$ - sld) matrix with magnetization corrections
     Eigen::Matrix2cd polarizedSubtrSLD(const WavevectorInfo& wavevectors) const;
 #endif
 

--- a/Core/Material/Material.h
+++ b/Core/Material/Material.h
@@ -1,0 +1,92 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Core/Material/Material.h
+//! @brief     Defines and implements class Material.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2015
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   C. Durniak, M. Ganeva, G. Pospelov, W. Van Herck, J. Wuttke
+//
+// ************************************************************************** //
+
+#ifndef MATERIAL_H_
+#define MATERIAL_H_
+
+#include "Complex.h"
+#include "Vectors3D.h"
+#include "EigenCore.h"
+#include "BaseMaterialImpl.h"
+#include <vector>
+#include <memory>
+
+class Transform3D;
+class WavevectorInfo;
+
+//! A wrapper for homogeneous and wavelength-independent materials
+//! @ingroup materials
+
+class BA_CORE_API_ Material
+{
+public:
+    //! Material copy-constructor
+    Material(const Material& material);
+
+    //! Material move-constructor
+    Material(Material&& material) = default;
+
+#ifndef SWIG
+    //! Creates material with particular material implementation
+    Material(std::unique_ptr<BaseMaterialImpl> material_impl);
+#endif //SWIG
+
+    //! Constructs a material with inverted magnetization
+    Material inverted() const;
+
+    complex_t refractiveIndex(double wavelength) const;
+    complex_t refractiveIndex2(double wavelength) const;
+
+    //! Indicates whether the interaction with the material is scalar.
+    //! This means that different polarization states will be diffracted equally
+    bool isScalarMaterial() const;
+
+    bool isMagneticMaterial() const;
+
+    //! Returns the name of material
+    std::string getName() const;
+
+    //! Returns hash code of underlying material implementation
+    size_t dataType() const;
+
+    //! Get the magnetization (in A/m)
+    kvector_t magnetization() const;
+
+    //! Returns underlying material data
+    complex_t materialData() const;
+
+    bool isEmpty() {return !m_material_impl;}
+
+    //! Returns \pi/(wl*wl) - sld, with wl being the wavelength
+    complex_t scalarSubtrSLD(const WavevectorInfo& wavevectors) const;
+
+#ifndef SWIG
+    //! Returns \pi/(wl*wl) - sld matrix with magnetization corrections. wl denotes the wavelength
+    Eigen::Matrix2cd polarizedSubtrSLD(const WavevectorInfo& wavevectors) const;
+#endif
+
+    Material transformedMaterial(const Transform3D& transform) const;
+
+    friend BA_CORE_API_ std::ostream& operator<<(
+            std::ostream& ostr, const Material& mat);
+
+private:
+    std::unique_ptr<BaseMaterialImpl> m_material_impl;
+};
+
+//! Comparison operator for material wrapper
+BA_CORE_API_ bool operator==(const Material& left, const Material& right);
+
+#endif /* MATERIAL_H_ */

--- a/Core/Material/MaterialFactoryFuncs.cpp
+++ b/Core/Material/MaterialFactoryFuncs.cpp
@@ -1,0 +1,38 @@
+#include "MaterialFactoryFuncs.h"
+#include "RefractiveCoefMaterial.h"
+#include "WavelengthIndependentMaterial.h"
+
+Material RefractiveIndexMaterial(const std::string& name, complex_t refractive_index,
+                                 kvector_t magnetization)
+{
+    const double delta = 1.0 - refractive_index.real();
+    const double beta = refractive_index.imag();
+    std::unique_ptr<RefractiveCoefMaterial> mat_impl(
+        new RefractiveCoefMaterial(name, delta, beta, magnetization));
+    return Material(std::move(mat_impl));
+}
+
+Material RefractiveIndexMaterial(const std::string& name, double delta, double beta,
+                                 kvector_t magnetization)
+{
+    std::unique_ptr<RefractiveCoefMaterial> mat_impl(
+        new RefractiveCoefMaterial(name, delta, beta, magnetization));
+    return Material(std::move(mat_impl));
+}
+
+Material MaterialBySLD(const std::string& name, double sld, double abs_term,
+                       kvector_t magnetization)
+{
+    std::unique_ptr<WavelengthIndependentMaterial> mat_impl(
+        new WavelengthIndependentMaterial(name, sld, abs_term, magnetization));
+    return Material(std::move(mat_impl));
+}
+
+constexpr double basic_wavelength = 0.1798197; // nm, wavelength of 2200 m/s neutrons
+Material MaterialByAbsCX(const std::string& name, double sld, double abs_cx,
+                         kvector_t magnetization)
+{
+    std::unique_ptr<WavelengthIndependentMaterial> mat_impl(
+        new WavelengthIndependentMaterial(name, sld, abs_cx / basic_wavelength, magnetization));
+    return Material(std::move(mat_impl));
+}

--- a/Core/Material/MaterialFactoryFuncs.h
+++ b/Core/Material/MaterialFactoryFuncs.h
@@ -3,7 +3,7 @@
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
 //! @file      Core/Material/MaterialFactoryFuncs.h
-//! @brief     Defines factory functions for creating different flavors of materials.
+//! @brief     Factory functions used to create material instances.
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -18,14 +18,22 @@
 
 #include "Material.h"
 
+//! @ingroup materials
+
 //! Constructs a material with _name_ and _refractive_index_.
+//! @param magnetization: magnetization (in A/m)
 BA_CORE_API_ Material RefractiveIndexMaterial(const std::string& name, complex_t refractive_index,
                                               kvector_t magnetization = kvector_t());
 
+//! @ingroup materials
+
 //! Constructs a material with _name_ and refractive_index parameters
 //! \f$\delta\f$ and \f$\beta\f$ for refractive index \f$n = 1 - \delta + i \beta\f$.
+//! @param magnetization: magnetization (in A/m)
 BA_CORE_API_ Material RefractiveIndexMaterial(const std::string& name, double delta, double beta,
                                               kvector_t magnetization = kvector_t());
+
+//! @ingroup materials
 
 //! Constructs a wavelength-independent material with given sld and absorptive term
 //! Absorptive term is wavelength-independent (normalized to a wavelength)
@@ -36,8 +44,11 @@ BA_CORE_API_ Material RefractiveIndexMaterial(const std::string& name, double de
 //! \f$ \sigma_{abs}(\lambda_0) \f$ - absorption cross-section at \f$ \lambda_0 \f$ wavelength
 //! @param sld: scattering length density, \f$ nm^{-2} \f$
 //! @param abs_term: wavelength-independent absorptive term, \f$ nm^{-2} \f$
+//! @param magnetization: magnetization (in A/m)
 BA_CORE_API_ Material MaterialBySLD(const std::string& name, double sld, double abs_term,
                                     kvector_t magnetization = kvector_t());
+
+//! @ingroup materials
 
 //! Constructs a wavelength-independent material with given sld and absorptive term
 //! As opposed to MaterialBySLD, absorptive term is the product of number density and
@@ -45,6 +56,7 @@ BA_CORE_API_ Material MaterialBySLD(const std::string& name, double sld, double 
 //! The latter corresponds to 2200 m/s neutrons.
 //! @param sld: scattering length density, \f$ nm^{-2} \f$
 //! @param abs_cx: absorptive term at \f$ \lambda = 1.798197\f$ Angstroms, \f$ nm^{-1} \f$
+//! @param magnetization: magnetization (in A/m)
 BA_CORE_API_ Material MaterialByAbsCX(const std::string& name, double sld, double abs_cx,
                                       kvector_t magnetization = kvector_t());
 

--- a/Core/Material/MaterialFactoryFuncs.h
+++ b/Core/Material/MaterialFactoryFuncs.h
@@ -1,0 +1,51 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Core/Material/MaterialFactoryFuncs.h
+//! @brief     Defines factory functions for creating different flavors of materials.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2015
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   C. Durniak, M. Ganeva, G. Pospelov, W. Van Herck, J. Wuttke
+//
+// ************************************************************************** //
+
+#ifndef MATERIALFACTORYFUNCS_H_
+#define MATERIALFACTORYFUNCS_H_
+
+#include "Material.h"
+
+//! Constructs a material with _name_ and _refractive_index_.
+BA_CORE_API_ Material RefractiveIndexMaterial(const std::string& name, complex_t refractive_index,
+                                              kvector_t magnetization = kvector_t());
+
+//! Constructs a material with _name_ and refractive_index parameters
+//! \f$\delta\f$ and \f$\beta\f$ for refractive index \f$n = 1 - \delta + i \beta\f$.
+BA_CORE_API_ Material RefractiveIndexMaterial(const std::string& name, double delta, double beta,
+                                              kvector_t magnetization = kvector_t());
+
+//! Constructs a wavelength-independent material with given sld and absorptive term
+//! Absorptive term is wavelength-independent (normalized to a wavelength)
+//! and can be considered as inverse of imaginary part of complex scattering length density:
+//! \f$ SLD = (N b_{coh}, N \sigma_{abs}(\lambda_0) / \lambda_0) \f$
+//! Here \f$ N \f$ - material number density,
+//! \f$ b_{coh} \f$ - bound coherent scattering length
+//! \f$ \sigma_{abs}(\lambda_0) \f$ - absorption cross-section at \f$ \lambda_0 \f$ wavelength
+//! @param sld: scattering length density, \f$ nm^{-2} \f$
+//! @param abs_term: wavelength-independent absorptive term, \f$ nm^{-2} \f$
+BA_CORE_API_ Material MaterialBySLD(const std::string& name, double sld, double abs_term,
+                                    kvector_t magnetization = kvector_t());
+
+//! Constructs a wavelength-independent material with given sld and absorptive term
+//! As opposed to MaterialBySLD, absorptive term is the product of number density and
+//! absorptive cross-section \f$ \sigma_0 \f$ at \f$ \lambda = 1.798197\f$ Angstroms.
+//! The latter corresponds to 2200 m/s neutrons.
+//! @param sld: scattering length density, \f$ nm^{-2} \f$
+//! @param abs_cx: absorptive term at \f$ \lambda = 1.798197\f$ Angstroms, \f$ nm^{-1} \f$
+BA_CORE_API_ Material MaterialByAbsCX(const std::string& name, double sld, double abs_cx,
+                                      kvector_t magnetization = kvector_t());
+
+#endif /* MATERIALFACTORYFUNCS_H_ */

--- a/Core/Material/RefractiveCoefMaterial.cpp
+++ b/Core/Material/RefractiveCoefMaterial.cpp
@@ -1,0 +1,48 @@
+#include "RefractiveCoefMaterial.h"
+#include "WavevectorInfo.h"
+
+RefractiveCoefMaterial::RefractiveCoefMaterial(const std::string& name, double delta, double beta,
+                                                 kvector_t magnetization)
+    : BaseMaterialImpl(name, magnetization)
+    , m_delta(delta)
+    , m_beta(beta)
+{}
+
+RefractiveCoefMaterial::~RefractiveCoefMaterial()
+{}
+
+RefractiveCoefMaterial* RefractiveCoefMaterial::clone() const
+{
+    return new RefractiveCoefMaterial(*this);
+}
+
+complex_t RefractiveCoefMaterial::refractiveIndex(double) const
+{
+    return complex_t(1.0 - m_delta, m_beta);
+}
+
+complex_t RefractiveCoefMaterial::refractiveIndex2(double) const
+{
+    complex_t result(1.0 - m_delta, m_beta);
+    return result * result;
+}
+
+complex_t RefractiveCoefMaterial::materialData() const
+{
+    return complex_t(m_delta, m_beta);
+}
+
+complex_t RefractiveCoefMaterial::scalarSubtrSLD(const WavevectorInfo& wavevectors) const
+{
+    double wavelength = wavevectors.getWavelength();
+    double prefactor = M_PI/wavelength/wavelength;
+    return prefactor * refractiveIndex2(wavelength);
+}
+
+void RefractiveCoefMaterial::print(std::ostream& ostr) const
+{
+    ostr << "RefractiveCoefMaterial:" << getName() << "<" << this << ">{ "
+         << "delta=" << m_delta << ", beta=" << m_beta
+         << ", B=" << magnetization() << "}";
+}
+

--- a/Core/Material/RefractiveCoefMaterial.h
+++ b/Core/Material/RefractiveCoefMaterial.h
@@ -19,14 +19,14 @@
 #include "BaseMaterialImpl.h"
 #include "Material.h"
 
+//! Material implementation based on refractive coefficiencts (valid for one wavelength value only)
+//! @ingroup materials
+
 class BA_CORE_API_ RefractiveCoefMaterial : public BaseMaterialImpl
 {
 public:
-    //! Constructs a material with _name_ and _refractive_index_.
     friend BA_CORE_API_ Material RefractiveIndexMaterial(const std::string&, complex_t, kvector_t);
 
-    //! Constructs a material with _name_ and refractive_index parameters
-    //! \f$\delta\f$ and \f$\beta\f$ for refractive index \f$n = 1 - \delta + i \beta\f$.
     friend BA_CORE_API_ Material RefractiveIndexMaterial(const std::string&, double, double,
                                                          kvector_t);
 
@@ -35,13 +35,23 @@ public:
     //! Returns pointer to a copy of material
     virtual RefractiveCoefMaterial* clone() const override;
 
+    //! Returns refractive index
+    //! For this particular implementation returned value does not depend
+    //! on passed wavelength
     virtual complex_t refractiveIndex(double wavelength) const override;
+
+    //! Returns squared refractive index.
+    //! For this particular implementation returned value does not depend
+    //! on passed wavelength.
     virtual complex_t refractiveIndex2(double wavelength) const override;
 
     //! Returns underlying material data
     virtual complex_t materialData() const override;
 
-    //! Returns \pi/(wl*wl) - sld, with wl being the wavelength
+    //! Returns (\f$ \pi/\lambda^2 \f$ - sld), sld (in \f$nm^{-2}\f$) being the scattering length density.
+    //! If the wavelength associated with passed wavevector is different from the one
+    //! associated with refractive coefficients used during the object construction,
+    //! provided result is inconsistent.
     virtual complex_t scalarSubtrSLD(const WavevectorInfo& wavevectors) const override;
 
     //! Prints object data

--- a/Core/Material/RefractiveCoefMaterial.h
+++ b/Core/Material/RefractiveCoefMaterial.h
@@ -1,0 +1,58 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Core/Material/RefractiveIndexMaterial.h
+//! @brief     Defines class RefractiveIndexMaterial.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2015
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   C. Durniak, M. Ganeva, G. Pospelov, W. Van Herck, J. Wuttke
+//
+// ************************************************************************** //
+
+#ifndef REFRACTIVECOEFMATERIAL_H_
+#define REFRACTIVECOEFMATERIAL_H_
+
+#include "BaseMaterialImpl.h"
+#include "Material.h"
+
+class BA_CORE_API_ RefractiveCoefMaterial : public BaseMaterialImpl
+{
+public:
+    //! Constructs a material with _name_ and _refractive_index_.
+    friend BA_CORE_API_ Material RefractiveIndexMaterial(const std::string&, complex_t, kvector_t);
+
+    //! Constructs a material with _name_ and refractive_index parameters
+    //! \f$\delta\f$ and \f$\beta\f$ for refractive index \f$n = 1 - \delta + i \beta\f$.
+    friend BA_CORE_API_ Material RefractiveIndexMaterial(const std::string&, double, double,
+                                                         kvector_t);
+
+    virtual ~RefractiveCoefMaterial();
+
+    //! Returns pointer to a copy of material
+    virtual RefractiveCoefMaterial* clone() const override;
+
+    virtual complex_t refractiveIndex(double wavelength) const override;
+    virtual complex_t refractiveIndex2(double wavelength) const override;
+
+    //! Returns underlying material data
+    virtual complex_t materialData() const override;
+
+    //! Returns \pi/(wl*wl) - sld, with wl being the wavelength
+    virtual complex_t scalarSubtrSLD(const WavevectorInfo& wavevectors) const override;
+
+    //! Prints object data
+    virtual void print(std::ostream &ostr) const override;
+
+private:
+    RefractiveCoefMaterial(const std::string& name, double delta, double beta,
+                           kvector_t magnetization);
+
+    double m_delta; //!< \f$\delta\f$ coefficient for refractive index \f$n = 1 - \delta + i \beta\f$
+    double m_beta; //!< \f$\beta\f$ coefficient for refractive index \f$n = 1 - \delta + i \beta\f$
+};
+
+#endif /* REFRACTIVECOEFMATERIAL_H_ */

--- a/Core/Material/WavelengthIndependentMaterial.cpp
+++ b/Core/Material/WavelengthIndependentMaterial.cpp
@@ -5,9 +5,9 @@ namespace
 {
 // Returns SLD-like complex value, where real part is SLD and imaginary one is
 // wavelength-independent absorptive term
-inline complex_t getSLD(double delta_factor, double beta_factor)
+inline complex_t getSLD(double sld, double abs_term)
 {
-    return complex_t(delta_factor, -beta_factor / 2.0);
+    return complex_t(sld, -abs_term / 2.0);
 }
 
 inline double getWlPrefactor(double wavelength)

--- a/Core/Material/WavelengthIndependentMaterial.cpp
+++ b/Core/Material/WavelengthIndependentMaterial.cpp
@@ -1,0 +1,59 @@
+#include "WavelengthIndependentMaterial.h"
+#include "WavevectorInfo.h"
+
+namespace
+{
+// Returns SLD-like complex value, where real part is SLD and imaginary one is
+// wavelength-independent absorptive term
+inline complex_t getSLD(double delta_factor, double beta_factor)
+{
+    return complex_t(delta_factor, -beta_factor / 2.0);
+}
+
+inline double getWlPrefactor(double wavelength)
+{
+    return wavelength * wavelength / M_PI;
+}
+}
+
+WavelengthIndependentMaterial::WavelengthIndependentMaterial(const std::string& name, double sld,
+                                                             double abs_term,
+                                                             kvector_t magnetization)
+    : BaseMaterialImpl(name, magnetization), m_sld(sld), m_abs_term(abs_term)
+{}
+
+WavelengthIndependentMaterial::~WavelengthIndependentMaterial()
+{}
+
+WavelengthIndependentMaterial* WavelengthIndependentMaterial::clone() const
+{
+    return new WavelengthIndependentMaterial(*this);
+}
+
+complex_t WavelengthIndependentMaterial::refractiveIndex(double wavelength) const
+{
+    return std::sqrt(refractiveIndex2(wavelength));
+}
+
+complex_t WavelengthIndependentMaterial::refractiveIndex2(double wavelength) const
+{
+    return 1.0 - getWlPrefactor(wavelength) * getSLD(m_sld, m_abs_term);
+}
+
+complex_t WavelengthIndependentMaterial::materialData() const
+{
+    return complex_t(m_sld, m_abs_term);
+}
+
+complex_t WavelengthIndependentMaterial::scalarSubtrSLD(const WavevectorInfo& wavevectors) const
+{
+    double wavelength = wavevectors.getWavelength();
+    return 1.0 / getWlPrefactor(wavelength) - getSLD(m_sld, m_abs_term);
+}
+
+void WavelengthIndependentMaterial::print(std::ostream& ostr) const
+{
+    ostr << "WavelengthIndependentMaterial:" << getName() << "<" << this << ">{ "
+         << "sld=" << m_sld << ", absorp_term=" << m_abs_term
+         << ", B=" << magnetization() << "}";
+}

--- a/Core/Material/WavelengthIndependentMaterial.h
+++ b/Core/Material/WavelengthIndependentMaterial.h
@@ -19,6 +19,9 @@
 #include "BaseMaterialImpl.h"
 #include "Material.h"
 
+//! Material implementation based on wavelength-independent data (valid for a range of wavelengths)
+//! @ingroup materials
+
 class BA_CORE_API_ WavelengthIndependentMaterial : public BaseMaterialImpl
 {
 public:
@@ -31,13 +34,16 @@ public:
     //! Returns pointer to a copy of material
     virtual WavelengthIndependentMaterial* clone() const override;
 
+    //! Returns refractive index
     virtual complex_t refractiveIndex(double wavelength) const override;
+
+    //! Returns squared refractive index
     virtual complex_t refractiveIndex2(double wavelength) const override;
 
     //! Returns underlying material data
     virtual complex_t materialData() const override;
 
-    //! Returns \pi/(wl*wl) - sld, with wl being the wavelength
+    //! Returns (\f$ \pi/\lambda^2 \f$ - sld), sld (in \f$nm^{-2}\f$) being the scattering length density
     virtual complex_t scalarSubtrSLD(const WavevectorInfo& wavevectors) const override;
 
     //! Prints object data

--- a/Core/Material/WavelengthIndependentMaterial.h
+++ b/Core/Material/WavelengthIndependentMaterial.h
@@ -1,0 +1,56 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Core/Material/WavelengthIndependentMaterial.h
+//! @brief     Defines class WavelengthIndependentMaterial.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2015
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   C. Durniak, M. Ganeva, G. Pospelov, W. Van Herck, J. Wuttke
+//
+// ************************************************************************** //
+
+#ifndef WAVELENGTHINDEPENDENTMATERIAL_H_
+#define WAVELENGTHINDEPENDENTMATERIAL_H_
+
+#include "BaseMaterialImpl.h"
+#include "Material.h"
+
+class BA_CORE_API_ WavelengthIndependentMaterial : public BaseMaterialImpl
+{
+public:
+    friend BA_CORE_API_ Material MaterialBySLD(const std::string&, double, double, kvector_t);
+
+    friend BA_CORE_API_ Material MaterialByAbsCX(const std::string&, double, double, kvector_t);
+
+    virtual ~WavelengthIndependentMaterial();
+
+    //! Returns pointer to a copy of material
+    virtual WavelengthIndependentMaterial* clone() const override;
+
+    virtual complex_t refractiveIndex(double wavelength) const override;
+    virtual complex_t refractiveIndex2(double wavelength) const override;
+
+    //! Returns underlying material data
+    virtual complex_t materialData() const override;
+
+    //! Returns \pi/(wl*wl) - sld, with wl being the wavelength
+    virtual complex_t scalarSubtrSLD(const WavevectorInfo& wavevectors) const override;
+
+    //! Prints object data
+    virtual void print(std::ostream &ostr) const override;
+
+private:
+    WavelengthIndependentMaterial(const std::string& name, double sld, double abs_term,
+                                  kvector_t magnetization);
+
+    double m_sld; //!< product of number density and coherent scattering length
+                  //!< (scattering length density)
+    double m_abs_term;  //!< product of number density and
+                        //!< absorption cross-section normalized to wavelength
+};
+
+#endif /* WAVELENGTHINDEPENDENTMATERIAL_H_ */

--- a/Doc/Doxygen/defgroups.dox
+++ b/Doc/Doxygen/defgroups.dox
@@ -10,7 +10,7 @@
 @brief Classes to describe experimental sample.
 
 \defgroup materials Materials
-@brief Classes to describe magnetic and non-magnetic materials.
+@brief Classes and functions to describe magnetic and non-magnetic materials.
 
 \defgroup formfactors Available formfactors
 @brief Available form factors.

--- a/Tests/UnitTests/Core/Other/MaterialTest.h
+++ b/Tests/UnitTests/Core/Other/MaterialTest.h
@@ -160,12 +160,4 @@ TEST_F(MaterialTest, MaterialMove)
     EXPECT_EQ(material_data, move.materialData());
     EXPECT_EQ(magnetism, move.magnetization());
     EXPECT_TRUE(material.isEmpty());
-
-    Material material2
-        = MaterialBySLD("Material", material_data.real(), material_data.imag());
-    Material move_op = std::move(material2);
-    EXPECT_EQ("Material", move_op.getName());
-    EXPECT_EQ(material_data, move_op.materialData());
-    EXPECT_EQ(kvector_t{}, move_op.magnetization());
-    EXPECT_TRUE(material2.isEmpty());
 }

--- a/Tests/UnitTests/Core/Other/MaterialTest.h
+++ b/Tests/UnitTests/Core/Other/MaterialTest.h
@@ -1,0 +1,171 @@
+#include "MaterialFactoryFuncs.h"
+#include "WavevectorInfo.h"
+#include "Rotations.h"
+#include "Units.h"
+
+class MaterialTest : public ::testing::Test
+{
+public:
+    MaterialTest()
+    {
+    }
+    virtual ~MaterialTest()
+    {
+    }
+};
+
+TEST_F(MaterialTest, MaterialConstruction)
+{
+    complex_t material_data = complex_t(0.0, 2.0);
+    complex_t refIndex = complex_t(1.0 - material_data.real(), material_data.imag());
+    kvector_t magnetism = kvector_t(3.0, 4.0, 5.0);
+
+    Material material = RefractiveIndexMaterial("MagMaterial", refIndex, magnetism);
+    EXPECT_EQ("MagMaterial", material.getName());
+    EXPECT_EQ(material_data, material.materialData());
+    EXPECT_EQ(magnetism, material.magnetization());
+
+    Material material2 = RefractiveIndexMaterial("MagMaterial", material_data.real(),
+                                                 material_data.imag(), magnetism);
+    EXPECT_EQ("MagMaterial", material2.getName());
+    EXPECT_EQ(material_data, material2.materialData());
+    EXPECT_EQ(magnetism, material2.magnetization());
+
+    Material material3 = MaterialBySLD("MagMaterial", material_data.real(),
+                                                    material_data.imag(), magnetism);
+    EXPECT_EQ("MagMaterial", material3.getName());
+    EXPECT_EQ(material_data, material3.materialData());
+    EXPECT_EQ(magnetism, material3.magnetization());
+
+    kvector_t default_magnetism = kvector_t{};
+
+    Material material4 = RefractiveIndexMaterial("Material", refIndex);
+    EXPECT_EQ("Material", material4.getName());
+    EXPECT_EQ(material_data, material4.materialData());
+    EXPECT_EQ(default_magnetism, material4.magnetization());
+
+    Material material5
+        = RefractiveIndexMaterial("Material", material_data.real(), material_data.imag());
+    EXPECT_EQ("Material", material5.getName());
+    EXPECT_EQ(material_data, material5.materialData());
+    EXPECT_EQ(default_magnetism, material5.magnetization());
+
+    Material material6
+        = MaterialBySLD("Material", material_data.real(), material_data.imag());
+    EXPECT_EQ("Material", material6.getName());
+    EXPECT_EQ(material_data, material6.materialData());
+    EXPECT_EQ(default_magnetism, material6.magnetization());
+}
+
+TEST_F(MaterialTest, MaterialTransform)
+{
+    complex_t material_data = complex_t(1.0, 0.0);
+    complex_t refIndex = complex_t(1.0 - material_data.real(), material_data.imag());
+    kvector_t magnetism = kvector_t(1.0, 0.0, 0.0);
+    RotationZ transform(90. * Units::degree);
+    kvector_t transformed_mag = transform.getTransform3D().transformed(magnetism);
+
+    Material material = RefractiveIndexMaterial("Material", refIndex, magnetism);
+    Material material2 = material.transformedMaterial(transform.getTransform3D());
+
+    EXPECT_EQ("Material", material2.getName());
+    EXPECT_EQ(material_data, material2.materialData());
+    EXPECT_EQ(transformed_mag, material2.magnetization());
+
+    Material material3 = MaterialBySLD("Material", material_data.real(), material_data.imag(), magnetism);
+    Material material4 = material.transformedMaterial(transform.getTransform3D());
+
+    EXPECT_EQ("Material", material4.getName());
+    EXPECT_EQ(material_data, material4.materialData());
+    EXPECT_EQ(transformed_mag, material4.magnetization());
+}
+
+TEST_F(MaterialTest, ComputationTest)
+{
+    // Reference data for Fe taken from
+    // https://sld-calculator.appspot.com/save
+    // http://www.ati.ac.at/~neutropt/scattering/table.html
+    const double bc = 9.45e-6; // nm, bound coherent scattering length
+    const double abs_cs = 2.56e-10; // nm^2, absorption cross-section for 2200 m/s neutrons
+    const double basic_wavelength = 0.1798197; // nm, wavelength of 2200 m/s neutrons
+    const double mol_mass = 55.845; // g/mol, Fe molar mass
+    const double avog_number = 6.022e+23; // mol^{-1}, Avogadro number
+    const double density = 7.874e-21; // g/nm^3, Fe material density
+    const double number_density = avog_number * density / mol_mass; // 1/nm^3, Fe number density
+    const double sld = number_density * bc;
+    const double abs_term = number_density * abs_cs / basic_wavelength;
+
+    const complex_t sld_ref(8.0241e-04, -6.0448e-8); // nm^{-2}, reference data, wavelength-independent
+    const double wl_factor_2200 = basic_wavelength * basic_wavelength / M_PI;
+    const double wl_factor_1100 = 4.0 * basic_wavelength * basic_wavelength / M_PI;
+
+    Material material = MaterialBySLD("Fe", sld, abs_term);
+    const complex_t sld_res_2200 = (1.0 - material.refractiveIndex2(basic_wavelength)) / wl_factor_2200;
+    const complex_t sld_res_1100 = (1.0 - material.refractiveIndex2(2.0 * basic_wavelength)) / wl_factor_1100;
+
+    EXPECT_NEAR(0.0, (sld_ref.real() - sld_res_2200.real()) / sld_ref.real(), 1.e-3);
+    EXPECT_NEAR(0.0, (sld_ref.imag() - sld_res_2200.imag()) / sld_ref.imag(), 1.e-3);
+    EXPECT_NEAR(0.0, (sld_ref.real() - sld_res_1100.real()) / sld_ref.real(), 1.e-3);
+    EXPECT_NEAR(0.0, (sld_ref.imag() - sld_res_1100.imag()) / sld_ref.imag(), 1.e-3);
+
+    const complex_t refr_index = material.refractiveIndex(2.0 * basic_wavelength);
+    WavevectorInfo wv_info(cvector_t{}, cvector_t{}, 2.0 * basic_wavelength);
+
+    Material material2 = RefractiveIndexMaterial("Fe", 1.0 - refr_index.real(), std::abs(refr_index.imag()));
+    const complex_t subtrSLD = material2.scalarSubtrSLD(wv_info);
+    const complex_t subtrSLDWlIndep = material.scalarSubtrSLD(wv_info);
+    EXPECT_FLOAT_EQ(subtrSLD.real(), subtrSLDWlIndep.real());
+    EXPECT_FLOAT_EQ(subtrSLD.imag(), subtrSLDWlIndep.imag());
+}
+
+TEST_F(MaterialTest, EqualityTest)
+{
+    Material material = MaterialBySLD("Material", 1.0, 1.0);
+    Material material2 = RefractiveIndexMaterial("Material", 1.0, 1.0);
+    EXPECT_FALSE(material == material2);
+
+    constexpr double basic_wavelength = 0.1798197; // nm
+    Material material3 = MaterialByAbsCX("Material", 1.0, 1.0 * basic_wavelength);
+    EXPECT_TRUE(material.getName() == material3.getName());
+    EXPECT_TRUE(material.magnetization() == material3.magnetization());
+    EXPECT_DOUBLE_EQ(material.materialData().real(), material3.materialData().real());
+    EXPECT_DOUBLE_EQ(material.materialData().imag(), material3.materialData().imag());
+    EXPECT_TRUE(material.dataType() == material3.dataType());
+}
+
+TEST_F(MaterialTest, MaterialCopy)
+{
+    complex_t material_data = complex_t(0.0, 2.0);
+    complex_t refIndex = complex_t(1.0 - material_data.real(), material_data.imag());
+    kvector_t magnetism = kvector_t(3.0, 4.0, 5.0);
+    Material material = RefractiveIndexMaterial("MagMaterial", refIndex, magnetism);
+
+    Material copy = material;
+
+    EXPECT_EQ("MagMaterial", copy.getName());
+    EXPECT_EQ(material_data, copy.materialData());
+    EXPECT_EQ(magnetism, copy.magnetization());
+    EXPECT_TRUE(material == copy);
+}
+
+TEST_F(MaterialTest, MaterialMove)
+{
+    complex_t material_data = complex_t(0.0, 2.0);
+    complex_t refIndex = complex_t(1.0 - material_data.real(), material_data.imag());
+    kvector_t magnetism = kvector_t(3.0, 4.0, 5.0);
+    Material material = RefractiveIndexMaterial("MagMaterial", refIndex, magnetism);
+
+    Material move(std::move(material));
+    EXPECT_EQ("MagMaterial", move.getName());
+    EXPECT_EQ(material_data, move.materialData());
+    EXPECT_EQ(magnetism, move.magnetization());
+    EXPECT_TRUE(material.isEmpty());
+
+    Material material2
+        = MaterialBySLD("Material", material_data.real(), material_data.imag());
+    Material move_op = std::move(material2);
+    EXPECT_EQ("Material", move_op.getName());
+    EXPECT_EQ(material_data, move_op.materialData());
+    EXPECT_EQ(kvector_t{}, move_op.magnetization());
+    EXPECT_TRUE(material2.isEmpty());
+}

--- a/Tests/UnitTests/Core/Other/testlist.h
+++ b/Tests/UnitTests/Core/Other/testlist.h
@@ -5,6 +5,7 @@
 #include "TRangeTest.h"
 #include "Shape2DTest.h"
 #include "HomogeneousMaterialTest.h"
+#include "MaterialTest.h"
 #include "GISASSimulationTest.h"
 #include "ZLimitsTest.h"
 #include "ThreadInfoTest.h"


### PR DESCRIPTION
Now material must be created with a number of factory functions. Material class contains a pointer to implementation, which can be either analogous to old HomogeneousMaterial or implement material with wavelength-independent data.

ComputationTest in MaterialTest.h shows the usage and also verifies validity of created wavelength-independent material