### PR TITLE
SessionItemWidget refactoring

### DIFF
--- a/GUI/coregui/Views/CommonWidgets/SessionItemController.cpp
+++ b/GUI/coregui/Views/CommonWidgets/SessionItemController.cpp
@@ -81,7 +81,9 @@ void SessionItemController::unsubscribe()
     if (!m_item)
         return;
 
-    unsubscribeParent();
+    if (m_parent_subscribed)
+        unsubscribeParent();
+
     m_item->mapper()->unsubscribe(parent());
 }
 

--- a/GUI/coregui/Views/CommonWidgets/SessionItemController.cpp
+++ b/GUI/coregui/Views/CommonWidgets/SessionItemController.cpp
@@ -1,0 +1,118 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Views/CommonWidgets/SessionItemController.h
+//! @brief     Implements class SessionItemController
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
+//! @authors   Walter Van Herck, Joachim Wuttke
+//
+// ************************************************************************** //
+
+#include "SessionItemController.h"
+#include "SessionItem.h"
+#include "GUIHelpers.h"
+
+SessionItemController::SessionItemController(QObject* prt)
+    : QObject(prt)
+    , m_item(nullptr)
+    , m_parent_subscribed(false)
+{
+    Q_ASSERT(parent());
+}
+
+SessionItemController::~SessionItemController()
+{
+    onControllerDestroy();
+}
+
+void SessionItemController::setItem(SessionItem* item)
+{
+    if(m_item == item)
+        return;
+
+    if (m_item) {
+        m_item->mapper()->unsubscribe(this);
+        unsubscribe();
+    }
+
+    m_item = item;
+    if (!m_item)
+        return;
+
+    m_item->mapper()->setOnItemDestroy([this](SessionItem*) { onItemDestroy(); }, this);
+}
+
+SessionItem* SessionItemController::currentItem()
+{
+    return m_item;
+}
+
+void SessionItemController::setSubscribeCallback(callback_t fun)
+{
+    m_subscribe_callback = fun;
+}
+
+void SessionItemController::setUnsubscribeCallback(callback_t fun)
+{
+    m_unsubscribe_callback = fun;
+}
+
+void SessionItemController::subscribe()
+{
+    if (!m_item)
+        return;
+
+    subscribeParent();
+}
+
+void SessionItemController::unsubscribe()
+{
+    if (!m_item)
+        return;
+
+    unsubscribeParent();
+}
+
+void SessionItemController::onItemDestroy()
+{
+    if (m_parent_subscribed)
+        unsubscribeParent();
+    m_item = nullptr;
+}
+
+void SessionItemController::onControllerDestroy()
+{
+    if (m_item) {
+        m_item->mapper()->unsubscribe(this);
+
+        if (m_parent_subscribed)
+            unsubscribeParent();
+
+        m_item->mapper()->unsubscribe(parent());
+    }
+}
+
+void SessionItemController::subscribeParent()
+{
+    Q_ASSERT(m_subscribe_callback);
+    Q_ASSERT(m_parent_subscribed == false);
+    m_subscribe_callback();
+    m_parent_subscribed = true;
+}
+
+void SessionItemController::unsubscribeParent()
+{
+    Q_ASSERT(m_unsubscribe_callback);
+    Q_ASSERT(m_parent_subscribed == true);
+    m_unsubscribe_callback();
+    m_parent_subscribed = false;
+}
+
+
+

--- a/GUI/coregui/Views/CommonWidgets/SessionItemController.cpp
+++ b/GUI/coregui/Views/CommonWidgets/SessionItemController.cpp
@@ -63,6 +63,8 @@ void SessionItemController::setUnsubscribeCallback(callback_t fun)
     m_unsubscribe_callback = fun;
 }
 
+//! Subscribe parent to item's signals.
+
 void SessionItemController::subscribe()
 {
     if (!m_item)
@@ -71,12 +73,16 @@ void SessionItemController::subscribe()
     subscribeParent();
 }
 
+//! Fully unsubscribes the parent from listening item's signals.
+//! Controller stays active to track item destruction.
+
 void SessionItemController::unsubscribe()
 {
     if (!m_item)
         return;
 
     unsubscribeParent();
+    m_item->mapper()->unsubscribe(parent());
 }
 
 void SessionItemController::onItemDestroy()
@@ -105,6 +111,8 @@ void SessionItemController::subscribeParent()
     m_subscribe_callback();
     m_parent_subscribed = true;
 }
+
+//! Calls additional callback on un
 
 void SessionItemController::unsubscribeParent()
 {

--- a/GUI/coregui/Views/CommonWidgets/SessionItemController.cpp
+++ b/GUI/coregui/Views/CommonWidgets/SessionItemController.cpp
@@ -70,7 +70,8 @@ void SessionItemController::subscribe()
     if (!m_item)
         return;
 
-    subscribeParent();
+    if (!m_parent_subscribed)
+        subscribeParent();
 }
 
 //! Fully unsubscribes the parent from listening item's signals.

--- a/GUI/coregui/Views/CommonWidgets/SessionItemController.h
+++ b/GUI/coregui/Views/CommonWidgets/SessionItemController.h
@@ -1,0 +1,60 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Views/CommonWidgets/SessionItemController.h
+//! @brief     Defines class SessionItemController
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
+//! @authors   Walter Van Herck, Joachim Wuttke
+//
+// ************************************************************************** //
+
+#ifndef SESSIONITEMCONTROLLER_H
+#define SESSIONITEMCONTROLLER_H
+
+#include "WinDllMacros.h"
+#include <QObject>
+#include <functional>
+
+class SessionItem;
+
+//! Provides subscribe/unsubscribe mechanism for any QObject to track
+//! time of life of SessionItem. Mainly intended for SessionItemWidget.
+
+class BA_CORE_API_ SessionItemController : public QObject
+{
+    Q_OBJECT
+public:
+    using callback_t = std::function<void(void)>;
+
+    explicit SessionItemController(QObject* prt);
+    ~SessionItemController();
+
+    void setItem(SessionItem* item);
+
+    SessionItem* currentItem();
+
+    void setSubscribeCallback(callback_t fun);
+    void setUnsubscribeCallback(callback_t fun);
+
+    void subscribe();
+    void unsubscribe();
+
+private:
+    void onItemDestroy();
+    void onControllerDestroy();
+    void subscribeParent();
+    void unsubscribeParent();
+
+    callback_t m_subscribe_callback;
+    callback_t m_unsubscribe_callback;
+    SessionItem* m_item;
+    bool m_parent_subscribed;
+};
+
+#endif

--- a/GUI/coregui/Views/CommonWidgets/SessionItemWidget.h
+++ b/GUI/coregui/Views/CommonWidgets/SessionItemWidget.h
@@ -23,6 +23,7 @@
 class SessionItem;
 class QShowEvent;
 class QHideEvent;
+class SessionItemController;
 
 //! The SessionItemWidget class is a base for all widgets representing the content
 //! of SessionItem. It provides subscribe/unsibscribe mechanism on show/hide events.
@@ -39,7 +40,7 @@ public:
     virtual void setItem(SessionItem* item);
     virtual QList<QAction*> actionList();
 
-    SessionItem* currentItem() { return m_currentItem; }
+    SessionItem* currentItem();
 
 protected:
     virtual void subscribeToItem() {}
@@ -48,10 +49,7 @@ protected:
     virtual void hideEvent(QHideEvent*);
 
 private:
-    void subscribe();
-    void unsubscribe();
-    SessionItem* m_currentItem;
-    bool is_subscribed;
+    SessionItemController* m_itemController;
 };
 
 #endif // SESSIONITEMWIDGET_H

--- a/Tests/UnitTests/GUI/TestGUI.cpp
+++ b/Tests/UnitTests/GUI/TestGUI.cpp
@@ -30,6 +30,7 @@
 #include "TestProjectUtils.h"
 #include "TestParticleCoreShell.h"
 #include "TestPropertyRepeater.h"
+#include "TestSessionItemController.h"
 #include <memory>
 
 class GUITestFactory {
@@ -91,6 +92,7 @@ int main(int argc, char** argv) {
     tests.add<TestProjectUtils>();
     tests.add<TestParticleCoreShell>();
     tests.add<TestPropertyRepeater>();
+    tests.add<TestSessionItemController>();
 
     return tests.runAll(argc, argv);
 }

--- a/Tests/UnitTests/GUI/TestSessionItemController.h
+++ b/Tests/UnitTests/GUI/TestSessionItemController.h
@@ -173,12 +173,18 @@ inline void TestSessionItemController::test_onPropertyChange()
     item->setItemValue(BasicAxisItem::P_MAX, 4.1);
     QCOMPARE(listener.m_onPropertyChangeCount, 2);
 
+    // setting same item once again, setting visible, and then checking that no double subscription
+    object.setItem(item);
+    object.setVisible(true);
+    item->setItemValue(BasicAxisItem::P_MAX, 4.2);
+    QCOMPARE(listener.m_onPropertyChangeCount, 3);
+
     // setting invisible and changing item, no reaction on item value change expected
     object.setVisible(false);
     QCOMPARE(object.m_is_subscribed, false);
     item->setItemValue(BasicAxisItem::P_MAX, 5.0);
     QCOMPARE(listener.m_onItemDestroyedCount, 0);
-    QCOMPARE(listener.m_onPropertyChangeCount, 2);
+    QCOMPARE(listener.m_onPropertyChangeCount, 3);
 }
 
 //! Deleting item when widget is visible.

--- a/Tests/UnitTests/GUI/TestSessionItemController.h
+++ b/Tests/UnitTests/GUI/TestSessionItemController.h
@@ -1,0 +1,260 @@
+#include "SessionItemController.h"
+#include "SessionModel.h"
+#include "AxesItems.h"
+#include <QtTest>
+#include <QDebug>
+
+class TestListener
+{
+public:
+    TestListener() : m_onItemDestroyedCount(0), m_onPropertyChangeCount(0)
+      , m_onWidgetDestroyed(0) {}
+    void clear() {
+        m_onItemDestroyedCount = 0;
+        m_onPropertyChangeCount = 0;
+        m_onWidgetDestroyed = 0;
+    }
+    int m_onItemDestroyedCount;
+    int m_onPropertyChangeCount;
+    int m_onWidgetDestroyed;
+};
+
+class TestObject : public QObject
+{
+    Q_OBJECT
+public:
+    TestObject(TestListener* listener)
+        : m_listener(listener)
+        , m_controller(new SessionItemController(this))
+        , m_is_subscribed(false)
+    {
+        m_controller->setSubscribeCallback([this](){onSubscribe();});
+        m_controller->setUnsubscribeCallback([this](){onUnsubscribe();});
+    }
+    ~TestObject() { m_listener->m_onWidgetDestroyed++;}
+
+    void setItem(SessionItem* item) {m_controller->setItem(item);}
+    void onSubscribe() {
+        m_is_subscribed = true;
+        currentItem()->mapper()->setOnPropertyChange([this](const QString&) {
+            m_listener->m_onPropertyChangeCount++;}, this);
+
+        currentItem()->mapper()->setOnItemDestroy([this](SessionItem*) {
+            m_listener->m_onItemDestroyedCount++; }, this);
+
+    }
+
+    SessionItem* currentItem() { return m_controller->currentItem();}
+
+    void onUnsubscribe() {
+        m_is_subscribed = false;
+    }
+
+    void setVisible(bool isVisible) {
+        if (isVisible)
+            m_controller->subscribe();
+        else
+            m_controller->unsubscribe();
+    }
+
+    TestListener* m_listener;
+    SessionItemController* m_controller;
+    bool m_is_subscribed;
+};
+
+class TestSessionItemController : public QObject
+{
+    Q_OBJECT
+public:
+
+private slots:
+    void test_InitialState();
+    void test_setItem();
+    void test_setItemAndSubscribeItem();
+    void test_onPropertyChange();
+    void test_onItemDestroyWidgetVisible();
+    void test_onItemDestroyWidgetHidden();
+    void test_deleteWidget();
+};
+
+//! Testing helper classes which will be used for controller testing.
+
+inline void TestSessionItemController::test_InitialState()
+{
+    TestListener listener;
+    QCOMPARE(listener.m_onItemDestroyedCount, 0);
+    QCOMPARE(listener.m_onPropertyChangeCount, 0);
+
+    TestObject object(&listener);
+    QCOMPARE(object.currentItem(), nullptr);
+    QCOMPARE(object.m_is_subscribed, false);
+
+    // setting null item
+    object.setItem(nullptr);
+    QCOMPARE(listener.m_onItemDestroyedCount, 0);
+    QCOMPARE(listener.m_onPropertyChangeCount, 0);
+    QCOMPARE(object.currentItem(), nullptr);
+    QCOMPARE(object.m_is_subscribed, false);
+
+    object.setVisible(true);
+    QCOMPARE(object.currentItem(), nullptr);
+    QCOMPARE(object.m_is_subscribed, false);
+}
+
+//! Setting item and doing nothing.
+
+inline void TestSessionItemController::test_setItem()
+{
+    TestListener listener;
+    TestObject object(&listener);
+    SessionModel model("TestModel");
+    SessionItem* item = model.insertNewItem(Constants::BasicAxisType);
+
+    object.setItem(item);
+    QCOMPARE(object.currentItem(), item);
+    QCOMPARE(object.m_is_subscribed, false);
+    QCOMPARE(listener.m_onItemDestroyedCount, 0);
+    QCOMPARE(listener.m_onPropertyChangeCount, 0);
+}
+
+//! Setting item and subscribing to it.
+
+inline void TestSessionItemController::test_setItemAndSubscribeItem()
+{
+    TestListener listener;
+    TestObject object(&listener);
+    SessionModel model("TestModel");
+    SessionItem* item = model.insertNewItem(Constants::BasicAxisType);
+
+    object.setItem(item);
+    object.setVisible(true);
+    QCOMPARE(object.currentItem(), item);
+    QCOMPARE(object.m_is_subscribed, true);
+    QCOMPARE(listener.m_onItemDestroyedCount, 0);
+    QCOMPARE(listener.m_onPropertyChangeCount, 0);
+}
+
+//! Setting item properties when widget is in hidden/shown state
+
+inline void TestSessionItemController::test_onPropertyChange()
+{
+    TestListener listener;
+    TestObject object(&listener);
+    SessionModel model("TestModel");
+    SessionItem* item = model.insertNewItem(Constants::BasicAxisType);
+
+    object.setItem(item);
+    QCOMPARE(object.currentItem(), item);
+    QCOMPARE(object.m_is_subscribed, false);
+
+    // changing item, should be no reaction
+    item->setItemValue(BasicAxisItem::P_MAX, 3.0);
+    QCOMPARE(listener.m_onItemDestroyedCount, 0);
+    QCOMPARE(listener.m_onPropertyChangeCount, 0);
+
+    // setting visible and changing item
+    object.setVisible(true);
+    QCOMPARE(object.m_is_subscribed, true);
+    item->setItemValue(BasicAxisItem::P_MAX, 4.0);
+    QCOMPARE(listener.m_onItemDestroyedCount, 0);
+    QCOMPARE(listener.m_onPropertyChangeCount, 1);
+
+    // same value, no change expected
+    item->setItemValue(BasicAxisItem::P_MAX, 4.0);
+    QCOMPARE(listener.m_onPropertyChangeCount, 1);
+
+    // new value
+    item->setItemValue(BasicAxisItem::P_MAX, 4.1);
+    QCOMPARE(listener.m_onPropertyChangeCount, 2);
+
+    // setting invisible and changing item
+    object.setVisible(false);
+    QCOMPARE(object.m_is_subscribed, false);
+    item->setItemValue(BasicAxisItem::P_MAX, 5.0);
+    QCOMPARE(listener.m_onItemDestroyedCount, 0);
+    QCOMPARE(listener.m_onPropertyChangeCount, 3);
+}
+
+//! Deleting item when widget is visible
+
+inline void TestSessionItemController::test_onItemDestroyWidgetVisible()
+{
+    TestListener listener;
+    TestObject object(&listener);
+    SessionModel model("TestModel");
+    SessionItem* item = model.insertNewItem(Constants::BasicAxisType);
+
+    object.setItem(item);
+    object.setVisible(true);
+
+    item->setItemValue(BasicAxisItem::P_MAX, 4.0);
+    QCOMPARE(listener.m_onItemDestroyedCount, 0);
+    QCOMPARE(listener.m_onPropertyChangeCount, 1);
+
+    delete item->parent()->takeRow(0);
+    QCOMPARE(listener.m_onItemDestroyedCount, 1);
+    QCOMPARE(object.m_is_subscribed, false);
+    QCOMPARE(object.currentItem(), nullptr);
+
+    object.setVisible(false);
+    QCOMPARE(listener.m_onItemDestroyedCount, 1);
+    QCOMPARE(object.m_is_subscribed, false);
+    QCOMPARE(object.currentItem(), nullptr);
+}
+
+inline void TestSessionItemController::test_onItemDestroyWidgetHidden()
+{
+    TestListener listener;
+    TestObject object(&listener);
+    SessionModel model("TestModel");
+    SessionItem* item = model.insertNewItem(Constants::BasicAxisType);
+
+    object.setItem(item);
+    object.setVisible(true);
+
+    item->setItemValue(BasicAxisItem::P_MAX, 4.0);
+    QCOMPARE(listener.m_onItemDestroyedCount, 0);
+    QCOMPARE(listener.m_onPropertyChangeCount, 1);
+
+    object.setVisible(false);
+
+    delete item->parent()->takeRow(0);
+    QCOMPARE(listener.m_onItemDestroyedCount, 1);
+    QCOMPARE(listener.m_onItemDestroyedCount, 1);
+    QCOMPARE(object.m_is_subscribed, false);
+    QCOMPARE(object.currentItem(), nullptr);
+
+    object.setVisible(true);
+    QCOMPARE(listener.m_onItemDestroyedCount, 1);
+    QCOMPARE(listener.m_onItemDestroyedCount, 1);
+    QCOMPARE(object.m_is_subscribed, false);
+    QCOMPARE(object.currentItem(), nullptr);
+}
+
+inline void TestSessionItemController::test_deleteWidget()
+{
+    TestListener listener;
+    TestObject* object = new TestObject(&listener);
+    SessionModel model("TestModel");
+    SessionItem* item = model.insertNewItem(Constants::BasicAxisType);
+
+    object->setItem(item);
+    object->setVisible(true);
+
+    item->setItemValue(BasicAxisItem::P_MAX, 4.0);
+
+    QCOMPARE(listener.m_onItemDestroyedCount, 0);
+    QCOMPARE(listener.m_onPropertyChangeCount, 1);
+    QCOMPARE(listener.m_onWidgetDestroyed, 0);
+
+    delete object;
+
+    QCOMPARE(listener.m_onItemDestroyedCount, 0);
+    QCOMPARE(listener.m_onPropertyChangeCount, 1);
+    QCOMPARE(listener.m_onWidgetDestroyed, 1);
+
+    item->setItemValue(BasicAxisItem::P_MAX, 4.1);
+    QCOMPARE(listener.m_onItemDestroyedCount, 0);
+    QCOMPARE(listener.m_onPropertyChangeCount, 1);
+}
+

--- a/Tests/UnitTests/GUI/TestSessionItemController.h
+++ b/Tests/UnitTests/GUI/TestSessionItemController.h
@@ -79,6 +79,7 @@ private slots:
     void test_onItemDestroyWidgetVisible();
     void test_onItemDestroyWidgetHidden();
     void test_onTwoItems();
+    void test_onTwoItemsWhenHidden();
     void test_deleteWidget();
 };
 
@@ -271,6 +272,39 @@ inline void TestSessionItemController::test_onTwoItems()
     // changing the value of new item, widget should react
     item2->setItemValue(BasicAxisItem::P_MAX, 6.0);
     QCOMPARE(listener.m_onPropertyChangeCount, 2);
+}
+
+//! Settings two items one after another, when widget stays hidden
+
+inline void TestSessionItemController::test_onTwoItemsWhenHidden()
+{
+    TestListener listener;
+    TestObject object(&listener);
+    SessionModel model("TestModel");
+    SessionItem* item1 = model.insertNewItem(Constants::BasicAxisType);
+    SessionItem* item2 = model.insertNewItem(Constants::BasicAxisType);
+
+    object.setVisible(false);
+
+    object.setItem(item1);
+    QCOMPARE(object.currentItem(), item1);
+
+    item1->setItemValue(BasicAxisItem::P_MAX, 4.0);
+    QCOMPARE(listener.m_onItemDestroyedCount, 0);
+    QCOMPARE(listener.m_onPropertyChangeCount, 0);
+
+    // changing the item
+    object.setItem(item2);
+    QCOMPARE(object.currentItem(), item2);
+
+    // changing the value of previous item, widget shouldn't react
+    item1->setItemValue(BasicAxisItem::P_MAX, 5.0);
+    QCOMPARE(listener.m_onItemDestroyedCount, 0);
+    QCOMPARE(listener.m_onPropertyChangeCount, 0);
+
+    // changing the value of new item, widget shouldn't react
+    item2->setItemValue(BasicAxisItem::P_MAX, 6.0);
+    QCOMPARE(listener.m_onPropertyChangeCount, 0);
 }
 
 //! Deleting the widget when item still alive.


### PR DESCRIPTION
SessionItemWidget is a common base intended for SessionItem presentation. It's main feature was subscription/unsubscription mechanism to allow update on SessionItem's change, when widget is visible.
This mechanism was also responsible for the time of life: widget is destroyed before item, item is destroyed before widget.

* With this pull request, the logic is moved out of widget to the dedicated SessionItemController.
* Lots of unit tests for the controller
* Subtle bug with access to the deleted widget was caught