### PR TITLE
Renamed BornAgainMacros.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,6 @@ endif()
 
 #--- Include CMake macros and functions ---
 include(GetFilenameComponent) # overwrite CMake command
-include(BornAgainMacros)
 include(SearchInstalledSoftware)
 include(CheckCompiler)
 if(ZERO_TOLERANCE)

--- a/cmake/bornagain/modules/SearchInstalledSoftware.cmake
+++ b/cmake/bornagain/modules/SearchInstalledSoftware.cmake
@@ -67,6 +67,7 @@ if(BORNAGAIN_PYTHON OR BORNAGAIN_GUI)
     message(STATUS "Found Python libraries version ${PYTHONLIBS_VERSION_STRING} at ${PYTHON_LIBRARIES}; includes at ${PYTHON_INCLUDE_DIRS}")
 
     if(NOT WIN32)
+        include(ValidatePythonInstallation)
         ValidatePythonInstallation()
     endif()
 

--- a/cmake/bornagain/modules/ValidatePythonInstallation.cmake
+++ b/cmake/bornagain/modules/ValidatePythonInstallation.cmake
@@ -1,4 +1,3 @@
-
 function(ValidatePythonInstallation)
     message(STATUS "--> Validating Python installation corresponding to the interpreter ${PYTHON_EXECUTABLE}")
 


### PR DESCRIPTION
File BornAgainMacros.cmake contained one single macro.
Therefore renamed. Moved include statement.