### PR TITLE
ComponentTreeView with the behavior of old PropertyEditor

### DIFF
--- a/GUI/coregui/Models/ComponentProxyModel.cpp
+++ b/GUI/coregui/Models/ComponentProxyModel.cpp
@@ -17,7 +17,7 @@
 #include "ComponentProxyModel.h"
 #include "SessionModel.h"
 #include "ModelUtils.h"
-#include "ProxyModelStrategy.h"
+#include "ComponentProxyStrategy.h"
 #include <functional>
 #include <QDebug>
 

--- a/GUI/coregui/Models/ComponentProxyModel.cpp
+++ b/GUI/coregui/Models/ComponentProxyModel.cpp
@@ -70,7 +70,6 @@ void ComponentProxyModel::setSessionModel(SessionModel* model)
 
 void ComponentProxyModel::setRootIndex(const QModelIndex& sourceRootIndex)
 {
-    Q_ASSERT(m_model);
     m_proxyStrategy->setRootIndex(sourceRootIndex);
     buildModelMap();
 }
@@ -78,9 +77,7 @@ void ComponentProxyModel::setRootIndex(const QModelIndex& sourceRootIndex)
 void ComponentProxyModel::setProxyStrategy(ProxyModelStrategy* strategy)
 {
     m_proxyStrategy.reset(strategy);
-
-    if (m_model)
-        buildModelMap();
+    buildModelMap();
 }
 
 QModelIndex ComponentProxyModel::mapToSource(const QModelIndex& proxyIndex) const
@@ -206,6 +203,8 @@ void ComponentProxyModel::sourceRowsInserted(const QModelIndex& parent, int star
 
 void ComponentProxyModel::buildModelMap()
 {
+    if (!m_model)
+        return;
     m_proxyStrategy->buildModelMap(m_model, this);
     layoutChanged();
 }

--- a/GUI/coregui/Models/ComponentProxyStrategy.cpp
+++ b/GUI/coregui/Models/ComponentProxyStrategy.cpp
@@ -20,6 +20,7 @@
 #include "SessionItem.h"
 #include "ModelPath.h"
 #include "GroupItem.h"
+#include "SessionItemUtils.h"
 
 void ComponentProxyStrategy::onDataChanged(SessionModel* source, ComponentProxyModel* proxy)
 {
@@ -52,7 +53,7 @@ bool ComponentProxyStrategy::isNewRootItem(SessionItem* item)
     return item->index() == m_sourceRootIndex;
 }
 
-//! Makes SessionItem to be come the only one item in a tree.
+//! Makes SessionItem to become the only one item in a tree.
 
 void ComponentProxyStrategy::processRootItem(SessionItem* item,
                                              const QPersistentModelIndex& sourceIndex)
@@ -62,6 +63,8 @@ void ComponentProxyStrategy::processRootItem(SessionItem* item,
     m_sourceToProxy.insert(sourceIndex, proxyIndex);
     m_proxySourceParent.insert(proxyIndex, QModelIndex()); // new parent will be root
 }
+
+//! Returns true if item is a children/grandchildrent of some group item.
 
 bool ComponentProxyStrategy::isGroupChildren(SessionItem* item)
 {
@@ -75,6 +78,8 @@ bool ComponentProxyStrategy::isGroupChildren(SessionItem* item)
 
     return false;
 }
+
+//! All properties of current item of group item
 
 void ComponentProxyStrategy::processGroupItem(SessionItem* item,
                                               const QPersistentModelIndex& sourceIndex)
@@ -98,8 +103,12 @@ void ComponentProxyStrategy::processGroupItem(SessionItem* item,
 void ComponentProxyStrategy::processDefaultItem(SessionItem* item,
                                                 const QPersistentModelIndex& sourceIndex)
 {
+    Q_ASSERT(item);
+    if (!item->isVisible())
+        return;
+
     QPersistentModelIndex proxyIndex
-        = createProxyIndex(sourceIndex.row(), sourceIndex.column(), item);
+        = createProxyIndex(SessionItemUtils::ParentVisibleRow(*item), sourceIndex.column(), item);
 
     m_sourceToProxy.insert(sourceIndex, proxyIndex);
 

--- a/GUI/coregui/Models/ComponentProxyStrategy.cpp
+++ b/GUI/coregui/Models/ComponentProxyStrategy.cpp
@@ -27,18 +27,17 @@ void ComponentProxyStrategy::onDataChanged(SessionModel* source, ComponentProxyM
     proxy->layoutChanged();
 }
 
-void ComponentProxyStrategy::processSourceIndex(SessionModel* model, ComponentProxyModel* proxy,
-                                                const QModelIndex& index)
+void ComponentProxyStrategy::processSourceIndex(const QModelIndex& index)
 {
     QPersistentModelIndex sourceIndex = QPersistentModelIndex(index);
     QPersistentModelIndex proxyIndex
-        = createProxyIndex(proxy, index.row(), index.column(), index.internalPointer());
+        = createProxyIndex(index.row(), index.column(), index.internalPointer());
 
-    SessionItem* item = model->itemForIndex(index);
+    SessionItem* item = m_source->itemForIndex(index);
 
     if (item->index() == m_sourceRootIndex) {
         // if index is desired new source
-        proxyIndex = createProxyIndex(proxy, 0, index.column(), index.internalPointer());
+        proxyIndex = createProxyIndex(0, index.column(), index.internalPointer());
         m_sourceToProxy.insert(sourceIndex, proxyIndex);
         m_proxySourceParent.insert(proxyIndex, QModelIndex()); // new parent will be root
 

--- a/GUI/coregui/Models/ComponentProxyStrategy.cpp
+++ b/GUI/coregui/Models/ComponentProxyStrategy.cpp
@@ -1,0 +1,87 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Models/ComponentProxyStrategy.cpp
+//! @brief     Implements class ComponentProxyStrategy
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
+//! @authors   Walter Van Herck, Joachim Wuttke
+//
+// ************************************************************************** //
+
+#include "ComponentProxyStrategy.h"
+#include "ComponentProxyModel.h"
+#include "SessionModel.h"
+#include "SessionItem.h"
+#include "ModelPath.h"
+#include "GroupItem.h"
+
+void ComponentProxyStrategy::onDataChanged(SessionModel* source, ComponentProxyModel* proxy)
+{
+    buildModelMap(source, proxy);
+    proxy->layoutChanged();
+}
+
+void ComponentProxyStrategy::processSourceIndex(SessionModel* model, ComponentProxyModel* proxy,
+                                                const QModelIndex& index)
+{
+    QPersistentModelIndex sourceIndex = QPersistentModelIndex(index);
+    QPersistentModelIndex proxyIndex
+        = createProxyIndex(proxy, index.row(), index.column(), index.internalPointer());
+
+    SessionItem* item = model->itemForIndex(index);
+
+    if (item->index() == m_sourceRootIndex) {
+        // if index is desired new source
+        proxyIndex = createProxyIndex(proxy, 0, index.column(), index.internalPointer());
+        m_sourceToProxy.insert(sourceIndex, proxyIndex);
+        m_proxySourceParent.insert(proxyIndex, QModelIndex()); // new parent will be root
+
+    } else if (isGroupChildren(item)) {
+        // do parent substitution here
+        processGroupItem(item, sourceIndex, proxyIndex);
+    } else {
+        m_sourceToProxy.insert(sourceIndex, proxyIndex);
+
+        QPersistentModelIndex sourceParent;
+        if (index.parent().isValid())
+            sourceParent = index.parent();
+
+        m_proxySourceParent.insert(proxyIndex, sourceParent);
+    }
+}
+
+bool ComponentProxyStrategy::isGroupChildren(SessionItem* item)
+{
+    if (item->parent() && item->parent()->modelType() == Constants::GroupItemType)
+        return true;
+
+    if (const SessionItem* ancestor = ModelPath::ancestor(item, Constants::GroupItemType)) {
+        if (ancestor != item)
+            return true;
+    }
+
+    return false;
+}
+
+void ComponentProxyStrategy::processGroupItem(SessionItem* item,
+                                              const QPersistentModelIndex& sourceIndex,
+                                              const QPersistentModelIndex& proxyIndex)
+{
+    if (const SessionItem* ancestor = ModelPath::ancestor(item, Constants::GroupItemType)) {
+        if (ancestor == item)
+            return;
+
+        auto groupItem = dynamic_cast<const GroupItem*>(ancestor);
+        if (item->parent() == groupItem->currentItem()) {
+            m_sourceToProxy.insert(sourceIndex, proxyIndex);
+            m_proxySourceParent.insert(proxyIndex, groupItem->index());
+        }
+
+    }
+}

--- a/GUI/coregui/Models/ComponentProxyStrategy.h
+++ b/GUI/coregui/Models/ComponentProxyStrategy.h
@@ -27,8 +27,7 @@ public:
     void onDataChanged(SessionModel* source, ComponentProxyModel* proxy);
 
 protected:
-    void processSourceIndex(SessionModel* model, ComponentProxyModel* proxy,
-                            const QModelIndex& index);
+    void processSourceIndex(const QModelIndex& index);
 private:
     bool isGroupChildren(SessionItem* item);
     void processGroupItem(SessionItem* item, const QPersistentModelIndex& sourceIndex,

--- a/GUI/coregui/Models/ComponentProxyStrategy.h
+++ b/GUI/coregui/Models/ComponentProxyStrategy.h
@@ -29,9 +29,11 @@ public:
 protected:
     void processSourceIndex(const QModelIndex& index);
 private:
+    bool isNewRootItem(SessionItem* item);
+    void processRootItem(SessionItem* item, const QPersistentModelIndex& sourceIndex);
     bool isGroupChildren(SessionItem* item);
-    void processGroupItem(SessionItem* item, const QPersistentModelIndex& sourceIndex,
-                          const QPersistentModelIndex& proxyIndex);
+    void processGroupItem(SessionItem* item, const QPersistentModelIndex& sourceIndex);
+    void processDefaultItem(SessionItem* item, const QPersistentModelIndex& sourceIndex);
 };
 
 #endif  //  COMPONENTPROXYSTRATEGY_H

--- a/GUI/coregui/Models/ComponentProxyStrategy.h
+++ b/GUI/coregui/Models/ComponentProxyStrategy.h
@@ -1,0 +1,38 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Models/ComponentProxyStrategy.h
+//! @brief     Defines class ComponentProxyStrategy
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
+//! @authors   Walter Van Herck, Joachim Wuttke
+//
+// ************************************************************************** //
+
+#ifndef COMPONENTPROXYSTRATEGY_H
+#define COMPONENTPROXYSTRATEGY_H
+
+#include "ProxyModelStrategy.h"
+
+//! Strategy for ComponentProxyModel which hides extra level of GroupProperty.
+
+class BA_CORE_API_ ComponentProxyStrategy : public ProxyModelStrategy
+{
+public:
+    void onDataChanged(SessionModel* source, ComponentProxyModel* proxy);
+
+protected:
+    void processSourceIndex(SessionModel* model, ComponentProxyModel* proxy,
+                            const QModelIndex& index);
+private:
+    bool isGroupChildren(SessionItem* item);
+    void processGroupItem(SessionItem* item, const QPersistentModelIndex& sourceIndex,
+                          const QPersistentModelIndex& proxyIndex);
+};
+
+#endif  //  COMPONENTPROXYSTRATEGY_H

--- a/GUI/coregui/Models/ComponentProxyStrategy.h
+++ b/GUI/coregui/Models/ComponentProxyStrategy.h
@@ -27,8 +27,9 @@ public:
     void onDataChanged(SessionModel* source, ComponentProxyModel* proxy);
 
 protected:
-    void processSourceIndex(const QModelIndex& index);
+    bool processSourceIndex(const QModelIndex& index);
 private:
+    bool isPropertyRelated(SessionItem* item);
     bool isNewRootItem(SessionItem* item);
     void processRootItem(SessionItem* item, const QPersistentModelIndex& sourceIndex);
     bool isGroupChildren(SessionItem* item);

--- a/GUI/coregui/Models/ModelUtils.cpp
+++ b/GUI/coregui/Models/ModelUtils.cpp
@@ -31,3 +31,19 @@ void ModelUtils::iterate(const QModelIndex& index, const QAbstractItemModel* mod
         for (int j = 0; j < model->columnCount(index); ++j)
             iterate(model->index(i, j, index), model, fun);
 }
+
+void ModelUtils::iterate_if(const QModelIndex& index, const QAbstractItemModel* model,
+                            const std::function<bool (const QModelIndex&)>& fun)
+{
+    bool proceed_with_children(true);
+    if (index.isValid())
+        proceed_with_children = fun(index);
+
+    if (!model->hasChildren(index) || !proceed_with_children)
+        return;
+
+    for (int i = 0; i < model->rowCount(index); ++i)
+        for (int j = 0; j < model->columnCount(index); ++j)
+            iterate_if(model->index(i, j, index), model, fun);
+
+}

--- a/GUI/coregui/Models/ModelUtils.h
+++ b/GUI/coregui/Models/ModelUtils.h
@@ -30,7 +30,11 @@ namespace ModelUtils
 BA_CORE_API_ void iterate(const QModelIndex& index, const QAbstractItemModel* model,
                           const std::function<void(const QModelIndex&)>& fun);
 
-}
+//! Iterates through all model indices and calls user function.
+//! If function returns false for given index, iteration will not go down to children.
+BA_CORE_API_ void iterate_if(const QModelIndex& index, const QAbstractItemModel* model,
+                          const std::function<bool(const QModelIndex&)>& fun);
 
+}
 
 #endif  //  MODELUTILS_H

--- a/GUI/coregui/Models/ProxyModelStrategy.cpp
+++ b/GUI/coregui/Models/ProxyModelStrategy.cpp
@@ -18,9 +18,6 @@
 #include "ModelUtils.h"
 #include "ComponentProxyModel.h"
 #include "SessionModel.h"
-#include "SessionItem.h"
-#include "ModelPath.h"
-#include "GroupItem.h"
 
 void ProxyModelStrategy::buildModelMap(SessionModel* source, ComponentProxyModel* proxy)
 {
@@ -80,69 +77,4 @@ void IndentityProxyStrategy::processSourceIndex(SessionModel* model, ComponentPr
         sourceParent = index.parent();
 
     m_proxySourceParent.insert(proxyIndex, sourceParent);
-}
-
-void ComponentProxyStrategy::onDataChanged(SessionModel* source, ComponentProxyModel* proxy)
-{
-    buildModelMap(source, proxy);
-    proxy->layoutChanged();
-}
-
-void ComponentProxyStrategy::processSourceIndex(SessionModel* model, ComponentProxyModel* proxy,
-                                                const QModelIndex& index)
-{
-    QPersistentModelIndex sourceIndex = QPersistentModelIndex(index);
-    QPersistentModelIndex proxyIndex
-        = createProxyIndex(proxy, index.row(), index.column(), index.internalPointer());
-
-    SessionItem* item = model->itemForIndex(index);
-
-    if (item->index() == m_sourceRootIndex) {
-        // if index is desired new source
-        proxyIndex = createProxyIndex(proxy, 0, index.column(), index.internalPointer());
-        m_sourceToProxy.insert(sourceIndex, proxyIndex);
-        m_proxySourceParent.insert(proxyIndex, QModelIndex()); // new parent will be root
-
-    } else if (isGroupChildren(item)) {
-        // do parent substitution here
-        processGroupItem(item, sourceIndex, proxyIndex);
-    } else {
-        m_sourceToProxy.insert(sourceIndex, proxyIndex);
-
-        QPersistentModelIndex sourceParent;
-        if (index.parent().isValid())
-            sourceParent = index.parent();
-
-        m_proxySourceParent.insert(proxyIndex, sourceParent);
-    }
-}
-
-bool ComponentProxyStrategy::isGroupChildren(SessionItem* item)
-{
-    if (item->parent() && item->parent()->modelType() == Constants::GroupItemType)
-        return true;
-
-    if (const SessionItem* ancestor = ModelPath::ancestor(item, Constants::GroupItemType)) {
-        if (ancestor != item)
-            return true;
-    }
-
-    return false;
-}
-
-void ComponentProxyStrategy::processGroupItem(SessionItem* item,
-                                              const QPersistentModelIndex& sourceIndex,
-                                              const QPersistentModelIndex& proxyIndex)
-{
-    if (const SessionItem* ancestor = ModelPath::ancestor(item, Constants::GroupItemType)) {
-        if (ancestor == item)
-            return;
-
-        auto groupItem = dynamic_cast<const GroupItem*>(ancestor);
-        if (item->parent() == groupItem->currentItem()) {
-            m_sourceToProxy.insert(sourceIndex, proxyIndex);
-            m_proxySourceParent.insert(proxyIndex, groupItem->index());
-        }
-
-    }
 }

--- a/GUI/coregui/Models/ProxyModelStrategy.cpp
+++ b/GUI/coregui/Models/ProxyModelStrategy.cpp
@@ -34,7 +34,7 @@ void ProxyModelStrategy::buildModelMap(SessionModel* source, ComponentProxyModel
     m_proxy = proxy;
 
     ModelUtils::iterate(m_sourceRootIndex, source, [=](const QModelIndex& index) {
-        processSourceIndex(index);
+        return processSourceIndex(index);
     });
 
     // kind of hack since we have to visit col=1 which has QModelIndex() parent
@@ -72,7 +72,7 @@ QModelIndex ProxyModelStrategy::createProxyIndex(int nrow, int ncol, void* adata
 
 //! Builds one-to-one mapping for source and proxy.
 
-void IndentityProxyStrategy::processSourceIndex(const QModelIndex& index)
+bool IndentityProxyStrategy::processSourceIndex(const QModelIndex& index)
 {
     QPersistentModelIndex proxyIndex
         = createProxyIndex(index.row(), index.column(), index.internalPointer());
@@ -83,4 +83,6 @@ void IndentityProxyStrategy::processSourceIndex(const QModelIndex& index)
         sourceParent = index.parent();
 
     m_proxySourceParent.insert(proxyIndex, sourceParent);
+
+    return true;
 }

--- a/GUI/coregui/Models/ProxyModelStrategy.h
+++ b/GUI/coregui/Models/ProxyModelStrategy.h
@@ -63,21 +63,4 @@ protected:
                             const QModelIndex& index);
 };
 
-//! Strategy for ComponentProxyModel which hides extra level of GroupProperty.
-
-class BA_CORE_API_ ComponentProxyStrategy : public ProxyModelStrategy
-{
-public:
-    void onDataChanged(SessionModel* source, ComponentProxyModel* proxy);
-
-protected:
-    void processSourceIndex(SessionModel* model, ComponentProxyModel* proxy,
-                            const QModelIndex& index);
-private:
-    bool isGroupChildren(SessionItem* item);
-    void processGroupItem(SessionItem* item, const QPersistentModelIndex& sourceIndex,
-                          const QPersistentModelIndex& proxyIndex);
-
-};
-
 #endif  // ProxyModelStrategy

--- a/GUI/coregui/Models/ProxyModelStrategy.h
+++ b/GUI/coregui/Models/ProxyModelStrategy.h
@@ -31,6 +31,7 @@ class BA_CORE_API_ ProxyModelStrategy
 public:
     using map_t = QMap<QPersistentModelIndex, QPersistentModelIndex>;
 
+    ProxyModelStrategy();
     virtual ~ProxyModelStrategy() = default;
 
     void buildModelMap(SessionModel* source, ComponentProxyModel* proxy);
@@ -42,9 +43,8 @@ public:
     void setRootIndex(const QModelIndex& sourceRootIndex);
 
 protected:
-    QModelIndex createProxyIndex(ComponentProxyModel* proxy, int nrow, int ncol, void* adata);
-    virtual void processSourceIndex(SessionModel* model, ComponentProxyModel* proxy,
-                                    const QModelIndex& index) = 0;
+    QModelIndex createProxyIndex(int nrow, int ncol, void* adata);
+    virtual void processSourceIndex(const QModelIndex& index) = 0;
 
     //!< Mapping of proxy model indices to indices in source model
     QMap<QPersistentModelIndex, QPersistentModelIndex> m_sourceToProxy;
@@ -52,6 +52,8 @@ protected:
     QMap<QPersistentModelIndex, QPersistentModelIndex> m_proxySourceParent;
 
     QModelIndex m_sourceRootIndex;
+    SessionModel* m_source;
+    ComponentProxyModel* m_proxy;
 };
 
 //! Strategy for ComponentProxyModel which makes it identical to source model.
@@ -59,8 +61,7 @@ protected:
 class BA_CORE_API_ IndentityProxyStrategy : public ProxyModelStrategy
 {
 protected:
-    void processSourceIndex(SessionModel* model, ComponentProxyModel* proxy,
-                            const QModelIndex& index);
+    void processSourceIndex(const QModelIndex& index);
 };
 
 #endif  // ProxyModelStrategy

--- a/GUI/coregui/Models/ProxyModelStrategy.h
+++ b/GUI/coregui/Models/ProxyModelStrategy.h
@@ -44,7 +44,7 @@ public:
 
 protected:
     QModelIndex createProxyIndex(int nrow, int ncol, void* adata);
-    virtual void processSourceIndex(const QModelIndex& index) = 0;
+    virtual bool processSourceIndex(const QModelIndex& index) = 0;
 
     //!< Mapping of proxy model indices to indices in source model
     QMap<QPersistentModelIndex, QPersistentModelIndex> m_sourceToProxy;
@@ -61,7 +61,7 @@ protected:
 class BA_CORE_API_ IndentityProxyStrategy : public ProxyModelStrategy
 {
 protected:
-    void processSourceIndex(const QModelIndex& index);
+    bool processSourceIndex(const QModelIndex& index);
 };
 
 #endif  // ProxyModelStrategy

--- a/GUI/coregui/Models/SessionItemUtils.cpp
+++ b/GUI/coregui/Models/SessionItemUtils.cpp
@@ -42,3 +42,21 @@ void SessionItemUtils::SetVectorItem(const SessionItem& item, const QString& nam
     p_vector_item->setItemValue(VectorItem::P_Y, value.y());
     p_vector_item->setItemValue(VectorItem::P_Z, value.z());
 }
+
+int SessionItemUtils::ParentVisibleRow(const SessionItem& item)
+{
+    int result(-1);
+
+    if (!item.parent() || !item.isVisible())
+        return result;
+
+    for(auto child : item.parent()->children()) {
+        if (child->isVisible())
+            ++result;
+
+        if (&item == child)
+            return result;
+    }
+
+    return result;
+}

--- a/GUI/coregui/Models/SessionItemUtils.h
+++ b/GUI/coregui/Models/SessionItemUtils.h
@@ -28,11 +28,17 @@ namespace SessionItemUtils
 //! Returns the index of the given item within its parent. Returns -1 when no parent is set.
 BA_CORE_API_ int ParentRow(const SessionItem& item);
 
-//! Returns a VectorType group property's value as a kvector_t
+//! Returns a VectorType group property's value as a kvector_t.
 BA_CORE_API_ kvector_t GetVectorItem(const SessionItem& item, const QString& name);
 
-//! Returns a VectorType group property's value as a kvector_t
+//! Returns a VectorType group property's value as a kvector_t.
 BA_CORE_API_ void SetVectorItem(const SessionItem& item, const QString& name, kvector_t value);
+
+//! Returns the row of the given item within its parent not accounting for all hidden items
+//! above. Returns -1 when no parent set or item is hidden.
+
+BA_CORE_API_ int ParentVisibleRow(const SessionItem& item);
+
 }  // namespace SessionItemUtils
 
 #endif // SESSIONITEMUTILS_H

--- a/GUI/coregui/Views/PropertyEditor/ComponentTreeView.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ComponentTreeView.cpp
@@ -1,0 +1,60 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Views/PropertyEditor/ComponentTreeView.cpp
+//! @brief     Implements class ComponentTreeView
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
+//! @authors   Walter Van Herck, Joachim Wuttke
+//
+// ************************************************************************** //
+
+#include "ComponentTreeView.h"
+#include "ComponentProxyModel.h"
+#include "StyleUtils.h"
+#include "SessionModelDelegate.h"
+#include "SessionModel.h"
+#include <QTreeView>
+#include <QBoxLayout>
+
+ComponentTreeView::ComponentTreeView(QWidget* parent)
+    : QWidget(parent)
+    , m_tree(new QTreeView)
+    , m_delegate(new SessionModelDelegate(this))
+    , m_proxyModel(new ComponentProxyModel(this))
+{
+    auto layout = new QVBoxLayout;
+
+    layout->setMargin(0);
+    layout->setSpacing(0);
+    layout->addWidget(m_tree);
+
+    setLayout(layout);
+
+    StyleUtils::setPropertyStyle(m_tree);
+    m_tree->setRootIsDecorated(false);
+    m_tree->setModel(m_proxyModel);
+    m_tree->setItemDelegate(m_delegate);
+}
+
+void ComponentTreeView::setModel(SessionModel* model)
+{
+    m_proxyModel->setSessionModel(model);
+}
+
+void ComponentTreeView::setRootIndex(const QModelIndex& index)
+{
+    Q_ASSERT(m_proxyModel);
+    m_proxyModel->setRootIndex(index);
+}
+
+QTreeView* ComponentTreeView::treeView()
+{
+    return m_tree;
+}
+

--- a/GUI/coregui/Views/PropertyEditor/ComponentTreeView.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentTreeView.h
@@ -1,0 +1,49 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Views/PropertyEditor/ComponentTreeView.h
+//! @brief     Defines class ComponentTreeView
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
+//! @authors   Walter Van Herck, Joachim Wuttke
+//
+// ************************************************************************** //
+
+#ifndef COMPONENTTREEVIEW_H
+#define COMPONENTTREEVIEW_H
+
+#include "WinDllMacros.h"
+#include <QWidget>
+
+class QTreeView;
+class SessionModel;
+class SessionModelDelegate;
+class ComponentProxyModel;
+class QModelIndex;
+
+//! Component property tree for SessionItems.
+//! Shows only PropertyItems and current items of GroupProperties.
+
+class BA_CORE_API_ ComponentTreeView : public QWidget
+{
+    Q_OBJECT
+public:
+    ComponentTreeView(QWidget* parent = nullptr);
+
+    void setModel(SessionModel* model);
+    void setRootIndex(const QModelIndex& index);
+
+    QTreeView* treeView();
+
+private:
+    QTreeView* m_tree;
+    SessionModelDelegate* m_delegate;
+    ComponentProxyModel* m_proxyModel;
+};
+
+#endif  //  COMPONENTTREEVIEW_H

--- a/GUI/coregui/Views/PropertyEditor/TestComponentView.cpp
+++ b/GUI/coregui/Views/PropertyEditor/TestComponentView.cpp
@@ -16,7 +16,6 @@
 
 #include "TestComponentView.h"
 #include "mainwindow.h"
-#include "ComponentProxyModel.h"
 #include "SampleModel.h"
 #include "item_constants.h"
 #include "SessionModelDelegate.h"
@@ -26,6 +25,7 @@
 #include "GUIObjectBuilder.h"
 #include "MultiLayer.h"
 #include "SampleModel.h"
+#include "ComponentTreeView.h"
 #include <QTreeView>
 #include <QBoxLayout>
 #include <QItemSelectionModel>
@@ -35,9 +35,8 @@
 TestComponentView::TestComponentView(MainWindow* mainWindow)
     : m_mainWindow(mainWindow)
     , m_sourceModel(new SampleModel(this))
-    , m_proxyModel(new ComponentProxyModel(this))
     , m_sourceTree(new QTreeView)
-    , m_proxyTree(new QTreeView)
+    , m_componentTree(new ComponentTreeView)
     , m_updateButton(new QPushButton("Update models"))
     , m_addItemButton(new QPushButton("Add item"))
     , m_expandButton(new QPushButton("Expand tree"))
@@ -51,7 +50,7 @@ TestComponentView::TestComponentView(MainWindow* mainWindow)
 
     auto widgetLayout = new QHBoxLayout;
     widgetLayout->addWidget(m_sourceTree);
-    widgetLayout->addWidget(m_proxyTree);
+    widgetLayout->addWidget(m_componentTree);
 
     auto layout = new QVBoxLayout();
     layout->setMargin(0);
@@ -73,19 +72,11 @@ TestComponentView::TestComponentView(MainWindow* mainWindow)
     connect(m_sourceTree->selectionModel(), &QItemSelectionModel::selectionChanged,
             this, &TestComponentView::onSelectionChanged);
 
-    m_proxyTree->setModel(m_proxyModel);
-//    m_proxyTree->setModel(m_sourceModel);
-    m_proxyTree->setItemDelegate(m_delegate);
-    m_proxyTree->setRootIsDecorated(false);
-    StyleUtils::setPropertyStyle(m_proxyTree);
 }
 
 void TestComponentView::onUpdateRequest()
 {
-    qDebug() << "TestComponentView::onUpdateRequest() ->";
-    m_proxyModel->setSessionModel(m_sourceModel);
-    m_proxyModel->setRootIndex(QModelIndex());
-    m_proxyTree->reset();
+    m_componentTree->setModel(m_sourceModel);
 }
 
 void TestComponentView::onAddItemRequest()
@@ -99,12 +90,12 @@ void TestComponentView::onExpandRequest()
         m_sourceTree->expandAll();
         m_sourceTree->resizeColumnToContents(0);
         m_sourceTree->resizeColumnToContents(1);
-        m_proxyTree->expandAll();
-        m_proxyTree->resizeColumnToContents(0);
-        m_proxyTree->resizeColumnToContents(1);
+        m_componentTree->treeView()->expandAll();
+        m_componentTree->treeView()->resizeColumnToContents(0);
+        m_componentTree->treeView()->resizeColumnToContents(1);
     } else {
         m_sourceTree->collapseAll();
-        m_proxyTree->collapseAll();
+        m_componentTree->treeView()->collapseAll();
     }
     m_isExpaned = !m_isExpaned;
 }
@@ -132,8 +123,8 @@ void TestComponentView::onSelectionChanged(const QItemSelection& selected, const
 
     if (indexes.size()) {
         QModelIndex selectedIndex = indexes.front();
-        m_proxyModel->setRootIndex(selectedIndex);
-        m_proxyTree->expandAll();
+        m_componentTree->setRootIndex(selectedIndex);
+        m_componentTree->treeView()->expandAll();
     }
 
 }

--- a/GUI/coregui/Views/PropertyEditor/TestComponentView.h
+++ b/GUI/coregui/Views/PropertyEditor/TestComponentView.h
@@ -22,11 +22,11 @@
 
 class MainWindow;
 class QPushButton;
-class ComponentProxyModel;
 class QTreeView;
 class SampleModel;
 class SessionModelDelegate;
 class QItemSelection;
+class ComponentTreeView;
 
 //! View to tests QListView working with ComponentProxyModel.
 
@@ -47,9 +47,8 @@ private:
 
     MainWindow* m_mainWindow;
     SampleModel* m_sourceModel;
-    ComponentProxyModel* m_proxyModel;
     QTreeView* m_sourceTree;
-    QTreeView* m_proxyTree;
+    ComponentTreeView* m_componentTree;
     QPushButton* m_updateButton;
     QPushButton* m_addItemButton;
     QPushButton* m_expandButton;

--- a/Tests/UnitTests/GUI/TestComponentProxyModel.h
+++ b/Tests/UnitTests/GUI/TestComponentProxyModel.h
@@ -5,6 +5,7 @@
 #include "ComponentProxyModel.h"
 #include "VectorItem.h"
 #include "ProxyModelStrategy.h"
+#include "ComponentProxyStrategy.h"
 #include "ParticleItem.h"
 #include "FormFactorItems.h"
 #include "GroupItem.h"

--- a/Tests/UnitTests/GUI/TestComponentProxyModel.h
+++ b/Tests/UnitTests/GUI/TestComponentProxyModel.h
@@ -382,7 +382,7 @@ inline void TestComponentProxyModel::test_setRootIndexLayer()
     QVERIFY(multilayerProxyIndex.isValid() == false);
 
     QModelIndex layerProxyIndex = proxy.mapFromSource(model.indexOfItem(layer1));
-    QCOMPARE(proxy.rowCount(layerProxyIndex), 6); // thickness, roughness, etc
+    QCOMPARE(proxy.rowCount(layerProxyIndex), 4); // thickness, material, slices, roughness
     QCOMPARE(proxy.columnCount(layerProxyIndex), 2);
     QVERIFY(layerProxyIndex.isValid());
     QVERIFY(layerProxyIndex.parent() == QModelIndex());

--- a/Tests/UnitTests/GUI/TestGUI.cpp
+++ b/Tests/UnitTests/GUI/TestGUI.cpp
@@ -96,7 +96,7 @@ int main(int argc, char** argv) {
 //    tests.add<TestParticleCoreShell>();
 //    tests.add<TestPropertyRepeater>();
 //    tests.add<TestSessionItemController>();
-//    tests.add<TestModelUtils>();
+    tests.add<TestModelUtils>();
     tests.add<TestComponentProxyModel>();
     tests.add<TestProxyModelStrategy>();
 

--- a/Tests/UnitTests/GUI/TestGUI.cpp
+++ b/Tests/UnitTests/GUI/TestGUI.cpp
@@ -34,6 +34,7 @@
 #include "TestModelUtils.h"
 #include "TestComponentProxyModel.h"
 #include "TestProxyModelStrategy.h"
+#include "TestSessionItemUtils.h"
 #include <memory>
 
 class GUITestFactory {
@@ -99,6 +100,7 @@ int main(int argc, char** argv) {
     tests.add<TestModelUtils>();
     tests.add<TestComponentProxyModel>();
     tests.add<TestProxyModelStrategy>();
+    tests.add<TestSessionItemUtils>();
 
     return tests.runAll(argc, argv);
 }

--- a/Tests/UnitTests/GUI/TestModelUtils.h
+++ b/Tests/UnitTests/GUI/TestModelUtils.h
@@ -3,17 +3,32 @@
 #include "SessionModel.h"
 #include "item_constants.h"
 #include "VectorItem.h"
+#include "LayerItem.h"
 #include <QVector>
 #include <QDebug>
 
 class TestModelUtils : public QObject
 {
     Q_OBJECT
-public:
+private:
+
+    //! Returns true if model contains given item using iterate_if procedure.
+    bool modelContainsItem(SessionModel* model, SessionItem* selectedItem)
+    {
+        bool result = false;
+        ModelUtils::iterate_if(QModelIndex(), model, [&](const QModelIndex& index) -> bool {
+            SessionItem* item = model->itemForIndex(index);
+            if(item == selectedItem)
+                result = true;
+            return item->isVisible();
+        });
+        return result;
+    }
 
 private slots:
     void test_emptyModel();
     void test_vectorItem();
+    void test_iterateIf();
 };
 
 //! Testing iteration over empty model.
@@ -56,4 +71,26 @@ inline void TestModelUtils::test_vectorItem()
     QCOMPARE(indices.size(), 4); // (VectorItem, P_X, P_Y, P_Z) x (row, col)
     QCOMPARE(model.itemForIndex(indices.front()), vectorItem);
     QCOMPARE(model.itemForIndex(indices.back()), vectorItem->getItem(VectorItem::P_Z));
+}
+
+//! Tests iteration when some children is invisible.
+
+inline void TestModelUtils::test_iterateIf()
+{
+    SessionModel model("TestModel");
+    SessionItem* multilayer = model.insertNewItem(Constants::MultiLayerType);
+    SessionItem* layer = model.insertNewItem(Constants::LayerType, model.indexOfItem(multilayer));
+    SessionItem* thicknessItem = layer->getItem(LayerItem::P_THICKNESS);
+
+    layer->setVisible(true);
+    QVERIFY(modelContainsItem(&model, layer) == true);
+    QVERIFY(modelContainsItem(&model, thicknessItem) == true);
+
+    // Setting layer invisible will hide its children from iteration.
+    // Layer itself still will be visible.
+    layer->setVisible(false);
+
+    layer->setVisible(false);
+    QVERIFY(modelContainsItem(&model, layer) == true);
+    QVERIFY(modelContainsItem(&model, thicknessItem) == false);
 }

--- a/Tests/UnitTests/GUI/TestSessionItemUtils.h
+++ b/Tests/UnitTests/GUI/TestSessionItemUtils.h
@@ -1,0 +1,56 @@
+#include <QtTest>
+#include "SessionItemUtils.h"
+#include "SessionModel.h"
+#include "SessionItem.h"
+#include "VectorItem.h"
+#include "item_constants.h"
+
+class TestSessionItemUtils : public QObject
+{
+    Q_OBJECT
+public:
+
+private slots:
+    void test_ParentVisibleRow();
+};
+
+//! Test SessionItemUtils::ParentVisibleRow utility method.
+
+inline void TestSessionItemUtils::test_ParentVisibleRow()
+{
+    SessionModel model("TestModel");
+
+    // 3 property items in root, all visible
+    auto item1 = model.insertNewItem(Constants::PropertyType);
+    auto item2 = model.insertNewItem(Constants::PropertyType);
+    auto item3 = model.insertNewItem(Constants::PropertyType);
+    QCOMPARE(SessionItemUtils::ParentVisibleRow(*item1), 0);
+    QCOMPARE(SessionItemUtils::ParentVisibleRow(*item2), 1);
+    QCOMPARE(SessionItemUtils::ParentVisibleRow(*item3), 2);
+
+    // one item become invisible
+    item2->setVisible(false);
+    QCOMPARE(SessionItemUtils::ParentVisibleRow(*item1), 0);
+    QCOMPARE(SessionItemUtils::ParentVisibleRow(*item2), -1);
+    QCOMPARE(SessionItemUtils::ParentVisibleRow(*item3), 1);
+
+    // two more items
+    auto item4 = model.insertNewItem(Constants::PropertyType);
+    auto item5 = model.insertNewItem(Constants::PropertyType);
+    item5->setVisible(false);
+    QCOMPARE(SessionItemUtils::ParentVisibleRow(*item1), 0);
+    QCOMPARE(SessionItemUtils::ParentVisibleRow(*item2), -1);
+    QCOMPARE(SessionItemUtils::ParentVisibleRow(*item3), 1);
+    QCOMPARE(SessionItemUtils::ParentVisibleRow(*item4), 2);
+    QCOMPARE(SessionItemUtils::ParentVisibleRow(*item5), -1);
+
+    // adding vector item
+    SessionItem* vector = model.insertNewItem(Constants::VectorType);
+    auto x = vector->getItem(VectorItem::P_X);
+    auto y = vector->getItem(VectorItem::P_Y);
+    auto z = vector->getItem(VectorItem::P_Z);
+    x->setVisible(false);
+    QCOMPARE(SessionItemUtils::ParentVisibleRow(*x), -1);
+    QCOMPARE(SessionItemUtils::ParentVisibleRow(*y), 0);
+    QCOMPARE(SessionItemUtils::ParentVisibleRow(*z), 1);
+}


### PR DESCRIPTION
* Hidden items are not shown in editor
* Only property-related items are shown (i.e. no ParticleLayout in LayerItem tree)
