### PR TITLE
New ComponentEditor

### DIFF
--- a/GUI/coregui/Models/SessionModelDelegate.cpp
+++ b/GUI/coregui/Models/SessionModelDelegate.cpp
@@ -15,7 +15,6 @@
 // ************************************************************************** //
 
 #include "SessionModelDelegate.h"
-#include "PropertyBrowserUtils.h"
 #include "SessionItem.h"
 #include "PropertyEditorFactory.h"
 #include "CustomEditors.h"

--- a/GUI/coregui/Views/FitWidgets/MinimizerSettingsWidget.cpp
+++ b/GUI/coregui/Views/FitWidgets/MinimizerSettingsWidget.cpp
@@ -15,7 +15,7 @@
 // ************************************************************************** //
 
 #include "MinimizerSettingsWidget.h"
-#include "ComponentTreeView.h"
+#include "ComponentEditor.h"
 #include "FitSuiteItem.h"
 #include "JobItem.h"
 #include "MinimizerItem.h"
@@ -25,7 +25,7 @@
 MinimizerSettingsWidget::MinimizerSettingsWidget(QWidget *parent)
     : QWidget(parent)
     , m_currentItem(nullptr)
-    , m_propertyEditor(new ComponentTreeView)
+    , m_componentEditor(new ComponentEditor)
 {
     setWindowTitle(QLatin1String("Minimizer Settings"));
 
@@ -33,7 +33,7 @@ MinimizerSettingsWidget::MinimizerSettingsWidget(QWidget *parent)
     layout->setMargin(0);
     layout->setSpacing(0);
     layout->setContentsMargins(0, 0, 0, 0);
-    layout->addWidget(m_propertyEditor);
+    layout->addWidget(m_componentEditor);
 
     setLayout(layout);
 }
@@ -53,5 +53,5 @@ void MinimizerSettingsWidget::setItem(MinimizerContainerItem* minimizerItem)
 {
     Q_ASSERT(minimizerItem);
     m_currentItem = minimizerItem;
-    m_propertyEditor->setItem(minimizerItem);
+    m_componentEditor->setItem(minimizerItem);
 }

--- a/GUI/coregui/Views/FitWidgets/MinimizerSettingsWidget.h
+++ b/GUI/coregui/Views/FitWidgets/MinimizerSettingsWidget.h
@@ -20,7 +20,7 @@
 #include "WinDllMacros.h"
 #include <QWidget>
 
-class ComponentTreeView;
+class ComponentEditor;
 class JobItem;
 class MinimizerContainerItem;
 
@@ -42,7 +42,7 @@ public slots:
 
 private:
     MinimizerContainerItem* m_currentItem;
-    ComponentTreeView* m_propertyEditor;
+    ComponentEditor* m_componentEditor;
 };
 
 #endif // MINIMIZERSETTINGSWIDGET_H

--- a/GUI/coregui/Views/InfoWidgets/DistributionEditor.cpp
+++ b/GUI/coregui/Views/InfoWidgets/DistributionEditor.cpp
@@ -56,7 +56,7 @@ DistributionEditor::DistributionEditor(QWidget* parent)
 void DistributionEditor::subscribeToItem()
 {
     m_propertyEditor->clearEditor();
-    m_propertyEditor->addItemProperties(currentItem());
+    m_propertyEditor->setItem(currentItem());
 
     currentItem()->mapper()->setOnPropertyChange(
         [this](const QString& name) { onPropertyChanged(name); }, this);

--- a/GUI/coregui/Views/InstrumentWidgets/BeamEditorWidget.cpp
+++ b/GUI/coregui/Views/InstrumentWidgets/BeamEditorWidget.cpp
@@ -17,7 +17,7 @@
 #include "BeamEditorWidget.h"
 #include "BeamDistributionItem.h"
 #include "BeamItem.h"
-#include "ComponentBoxEditor.h"
+#include "ObsoleteComponentBoxEditor.h"
 #include "ComponentInfoBox.h"
 #include "DistributionDialog.h"
 #include <QGridLayout>
@@ -31,11 +31,11 @@ const QString name_of_groupbox_azimuthal("Azimuthal angle [deg]");
 
 BeamEditorWidget::BeamEditorWidget(QWidget* parent)
     : QWidget(parent)
-    , m_intensityEditor(new ComponentBoxEditor)
+    , m_intensityEditor(new ObsoleteComponentBoxEditor)
     , m_wavelengthPresenter(new ComponentInfoBox(name_of_groupbox_wavenlength))
     , m_inclinationAnglePresenter(new ComponentInfoBox(name_of_groupbox_inclination))
     , m_azimuthalAnglePresenter(new ComponentInfoBox(name_of_groupbox_azimuthal))
-    , m_polarizationPresenter(new ComponentBoxEditor)
+    , m_polarizationPresenter(new ObsoleteComponentBoxEditor)
     , m_gridLayout(new QGridLayout)
     , m_beamItem(nullptr)
 {

--- a/GUI/coregui/Views/InstrumentWidgets/BeamEditorWidget.cpp
+++ b/GUI/coregui/Views/InstrumentWidgets/BeamEditorWidget.cpp
@@ -24,58 +24,58 @@
 
 namespace
 {
-const QString name_of_groupbox_wavenlength("Wavelength [nm]");
-const QString name_of_groupbox_inclination("Inclination angle [deg]");
-const QString name_of_groupbox_azimuthal("Azimuthal angle [deg]");
-const QString name_of_polarization_presenter("Polarization (Bloch vector)");
+const QString wavenlength_title("Wavelength [nm]");
+const QString inclination_title("Inclination angle [deg]");
+const QString azimuthal_title("Azimuthal angle [deg]");
+const QString polarization_title("Polarization (Bloch vector)");
 }
 
 BeamEditorWidget::BeamEditorWidget(QWidget* parent)
     : QWidget(parent)
-    , m_intensityEditor(new ComponentEditor(ComponentEditor::PlainWidget))
-    , m_wavelengthPresenter(new ComponentEditor(ComponentEditor::InfoWidget, name_of_groupbox_wavenlength))
-    , m_inclinationAnglePresenter(new ComponentEditor(ComponentEditor::InfoWidget, name_of_groupbox_inclination))
-    , m_azimuthalAnglePresenter(new ComponentEditor(ComponentEditor::InfoWidget, name_of_groupbox_azimuthal))
-    , m_polarizationPresenter(new ComponentEditor(ComponentEditor::GroupWidget, name_of_polarization_presenter))
-    , m_gridLayout(new QGridLayout)
+    , m_intensityEditor(new ComponentEditor(ComponentEditor::PlainWidget)),
+      m_wavelengthEditor(new ComponentEditor(ComponentEditor::InfoWidget, wavenlength_title)),
+      m_inclinationEditor(new ComponentEditor(ComponentEditor::InfoWidget, inclination_title)),
+      m_azimuthalEditor(new ComponentEditor(ComponentEditor::InfoWidget, azimuthal_title)),
+      m_polarizationEditor(new ComponentEditor(ComponentEditor::GroupWidget, polarization_title)),
+      m_gridLayout(new QGridLayout)
     , m_beamItem(nullptr)
 {
     setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
 
     // whole content is represented as grid layout
     m_gridLayout->addWidget(m_intensityEditor, 0, 0);
-    m_gridLayout->addWidget(m_wavelengthPresenter, 1, 0);
-    m_gridLayout->addWidget(m_inclinationAnglePresenter, 1, 1);
-    m_gridLayout->addWidget(m_azimuthalAnglePresenter, 1, 2);
-    m_gridLayout->addWidget(m_polarizationPresenter, 1, 3);
+    m_gridLayout->addWidget(m_wavelengthEditor, 1, 0);
+    m_gridLayout->addWidget(m_inclinationEditor, 1, 1);
+    m_gridLayout->addWidget(m_azimuthalEditor, 1, 2);
+    m_gridLayout->addWidget(m_polarizationEditor, 1, 3);
 
-    QGroupBox* groupBox = new QGroupBox(QStringLiteral("Beam Parameters"));
-    QVBoxLayout* groupLayout = new QVBoxLayout;
+    auto groupBox = new QGroupBox(QStringLiteral("Beam Parameters"));
+    auto groupLayout = new QVBoxLayout;
     groupBox->setLayout(groupLayout);
     groupLayout->addLayout(m_gridLayout);
 
     // main layout
-    QVBoxLayout* mainLayout = new QVBoxLayout;
+    auto mainLayout = new QVBoxLayout;
     mainLayout->addWidget(groupBox);
     mainLayout->addStretch();
     setLayout(mainLayout);
 
-    connect(m_wavelengthPresenter, &ComponentEditor::dialogRequest,
-            this, &BeamEditorWidget::onDialogRequest);
-    connect(m_inclinationAnglePresenter, &ComponentEditor::dialogRequest,
-            this, &BeamEditorWidget::onDialogRequest);
-    connect(m_azimuthalAnglePresenter, &ComponentEditor::dialogRequest,
-            this, &BeamEditorWidget::onDialogRequest);
+    connect(m_wavelengthEditor, &ComponentEditor::dialogRequest, this,
+            &BeamEditorWidget::onDialogRequest);
+    connect(m_inclinationEditor, &ComponentEditor::dialogRequest, this,
+            &BeamEditorWidget::onDialogRequest);
+    connect(m_azimuthalEditor, &ComponentEditor::dialogRequest, this,
+            &BeamEditorWidget::onDialogRequest);
 }
 
 void BeamEditorWidget::setBeamItem(BeamItem* beamItem)
 {
     m_beamItem = beamItem;
     m_intensityEditor->clearEditor();
-    m_wavelengthPresenter->clearEditor();
-    m_inclinationAnglePresenter->clearEditor();
-    m_azimuthalAnglePresenter->clearEditor();
-    m_polarizationPresenter->clearEditor();
+    m_wavelengthEditor->clearEditor();
+    m_inclinationEditor->clearEditor();
+    m_azimuthalEditor->clearEditor();
+    m_polarizationEditor->clearEditor();
 
     if (!m_beamItem)
         return;
@@ -83,19 +83,19 @@ void BeamEditorWidget::setBeamItem(BeamItem* beamItem)
     m_intensityEditor->setItem(m_beamItem->getItem(BeamItem::P_INTENSITY));
 
     SessionItem* wavelengthItem = m_beamItem->getItem(BeamItem::P_WAVELENGTH);
-    m_wavelengthPresenter->setItem(
+    m_wavelengthEditor->setItem(
         wavelengthItem->getItem(BeamDistributionItem::P_DISTRIBUTION));
 
     SessionItem* inclinationAngleItem = m_beamItem->getItem(BeamItem::P_INCLINATION_ANGLE);
-    m_inclinationAnglePresenter->setItem(
+    m_inclinationEditor->setItem(
         inclinationAngleItem->getItem(BeamDistributionItem::P_DISTRIBUTION));
 
     SessionItem* azimuthalAngleItem = m_beamItem->getItem(BeamItem::P_AZIMUTHAL_ANGLE);
-    m_azimuthalAnglePresenter->setItem(
+    m_azimuthalEditor->setItem(
         azimuthalAngleItem->getItem(BeamDistributionItem::P_DISTRIBUTION));
 
     SessionItem* polarizationItem = m_beamItem->getItem(BeamItem::P_POLARIZATION);
-    m_polarizationPresenter->setItem(polarizationItem);
+    m_polarizationEditor->setItem(polarizationItem);
 }
 
 void BeamEditorWidget::onDialogRequest(SessionItem* item, const QString& name)
@@ -103,7 +103,7 @@ void BeamEditorWidget::onDialogRequest(SessionItem* item, const QString& name)
     if(!item)
         return;
 
-    DistributionDialog* dialog = new DistributionDialog(this);
+    auto dialog = new DistributionDialog(this);
     dialog->setItem(item);
     dialog->setNameOfEditor(name);
     dialog->show();

--- a/GUI/coregui/Views/InstrumentWidgets/BeamEditorWidget.cpp
+++ b/GUI/coregui/Views/InstrumentWidgets/BeamEditorWidget.cpp
@@ -17,25 +17,26 @@
 #include "BeamEditorWidget.h"
 #include "BeamDistributionItem.h"
 #include "BeamItem.h"
-#include "ObsoleteComponentBoxEditor.h"
-#include "ComponentInfoBox.h"
+#include "ComponentEditor.h"
 #include "DistributionDialog.h"
 #include <QGridLayout>
+#include <QGroupBox>
 
 namespace
 {
 const QString name_of_groupbox_wavenlength("Wavelength [nm]");
 const QString name_of_groupbox_inclination("Inclination angle [deg]");
 const QString name_of_groupbox_azimuthal("Azimuthal angle [deg]");
+const QString name_of_polarization_presenter("Polarization (Bloch vector)");
 }
 
 BeamEditorWidget::BeamEditorWidget(QWidget* parent)
     : QWidget(parent)
-    , m_intensityEditor(new ObsoleteComponentBoxEditor)
-    , m_wavelengthPresenter(new ComponentInfoBox(name_of_groupbox_wavenlength))
-    , m_inclinationAnglePresenter(new ComponentInfoBox(name_of_groupbox_inclination))
-    , m_azimuthalAnglePresenter(new ComponentInfoBox(name_of_groupbox_azimuthal))
-    , m_polarizationPresenter(new ObsoleteComponentBoxEditor)
+    , m_intensityEditor(new ComponentEditor(ComponentEditor::PlainWidget))
+    , m_wavelengthPresenter(new ComponentEditor(ComponentEditor::InfoWidget, name_of_groupbox_wavenlength))
+    , m_inclinationAnglePresenter(new ComponentEditor(ComponentEditor::InfoWidget, name_of_groupbox_inclination))
+    , m_azimuthalAnglePresenter(new ComponentEditor(ComponentEditor::InfoWidget, name_of_groupbox_azimuthal))
+    , m_polarizationPresenter(new ComponentEditor(ComponentEditor::GroupWidget, name_of_polarization_presenter))
     , m_gridLayout(new QGridLayout)
     , m_beamItem(nullptr)
 {
@@ -59,11 +60,11 @@ BeamEditorWidget::BeamEditorWidget(QWidget* parent)
     mainLayout->addStretch();
     setLayout(mainLayout);
 
-    connect(m_wavelengthPresenter, &ComponentInfoBox::onDialogRequest,
+    connect(m_wavelengthPresenter, &ComponentEditor::dialogRequest,
             this, &BeamEditorWidget::onDialogRequest);
-    connect(m_inclinationAnglePresenter, &ComponentInfoBox::onDialogRequest,
+    connect(m_inclinationAnglePresenter, &ComponentEditor::dialogRequest,
             this, &BeamEditorWidget::onDialogRequest);
-    connect(m_azimuthalAnglePresenter, &ComponentInfoBox::onDialogRequest,
+    connect(m_azimuthalAnglePresenter, &ComponentEditor::dialogRequest,
             this, &BeamEditorWidget::onDialogRequest);
 }
 
@@ -79,23 +80,22 @@ void BeamEditorWidget::setBeamItem(BeamItem* beamItem)
     if (!m_beamItem)
         return;
 
-    m_intensityEditor->addItem(m_beamItem->getItem(BeamItem::P_INTENSITY));
+    m_intensityEditor->setItem(m_beamItem->getItem(BeamItem::P_INTENSITY));
 
     SessionItem* wavelengthItem = m_beamItem->getItem(BeamItem::P_WAVELENGTH);
-    m_wavelengthPresenter->addPropertyItems(
+    m_wavelengthPresenter->setItem(
         wavelengthItem->getItem(BeamDistributionItem::P_DISTRIBUTION));
 
     SessionItem* inclinationAngleItem = m_beamItem->getItem(BeamItem::P_INCLINATION_ANGLE);
-    m_inclinationAnglePresenter->addPropertyItems(
+    m_inclinationAnglePresenter->setItem(
         inclinationAngleItem->getItem(BeamDistributionItem::P_DISTRIBUTION));
 
     SessionItem* azimuthalAngleItem = m_beamItem->getItem(BeamItem::P_AZIMUTHAL_ANGLE);
-    m_azimuthalAnglePresenter->addPropertyItems(
+    m_azimuthalAnglePresenter->setItem(
         azimuthalAngleItem->getItem(BeamDistributionItem::P_DISTRIBUTION));
 
     SessionItem* polarizationItem = m_beamItem->getItem(BeamItem::P_POLARIZATION);
-    m_polarizationPresenter->addPropertyItems(
-        polarizationItem, QStringLiteral("Polarization (Bloch vector)"));
+    m_polarizationPresenter->setItem(polarizationItem);
 }
 
 void BeamEditorWidget::onDialogRequest(SessionItem* item, const QString& name)

--- a/GUI/coregui/Views/InstrumentWidgets/BeamEditorWidget.h
+++ b/GUI/coregui/Views/InstrumentWidgets/BeamEditorWidget.h
@@ -22,8 +22,7 @@
 #include <QWidget>
 
 class BeamItem;
-class ObsoleteComponentBoxEditor;
-class ComponentInfoBox;
+class ComponentEditor;
 class QGridLayout;
 
 class BA_CORE_API_ BeamEditorWidget : public QWidget
@@ -38,11 +37,11 @@ public:
 
 private:
     void onDialogRequest(SessionItem* item, const QString& name);
-    ObsoleteComponentBoxEditor* m_intensityEditor;
-    ComponentInfoBox* m_wavelengthPresenter;
-    ComponentInfoBox* m_inclinationAnglePresenter;
-    ComponentInfoBox* m_azimuthalAnglePresenter;
-    ObsoleteComponentBoxEditor* m_polarizationPresenter;
+    ComponentEditor* m_intensityEditor;
+    ComponentEditor* m_wavelengthPresenter;
+    ComponentEditor* m_inclinationAnglePresenter;
+    ComponentEditor* m_azimuthalAnglePresenter;
+    ComponentEditor* m_polarizationPresenter;
     QGridLayout* m_gridLayout;
     BeamItem* m_beamItem;
 };

--- a/GUI/coregui/Views/InstrumentWidgets/BeamEditorWidget.h
+++ b/GUI/coregui/Views/InstrumentWidgets/BeamEditorWidget.h
@@ -29,7 +29,7 @@ class BA_CORE_API_ BeamEditorWidget : public QWidget
 {
     Q_OBJECT
 public:
-    BeamEditorWidget(QWidget* parent = 0);
+    BeamEditorWidget(QWidget* parent = nullptr);
 
     void setBeamItem(BeamItem* beamItem);
 
@@ -38,10 +38,10 @@ public:
 private:
     void onDialogRequest(SessionItem* item, const QString& name);
     ComponentEditor* m_intensityEditor;
-    ComponentEditor* m_wavelengthPresenter;
-    ComponentEditor* m_inclinationAnglePresenter;
-    ComponentEditor* m_azimuthalAnglePresenter;
-    ComponentEditor* m_polarizationPresenter;
+    ComponentEditor* m_wavelengthEditor;
+    ComponentEditor* m_inclinationEditor;
+    ComponentEditor* m_azimuthalEditor;
+    ComponentEditor* m_polarizationEditor;
     QGridLayout* m_gridLayout;
     BeamItem* m_beamItem;
 };

--- a/GUI/coregui/Views/InstrumentWidgets/BeamEditorWidget.h
+++ b/GUI/coregui/Views/InstrumentWidgets/BeamEditorWidget.h
@@ -22,7 +22,7 @@
 #include <QWidget>
 
 class BeamItem;
-class ComponentBoxEditor;
+class ObsoleteComponentBoxEditor;
 class ComponentInfoBox;
 class QGridLayout;
 
@@ -38,11 +38,11 @@ public:
 
 private:
     void onDialogRequest(SessionItem* item, const QString& name);
-    ComponentBoxEditor* m_intensityEditor;
+    ObsoleteComponentBoxEditor* m_intensityEditor;
     ComponentInfoBox* m_wavelengthPresenter;
     ComponentInfoBox* m_inclinationAnglePresenter;
     ComponentInfoBox* m_azimuthalAnglePresenter;
-    ComponentBoxEditor* m_polarizationPresenter;
+    ObsoleteComponentBoxEditor* m_polarizationPresenter;
     QGridLayout* m_gridLayout;
     BeamItem* m_beamItem;
 };

--- a/GUI/coregui/Views/InstrumentWidgets/ComponentInfoBox.cpp
+++ b/GUI/coregui/Views/InstrumentWidgets/ComponentInfoBox.cpp
@@ -15,7 +15,7 @@
 // ************************************************************************** //
 
 #include "ComponentInfoBox.h"
-#include "ComponentBoxEditor.h"
+#include "ObsoleteComponentBoxEditor.h"
 #include <QGroupBox>
 #include <QVBoxLayout>
 #include <iostream>
@@ -23,7 +23,7 @@
 ComponentInfoBox::ComponentInfoBox(const QString &title, QWidget *parent)
     : QWidget(parent)
     , m_groupBox(new GroupInfoBox(title))
-    , m_editor(new ComponentBoxEditor)
+    , m_editor(new ObsoleteComponentBoxEditor)
     , m_item(0)
     , m_title(title)
 {

--- a/GUI/coregui/Views/InstrumentWidgets/ComponentInfoBox.h
+++ b/GUI/coregui/Views/InstrumentWidgets/ComponentInfoBox.h
@@ -21,7 +21,7 @@
 #include "WinDllMacros.h"
 #include <QWidget>
 
-class ComponentBoxEditor;
+class ObsoleteComponentBoxEditor;
 class SessionItem;
 
 //! The ComponentEditorBox is a widget to display ComponentEditor inside
@@ -46,7 +46,7 @@ private slots:
 
 private:
     GroupInfoBox* m_groupBox;
-    ComponentBoxEditor* m_editor;
+    ObsoleteComponentBoxEditor* m_editor;
     SessionItem* m_item;
     QString m_title;
 };

--- a/GUI/coregui/Views/InstrumentWidgets/DetectorEditorWidget.cpp
+++ b/GUI/coregui/Views/InstrumentWidgets/DetectorEditorWidget.cpp
@@ -15,7 +15,7 @@
 // ************************************************************************** //
 
 #include "DetectorEditorWidget.h"
-#include "ObsoleteComponentBoxEditor.h"
+#include "ComponentEditor.h"
 #include "DetectorItems.h"
 #include "SphericalDetectorItem.h"
 #include "RectangularDetectorItem.h"
@@ -35,7 +35,7 @@
 DetectorEditorWidget::DetectorEditorWidget(ColumnResizer* columnResizer, QWidget* parent)
     : SessionItemWidget(parent)
     , m_columnResizer(columnResizer)
-    , m_detectorTypeEditor(new ObsoleteComponentBoxEditor)
+    , m_detectorTypeEditor(new ComponentEditor(ComponentEditor::PlainWidget |ComponentEditor::W_NoChildren))
     , m_groupBox(new GroupInfoBox("Detector Parameters"))
     , m_currentDetector(nullptr)
     , m_subDetectorWidget(nullptr)
@@ -69,7 +69,7 @@ void DetectorEditorWidget::subscribeToItem()
         }, this);
 
     m_detectorTypeEditor->clearEditor();
-    m_detectorTypeEditor->addItem(instrumentItem()->detectorGroup());
+    m_detectorTypeEditor->setItem(instrumentItem()->detectorGroup());
 
     init_SubDetector_Widget();
 }

--- a/GUI/coregui/Views/InstrumentWidgets/DetectorEditorWidget.cpp
+++ b/GUI/coregui/Views/InstrumentWidgets/DetectorEditorWidget.cpp
@@ -15,7 +15,7 @@
 // ************************************************************************** //
 
 #include "DetectorEditorWidget.h"
-#include "ComponentBoxEditor.h"
+#include "ObsoleteComponentBoxEditor.h"
 #include "DetectorItems.h"
 #include "SphericalDetectorItem.h"
 #include "RectangularDetectorItem.h"
@@ -35,7 +35,7 @@
 DetectorEditorWidget::DetectorEditorWidget(ColumnResizer* columnResizer, QWidget* parent)
     : SessionItemWidget(parent)
     , m_columnResizer(columnResizer)
-    , m_detectorTypeEditor(new ComponentBoxEditor)
+    , m_detectorTypeEditor(new ObsoleteComponentBoxEditor)
     , m_groupBox(new GroupInfoBox("Detector Parameters"))
     , m_currentDetector(nullptr)
     , m_subDetectorWidget(nullptr)

--- a/GUI/coregui/Views/InstrumentWidgets/DetectorEditorWidget.h
+++ b/GUI/coregui/Views/InstrumentWidgets/DetectorEditorWidget.h
@@ -21,7 +21,7 @@
 
 class GroupInfoBox;
 class DetectorItem;
-class ObsoleteComponentBoxEditor;
+class ComponentEditor;
 class QGridLayout;
 class ColumnResizer;
 class InstrumentItem;
@@ -48,7 +48,7 @@ private:
     InstrumentItem* instrumentItem();
 
     ColumnResizer* m_columnResizer;
-    ObsoleteComponentBoxEditor* m_detectorTypeEditor;
+    ComponentEditor* m_detectorTypeEditor;
     GroupInfoBox* m_groupBox;
     DetectorItem* m_currentDetector;
     QWidget* m_subDetectorWidget;

--- a/GUI/coregui/Views/InstrumentWidgets/DetectorEditorWidget.h
+++ b/GUI/coregui/Views/InstrumentWidgets/DetectorEditorWidget.h
@@ -21,7 +21,7 @@
 
 class GroupInfoBox;
 class DetectorItem;
-class ComponentBoxEditor;
+class ObsoleteComponentBoxEditor;
 class QGridLayout;
 class ColumnResizer;
 class InstrumentItem;
@@ -48,7 +48,7 @@ private:
     InstrumentItem* instrumentItem();
 
     ColumnResizer* m_columnResizer;
-    ComponentBoxEditor* m_detectorTypeEditor;
+    ObsoleteComponentBoxEditor* m_detectorTypeEditor;
     GroupInfoBox* m_groupBox;
     DetectorItem* m_currentDetector;
     QWidget* m_subDetectorWidget;

--- a/GUI/coregui/Views/InstrumentWidgets/ObsoleteComponentInfoBox.cpp
+++ b/GUI/coregui/Views/InstrumentWidgets/ObsoleteComponentInfoBox.cpp
@@ -2,8 +2,8 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/InstrumentWidgets/ComponentInfoBox.cpp
-//! @brief     Implements class ComponentInfoBox
+//! @file      GUI/coregui/Views/InstrumentWidgets/ObsoleteComponentInfoBox.cpp
+//! @brief     Implements class ObsoleteComponentInfoBox
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -14,13 +14,13 @@
 //
 // ************************************************************************** //
 
-#include "ComponentInfoBox.h"
+#include "ObsoleteComponentInfoBox.h"
 #include "ObsoleteComponentBoxEditor.h"
 #include <QGroupBox>
 #include <QVBoxLayout>
 #include <iostream>
 
-ComponentInfoBox::ComponentInfoBox(const QString &title, QWidget *parent)
+ObsoleteComponentInfoBox::ObsoleteComponentInfoBox(const QString &title, QWidget *parent)
     : QWidget(parent)
     , m_groupBox(new GroupInfoBox(title))
     , m_editor(new ObsoleteComponentBoxEditor)
@@ -42,19 +42,19 @@ ComponentInfoBox::ComponentInfoBox(const QString &title, QWidget *parent)
     setLayout(mainLayout);
 }
 
-void ComponentInfoBox::addPropertyItems(SessionItem *item)
+void ObsoleteComponentInfoBox::addPropertyItems(SessionItem *item)
 {
     m_editor->addPropertyItems(item);
     m_item = item;
 }
 
-void ComponentInfoBox::clearEditor()
+void ObsoleteComponentInfoBox::clearEditor()
 {
     m_editor->clearEditor();
     m_item = 0;
 }
 
-void ComponentInfoBox::dialogRequest()
+void ObsoleteComponentInfoBox::dialogRequest()
 {
     emit onDialogRequest(m_item, m_title);
 }

--- a/GUI/coregui/Views/InstrumentWidgets/ObsoleteComponentInfoBox.h
+++ b/GUI/coregui/Views/InstrumentWidgets/ObsoleteComponentInfoBox.h
@@ -2,8 +2,8 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/InstrumentWidgets/ComponentInfoBox.h
-//! @brief     Defines class ComponentInfoBox
+//! @file      GUI/coregui/Views/InstrumentWidgets/ObsoleteComponentInfoBox.h
+//! @brief     Defines class ObsoleteComponentInfoBox
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -14,8 +14,8 @@
 //
 // ************************************************************************** //
 
-#ifndef COMPONENTINFOBOX_H
-#define COMPONENTINFOBOX_H
+#ifndef OBSOLETECOMPONENTINFOBOX_H
+#define OBSOLETECOMPONENTINFOBOX_H
 
 #include "GroupInfoBox.h"
 #include "WinDllMacros.h"
@@ -28,11 +28,11 @@ class SessionItem;
 //! custom group box equipped with help sign functionality
 //! (used to summon DistributionEditor)
 
-class BA_CORE_API_ ComponentInfoBox : public QWidget
+class BA_CORE_API_ ObsoleteComponentInfoBox : public QWidget
 {
     Q_OBJECT
 public:
-    ComponentInfoBox(const QString& title, QWidget* parent = 0);
+    ObsoleteComponentInfoBox(const QString& title, QWidget* parent = 0);
 
     void addPropertyItems(SessionItem* item);
 
@@ -51,4 +51,4 @@ private:
     QString m_title;
 };
 
-#endif // COMPONENTINFOBOX_H
+#endif // OBSOLETECOMPONENTINFOBOX_H

--- a/GUI/coregui/Views/InstrumentWidgets/RectangularDetectorWidget.cpp
+++ b/GUI/coregui/Views/InstrumentWidgets/RectangularDetectorWidget.cpp
@@ -16,8 +16,8 @@
 
 #include "RectangularDetectorWidget.h"
 #include "ComboProperty.h"
-#include "ComponentBoxEditor.h"
-#include "ComponentEditor.h"
+#include "ObsoleteComponentBoxEditor.h"
+#include "ObsoleteComponentEditor.h"
 #include "DetectorItems.h"
 #include "RectangularDetectorItem.h"
 #include "ExtendedDetectorDialog.h"
@@ -116,27 +116,27 @@ void RectangularDetectorWidget::setColumnResizer(ColumnResizer* columnResizer)
 void RectangularDetectorWidget::create_editors()
 {
     // axes and resolution function editors
-    m_xAxisEditor = new ComponentBoxEditor;
+    m_xAxisEditor = new ObsoleteComponentBoxEditor;
     m_gridLayout->addWidget(m_xAxisEditor, 1, 0);
 
-    m_yAxisEditor = new ComponentBoxEditor;
+    m_yAxisEditor = new ObsoleteComponentBoxEditor;
     m_gridLayout->addWidget(m_yAxisEditor, 1, 1);
 
-    m_resolutionFunctionEditor = new ComponentBoxEditor;
+    m_resolutionFunctionEditor = new ObsoleteComponentBoxEditor;
     m_gridLayout->addWidget(m_resolutionFunctionEditor, 1, 2);
 
     // alignment selector editors
-    m_alignmentEditor = new ComponentBoxEditor;
+    m_alignmentEditor = new ObsoleteComponentBoxEditor;
     m_gridLayout->addWidget(m_alignmentEditor, 2, 0);
 
     // editors for various positions
-    m_positionsEditor = new ComponentBoxEditor;
+    m_positionsEditor = new ObsoleteComponentBoxEditor;
     m_gridLayout->addWidget(m_positionsEditor, 3, 0);
 
-    m_normalEditor = new ComponentBoxEditor;
+    m_normalEditor = new ObsoleteComponentBoxEditor;
     m_gridLayout->addWidget(m_normalEditor, 3, 1);
 
-    m_directionEditor = new ComponentBoxEditor;
+    m_directionEditor = new ObsoleteComponentBoxEditor;
     m_gridLayout->addWidget(m_directionEditor, 3, 2);
 }
 

--- a/GUI/coregui/Views/InstrumentWidgets/RectangularDetectorWidget.cpp
+++ b/GUI/coregui/Views/InstrumentWidgets/RectangularDetectorWidget.cpp
@@ -16,8 +16,7 @@
 
 #include "RectangularDetectorWidget.h"
 #include "ComboProperty.h"
-#include "ObsoleteComponentBoxEditor.h"
-#include "ObsoleteComponentEditor.h"
+#include "ComponentEditor.h"
 #include "DetectorItems.h"
 #include "RectangularDetectorItem.h"
 #include "ExtendedDetectorDialog.h"
@@ -116,27 +115,27 @@ void RectangularDetectorWidget::setColumnResizer(ColumnResizer* columnResizer)
 void RectangularDetectorWidget::create_editors()
 {
     // axes and resolution function editors
-    m_xAxisEditor = new ObsoleteComponentBoxEditor;
+    m_xAxisEditor = new ComponentEditor(ComponentEditor::GroupWidget, "X axis");
     m_gridLayout->addWidget(m_xAxisEditor, 1, 0);
 
-    m_yAxisEditor = new ObsoleteComponentBoxEditor;
+    m_yAxisEditor = new ComponentEditor(ComponentEditor::GroupWidget, "Y axis");
     m_gridLayout->addWidget(m_yAxisEditor, 1, 1);
 
-    m_resolutionFunctionEditor = new ObsoleteComponentBoxEditor;
+    m_resolutionFunctionEditor = new ComponentEditor(ComponentEditor::GroupWidget, "Resolution function");
     m_gridLayout->addWidget(m_resolutionFunctionEditor, 1, 2);
 
     // alignment selector editors
-    m_alignmentEditor = new ObsoleteComponentBoxEditor;
+    m_alignmentEditor = new ComponentEditor(ComponentEditor::PlainWidget);
     m_gridLayout->addWidget(m_alignmentEditor, 2, 0);
 
     // editors for various positions
-    m_positionsEditor = new ObsoleteComponentBoxEditor;
+    m_positionsEditor = new ComponentEditor(ComponentEditor::GroupWidget, "Positions");
     m_gridLayout->addWidget(m_positionsEditor, 3, 0);
 
-    m_normalEditor = new ObsoleteComponentBoxEditor;
+    m_normalEditor = new ComponentEditor(ComponentEditor::GroupWidget, "Normal vector");
     m_gridLayout->addWidget(m_normalEditor, 3, 1);
 
-    m_directionEditor = new ObsoleteComponentBoxEditor;
+    m_directionEditor = new ComponentEditor(ComponentEditor::GroupWidget, "Direction vector");
     m_gridLayout->addWidget(m_directionEditor, 3, 2);
 }
 
@@ -144,19 +143,19 @@ void RectangularDetectorWidget::init_editors()
 {
     m_xAxisEditor->clearEditor();
     SessionItem* xAxisItem = m_detectorItem->getItem(RectangularDetectorItem::P_X_AXIS);
-    m_xAxisEditor->addPropertyItems(xAxisItem, QString("X axis"));
+    m_xAxisEditor->setItem(xAxisItem);
 
     m_yAxisEditor->clearEditor();
     SessionItem* yAxisItem = m_detectorItem->getItem(RectangularDetectorItem::P_Y_AXIS);
-    m_yAxisEditor->addPropertyItems(yAxisItem, QString("Y axis"));
+    m_yAxisEditor->setItem(yAxisItem);
 
     m_resolutionFunctionEditor->clearEditor();
     SessionItem* resFuncGroup
         = m_detectorItem->getItem(RectangularDetectorItem::P_RESOLUTION_FUNCTION);
-    m_resolutionFunctionEditor->addPropertyItems(resFuncGroup, QString("Resolution function"));
+    m_resolutionFunctionEditor->setItem(resFuncGroup);
 
     m_alignmentEditor->clearEditor();
-    m_alignmentEditor->addItem(m_detectorItem->getItem(RectangularDetectorItem::P_ALIGNMENT));
+    m_alignmentEditor->setItem(m_detectorItem->getItem(RectangularDetectorItem::P_ALIGNMENT));
 
     init_alignment_editors();
 }
@@ -180,39 +179,29 @@ void RectangularDetectorWidget::init_alignment_editors()
         m_normalEditor->show();
         m_directionEditor->show();
 
-        m_positionsEditor->addPropertyItems(m_detectorItem->getItem(RectangularDetectorItem::P_U0),
-                                            "Positions");
-        m_positionsEditor->addPropertyItems(m_detectorItem->getItem(RectangularDetectorItem::P_V0),
-                                            "Positions");
+        m_positionsEditor->addItem(m_detectorItem->getItem(RectangularDetectorItem::P_U0));
+        m_positionsEditor->addItem(m_detectorItem->getItem(RectangularDetectorItem::P_V0));
 
         SessionItem* normalVectorItem = m_detectorItem->getItem(RectangularDetectorItem::P_NORMAL);
-        m_normalEditor->addPropertyItems(normalVectorItem, "Normal vector");
+        m_normalEditor->setItem(normalVectorItem);
 
         SessionItem* directionVectorItem
             = m_detectorItem->getItem(RectangularDetectorItem::P_DIRECTION);
-        m_directionEditor->addPropertyItems(directionVectorItem, "Direction vector");
+        m_directionEditor->setItem(directionVectorItem);
 
     } else if (alignment.getValue() == Constants::ALIGNMENT_TO_DIRECT_BEAM
                || alignment.getValue() == Constants::ALIGNMENT_TO_REFLECTED_BEAM_DPOS) {
         m_positionsEditor->show();
-        m_positionsEditor->addPropertyItems(
-            m_detectorItem->getItem(RectangularDetectorItem::P_DBEAM_U0), "Positions");
-        m_positionsEditor->addPropertyItems(
-            m_detectorItem->getItem(RectangularDetectorItem::P_DBEAM_V0), "Positions");
-
-        m_positionsEditor->addPropertyItems(
-            m_detectorItem->getItem(RectangularDetectorItem::P_DISTANCE), "Positions");
+        m_positionsEditor->addItem(m_detectorItem->getItem(RectangularDetectorItem::P_DBEAM_U0));
+        m_positionsEditor->addItem(m_detectorItem->getItem(RectangularDetectorItem::P_DBEAM_V0));
+        m_positionsEditor->addItem(m_detectorItem->getItem(RectangularDetectorItem::P_DISTANCE));
 
     } else if (alignment.getValue() == Constants::ALIGNMENT_TO_SAMPLE
                || alignment.getValue() == Constants::ALIGNMENT_TO_REFLECTED_BEAM) {
         m_positionsEditor->show();
 
-        m_positionsEditor->addPropertyItems(m_detectorItem->getItem(RectangularDetectorItem::P_U0),
-                                            "Positions");
-        m_positionsEditor->addPropertyItems(m_detectorItem->getItem(RectangularDetectorItem::P_V0),
-                                            "Positions");
-
-        m_positionsEditor->addPropertyItems(
-            m_detectorItem->getItem(RectangularDetectorItem::P_DISTANCE), "Positions");
+        m_positionsEditor->addItem(m_detectorItem->getItem(RectangularDetectorItem::P_U0));
+        m_positionsEditor->addItem(m_detectorItem->getItem(RectangularDetectorItem::P_V0));
+        m_positionsEditor->addItem(m_detectorItem->getItem(RectangularDetectorItem::P_DISTANCE));
     }
 }

--- a/GUI/coregui/Views/InstrumentWidgets/RectangularDetectorWidget.h
+++ b/GUI/coregui/Views/InstrumentWidgets/RectangularDetectorWidget.h
@@ -23,7 +23,7 @@
 
 class ColumnResizer;
 class RectangularDetectorItem;
-class ComponentBoxEditor;
+class ObsoleteComponentBoxEditor;
 class QGridLayout;
 class ColumnResizer;
 
@@ -48,14 +48,14 @@ private:
     void init_alignment_editors();
 
     ColumnResizer* m_columnResizer;
-    ComponentBoxEditor* m_xAxisEditor;
-    ComponentBoxEditor* m_yAxisEditor;
-    ComponentBoxEditor* m_resolutionFunctionEditor;
-    ComponentBoxEditor* m_alignmentEditor;
+    ObsoleteComponentBoxEditor* m_xAxisEditor;
+    ObsoleteComponentBoxEditor* m_yAxisEditor;
+    ObsoleteComponentBoxEditor* m_resolutionFunctionEditor;
+    ObsoleteComponentBoxEditor* m_alignmentEditor;
 
-    ComponentBoxEditor* m_positionsEditor;
-    ComponentBoxEditor* m_normalEditor;
-    ComponentBoxEditor* m_directionEditor;
+    ObsoleteComponentBoxEditor* m_positionsEditor;
+    ObsoleteComponentBoxEditor* m_normalEditor;
+    ObsoleteComponentBoxEditor* m_directionEditor;
 
     QGridLayout* m_gridLayout;
 

--- a/GUI/coregui/Views/InstrumentWidgets/RectangularDetectorWidget.h
+++ b/GUI/coregui/Views/InstrumentWidgets/RectangularDetectorWidget.h
@@ -23,7 +23,7 @@
 
 class ColumnResizer;
 class RectangularDetectorItem;
-class ObsoleteComponentBoxEditor;
+class ComponentEditor;
 class QGridLayout;
 class ColumnResizer;
 
@@ -48,14 +48,14 @@ private:
     void init_alignment_editors();
 
     ColumnResizer* m_columnResizer;
-    ObsoleteComponentBoxEditor* m_xAxisEditor;
-    ObsoleteComponentBoxEditor* m_yAxisEditor;
-    ObsoleteComponentBoxEditor* m_resolutionFunctionEditor;
-    ObsoleteComponentBoxEditor* m_alignmentEditor;
+    ComponentEditor* m_xAxisEditor;
+    ComponentEditor* m_yAxisEditor;
+    ComponentEditor* m_resolutionFunctionEditor;
+    ComponentEditor* m_alignmentEditor;
 
-    ObsoleteComponentBoxEditor* m_positionsEditor;
-    ObsoleteComponentBoxEditor* m_normalEditor;
-    ObsoleteComponentBoxEditor* m_directionEditor;
+    ComponentEditor* m_positionsEditor;
+    ComponentEditor* m_normalEditor;
+    ComponentEditor* m_directionEditor;
 
     QGridLayout* m_gridLayout;
 

--- a/GUI/coregui/Views/InstrumentWidgets/SphericalDetectorWidget.cpp
+++ b/GUI/coregui/Views/InstrumentWidgets/SphericalDetectorWidget.cpp
@@ -15,20 +15,27 @@
 // ************************************************************************** //
 
 #include "SphericalDetectorWidget.h"
-#include "ObsoleteComponentBoxEditor.h"
+#include "ComponentEditor.h"
 #include "SphericalDetectorItem.h"
 #include "ColumnResizer.h"
 #include <QGroupBox>
 #include <QVBoxLayout>
 
+namespace {
+const QString phi_axis_title = "Phi axis";
+const QString alpha_axis_title = "Alpha axis";
+const QString resolution_title = "Resolution function";
+const QString polarization_title = "Analyzer orientation";
+}
+
 SphericalDetectorWidget::SphericalDetectorWidget(ColumnResizer* columnResizer,
                                                  SessionItem* detectorItem, QWidget* parent)
     : QWidget(parent)
     , m_columnResizer(columnResizer)
-    , m_phiAxisEditor(new ObsoleteComponentBoxEditor)
-    , m_alphaAxisEditor(new ObsoleteComponentBoxEditor)
-    , m_resolutionFunctionEditor(new ObsoleteComponentBoxEditor)
-    , m_polarizationAnalysisEditor(new ObsoleteComponentBoxEditor)
+    , m_phiAxisEditor(new ComponentEditor(ComponentEditor::GroupWidget, phi_axis_title))
+    , m_alphaAxisEditor(new ComponentEditor(ComponentEditor::GroupWidget, alpha_axis_title))
+    , m_resolutionFunctionEditor(new ComponentEditor(ComponentEditor::GroupWidget, resolution_title))
+    , m_polarizationAnalysisEditor(new ComponentEditor(ComponentEditor::GroupWidget, polarization_title))
     , m_gridLayout(new QGridLayout)
 {
     m_gridLayout->addWidget(m_phiAxisEditor, 1, 0);
@@ -76,22 +83,25 @@ void SphericalDetectorWidget::setDetectorItem(SessionItem* detectorItem)
     Q_ASSERT(detectorItem->modelType() == Constants::SphericalDetectorType);
 
     SessionItem* phiAxisItem = detectorItem->getItem(SphericalDetectorItem::P_PHI_AXIS);
-    m_phiAxisEditor->addPropertyItems(phiAxisItem, QStringLiteral("Phi axis"));
+    m_phiAxisEditor->setItem(phiAxisItem);
 
     SessionItem* alphaAxisItem = detectorItem->getItem(SphericalDetectorItem::P_ALPHA_AXIS);
-    m_alphaAxisEditor->addPropertyItems(alphaAxisItem, QStringLiteral("Alpha axis"));
+    m_alphaAxisEditor->setItem(alphaAxisItem);
 
     SessionItem* resFuncGroup = detectorItem->getItem(SphericalDetectorItem::P_RESOLUTION_FUNCTION);
-    m_resolutionFunctionEditor->addPropertyItems(resFuncGroup,
-                                                 QStringLiteral("Resolution function"));
+    m_resolutionFunctionEditor->setItem(resFuncGroup);
 
     SessionItem* analysisDirection = detectorItem->getItem(DetectorItem::P_ANALYZER_DIRECTION);
-    m_polarizationAnalysisEditor->addPropertyItems(
-        analysisDirection, QStringLiteral("Analyzer orientation"));
-    m_polarizationAnalysisEditor->addItem(
-        detectorItem->getItem(DetectorItem::P_ANALYZER_EFFICIENCY));
-    m_polarizationAnalysisEditor->addItem(
-        detectorItem->getItem(DetectorItem::P_ANALYZER_TOTAL_TRANSMISSION));
+    m_polarizationAnalysisEditor->setItem(analysisDirection);
+
+// TODO FIXME together with rectangular detector
+// Provide method ComponentEditor::addItem or better make separate AnalyzerItem
+// to enable editors for P_ANALYZER_EFFICIENCY and P_ANALYZER_TOTAL_TRANSMISSION
+
+//    m_polarizationAnalysisEditor->addItem(
+//        detectorItem->getItem(DetectorItem::P_ANALYZER_EFFICIENCY));
+//    m_polarizationAnalysisEditor->addItem(
+//        detectorItem->getItem(DetectorItem::P_ANALYZER_TOTAL_TRANSMISSION));
 }
 
 void SphericalDetectorWidget::onColumnResizerDestroyed(QObject* object)

--- a/GUI/coregui/Views/InstrumentWidgets/SphericalDetectorWidget.cpp
+++ b/GUI/coregui/Views/InstrumentWidgets/SphericalDetectorWidget.cpp
@@ -94,14 +94,10 @@ void SphericalDetectorWidget::setDetectorItem(SessionItem* detectorItem)
     SessionItem* analysisDirection = detectorItem->getItem(DetectorItem::P_ANALYZER_DIRECTION);
     m_polarizationAnalysisEditor->setItem(analysisDirection);
 
-// TODO FIXME together with rectangular detector
-// Provide method ComponentEditor::addItem or better make separate AnalyzerItem
-// to enable editors for P_ANALYZER_EFFICIENCY and P_ANALYZER_TOTAL_TRANSMISSION
-
-//    m_polarizationAnalysisEditor->addItem(
-//        detectorItem->getItem(DetectorItem::P_ANALYZER_EFFICIENCY));
-//    m_polarizationAnalysisEditor->addItem(
-//        detectorItem->getItem(DetectorItem::P_ANALYZER_TOTAL_TRANSMISSION));
+    m_polarizationAnalysisEditor->addItem(
+        detectorItem->getItem(DetectorItem::P_ANALYZER_EFFICIENCY));
+    m_polarizationAnalysisEditor->addItem(
+        detectorItem->getItem(DetectorItem::P_ANALYZER_TOTAL_TRANSMISSION));
 }
 
 void SphericalDetectorWidget::onColumnResizerDestroyed(QObject* object)

--- a/GUI/coregui/Views/InstrumentWidgets/SphericalDetectorWidget.cpp
+++ b/GUI/coregui/Views/InstrumentWidgets/SphericalDetectorWidget.cpp
@@ -15,7 +15,7 @@
 // ************************************************************************** //
 
 #include "SphericalDetectorWidget.h"
-#include "ComponentBoxEditor.h"
+#include "ObsoleteComponentBoxEditor.h"
 #include "SphericalDetectorItem.h"
 #include "ColumnResizer.h"
 #include <QGroupBox>
@@ -25,10 +25,10 @@ SphericalDetectorWidget::SphericalDetectorWidget(ColumnResizer* columnResizer,
                                                  SessionItem* detectorItem, QWidget* parent)
     : QWidget(parent)
     , m_columnResizer(columnResizer)
-    , m_phiAxisEditor(new ComponentBoxEditor)
-    , m_alphaAxisEditor(new ComponentBoxEditor)
-    , m_resolutionFunctionEditor(new ComponentBoxEditor)
-    , m_polarizationAnalysisEditor(new ComponentBoxEditor)
+    , m_phiAxisEditor(new ObsoleteComponentBoxEditor)
+    , m_alphaAxisEditor(new ObsoleteComponentBoxEditor)
+    , m_resolutionFunctionEditor(new ObsoleteComponentBoxEditor)
+    , m_polarizationAnalysisEditor(new ObsoleteComponentBoxEditor)
     , m_gridLayout(new QGridLayout)
 {
     m_gridLayout->addWidget(m_phiAxisEditor, 1, 0);

--- a/GUI/coregui/Views/InstrumentWidgets/SphericalDetectorWidget.h
+++ b/GUI/coregui/Views/InstrumentWidgets/SphericalDetectorWidget.h
@@ -22,7 +22,7 @@
 
 class QGridLayout;
 class ColumnResizer;
-class ObsoleteComponentBoxEditor;
+class ComponentEditor;
 class SessionItem;
 
 //! Widget for editing a spherical detector settings
@@ -42,10 +42,10 @@ public slots:
 
 private:
     ColumnResizer* m_columnResizer;
-    ObsoleteComponentBoxEditor* m_phiAxisEditor;
-    ObsoleteComponentBoxEditor* m_alphaAxisEditor;
-    ObsoleteComponentBoxEditor* m_resolutionFunctionEditor;
-    ObsoleteComponentBoxEditor* m_polarizationAnalysisEditor;
+    ComponentEditor* m_phiAxisEditor;
+    ComponentEditor* m_alphaAxisEditor;
+    ComponentEditor* m_resolutionFunctionEditor;
+    ComponentEditor* m_polarizationAnalysisEditor;
     QGridLayout* m_gridLayout;
 };
 

--- a/GUI/coregui/Views/InstrumentWidgets/SphericalDetectorWidget.h
+++ b/GUI/coregui/Views/InstrumentWidgets/SphericalDetectorWidget.h
@@ -22,7 +22,7 @@
 
 class QGridLayout;
 class ColumnResizer;
-class ComponentBoxEditor;
+class ObsoleteComponentBoxEditor;
 class SessionItem;
 
 //! Widget for editing a spherical detector settings
@@ -42,10 +42,10 @@ public slots:
 
 private:
     ColumnResizer* m_columnResizer;
-    ComponentBoxEditor* m_phiAxisEditor;
-    ComponentBoxEditor* m_alphaAxisEditor;
-    ComponentBoxEditor* m_resolutionFunctionEditor;
-    ComponentBoxEditor* m_polarizationAnalysisEditor;
+    ObsoleteComponentBoxEditor* m_phiAxisEditor;
+    ObsoleteComponentBoxEditor* m_alphaAxisEditor;
+    ObsoleteComponentBoxEditor* m_resolutionFunctionEditor;
+    ObsoleteComponentBoxEditor* m_polarizationAnalysisEditor;
     QGridLayout* m_gridLayout;
 };
 

--- a/GUI/coregui/Views/IntensityDataWidgets/IntensityDataPropertyWidget.cpp
+++ b/GUI/coregui/Views/IntensityDataWidgets/IntensityDataPropertyWidget.cpp
@@ -17,14 +17,14 @@
 #include "IntensityDataPropertyWidget.h"
 #include "IntensityDataItem.h"
 #include "JobModel.h"
-#include "ComponentTreeView.h"
+#include "ComponentEditor.h"
 #include <QAction>
 #include <QVBoxLayout>
 
 IntensityDataPropertyWidget::IntensityDataPropertyWidget(QWidget* parent)
     : SessionItemWidget(parent)
     , m_togglePanelAction(new QAction(this))
-    , m_componentEditor(new ComponentTreeView)
+    , m_componentEditor(new ComponentEditor)
 {
     setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
     setWindowTitle(QLatin1String("Intensity Data Properties"));

--- a/GUI/coregui/Views/IntensityDataWidgets/IntensityDataPropertyWidget.h
+++ b/GUI/coregui/Views/IntensityDataWidgets/IntensityDataPropertyWidget.h
@@ -20,7 +20,7 @@
 #include "SessionItemWidget.h"
 
 class IntensityDataItem;
-class ComponentTreeView;
+class ComponentEditor;
 class SessionItem;
 
 //! The IntensityDataPropertyWidget shows ComponentEditor for given IntensityDataItem.
@@ -46,7 +46,7 @@ protected:
 
 private:
     QAction* m_togglePanelAction;
-    ComponentTreeView* m_componentEditor;
+    ComponentEditor* m_componentEditor;
 };
 
 #endif // INTENSITYDATAPROPERTYWIDGET_H

--- a/GUI/coregui/Views/JobWidgets/JobPropertiesWidget.cpp
+++ b/GUI/coregui/Views/JobWidgets/JobPropertiesWidget.cpp
@@ -15,7 +15,7 @@
 // ************************************************************************** //
 
 #include "JobPropertiesWidget.h"
-#include "ComponentTreeView.h"
+#include "ComponentEditor.h"
 #include "JobItem.h"
 #include "mainwindow_constants.h"
 #include <QTabBar>
@@ -26,7 +26,7 @@
 JobPropertiesWidget::JobPropertiesWidget(QWidget* parent)
     : SessionItemWidget(parent)
     , m_tabWidget(new QTabWidget)
-    , m_propertyEditor(new ComponentTreeView)
+    , m_componentEditor(new ComponentEditor)
     , m_commentsEditor(new QTextEdit)
     , m_block_update(false)
 {
@@ -39,7 +39,7 @@ JobPropertiesWidget::JobPropertiesWidget(QWidget* parent)
     mainLayout->setContentsMargins(0, 0, 0, 0);
 
     m_tabWidget->setTabPosition(QTabWidget::South);
-    m_tabWidget->insertTab(JOB_PROPERTIES, m_propertyEditor, "Job Properties");
+    m_tabWidget->insertTab(JOB_PROPERTIES, m_componentEditor, "Job Properties");
     m_tabWidget->insertTab(JOB_COMMENTS, m_commentsEditor, "Details");
 
     mainLayout->addWidget(m_tabWidget);
@@ -56,14 +56,14 @@ void JobPropertiesWidget::subscribeToItem()
                 updateItem();
         }, this);
 
-    m_propertyEditor->setItem(currentItem());
+    m_componentEditor->setItem(currentItem());
 
     updateItem();
 }
 
 void JobPropertiesWidget::unsubscribeFromItem()
 {
-    m_propertyEditor->setItem(nullptr);
+    m_componentEditor->setItem(nullptr);
 }
 
 void JobPropertiesWidget::contextMenuEvent(QContextMenuEvent*)

--- a/GUI/coregui/Views/JobWidgets/JobPropertiesWidget.h
+++ b/GUI/coregui/Views/JobWidgets/JobPropertiesWidget.h
@@ -22,7 +22,7 @@
 class JobItem;
 class QTextEdit;
 class QTabWidget;
-class ComponentTreeView;
+class ComponentEditor;
 
 //! The JobPropertiesWidget class holds component editor for JobItem. Part of JobSelectorWidget,
 //! resides at lower left corner of JobView.
@@ -50,7 +50,7 @@ private:
     JobItem* jobItem();
 
     QTabWidget* m_tabWidget;
-    ComponentTreeView* m_propertyEditor;
+    ComponentEditor* m_componentEditor;
     QTextEdit* m_commentsEditor;
     bool m_block_update;
 };

--- a/GUI/coregui/Views/JobWidgets/ProjectionsPropertyPanel.cpp
+++ b/GUI/coregui/Views/JobWidgets/ProjectionsPropertyPanel.cpp
@@ -15,12 +15,12 @@
 // ************************************************************************** //
 
 #include "ProjectionsPropertyPanel.h"
-#include "ComponentTreeView.h"
+#include "ComponentEditor.h"
 #include <QVBoxLayout>
 
 ProjectionsPropertyPanel::ProjectionsPropertyPanel(QWidget* parent)
     : SessionItemWidget(parent)
-    , m_componentEditor(new ComponentTreeView)
+    , m_componentEditor(new ComponentEditor)
 {
     setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
 

--- a/GUI/coregui/Views/JobWidgets/ProjectionsPropertyPanel.h
+++ b/GUI/coregui/Views/JobWidgets/ProjectionsPropertyPanel.h
@@ -19,7 +19,7 @@
 
 #include "SessionItemWidget.h"
 
-class ComponentTreeView;
+class ComponentEditor;
 
 class BA_CORE_API_ ProjectionsPropertyPanel : public SessionItemWidget
 {
@@ -36,7 +36,7 @@ protected:
     void unsubscribeFromItem();
 
 private:
-    ComponentTreeView* m_componentEditor;
+    ComponentEditor* m_componentEditor;
 };
 
 #endif // PROJECTIONSPROPERTYPANEL_H

--- a/GUI/coregui/Views/MaskWidgets/MaskEditorPropertyPanel.cpp
+++ b/GUI/coregui/Views/MaskWidgets/MaskEditorPropertyPanel.cpp
@@ -16,7 +16,7 @@
 
 #include "MaskEditorPropertyPanel.h"
 #include "AccordionWidget.h"
-#include "ComponentTreeView.h"
+#include "ComponentEditor.h"
 #include "ContentPane.h"
 #include "IntensityDataItem.h"
 #include "SessionModel.h"
@@ -44,8 +44,8 @@ public:
 MaskEditorPropertyPanel::MaskEditorPropertyPanel(QWidget* parent)
     : QWidget(parent)
     , m_listView(new QListView)
-    , m_maskPropertyEditor(new ComponentTreeView)
-    , m_plotPropertyEditor(new ComponentTreeView)
+    , m_maskPropertyEditor(new ComponentEditor)
+    , m_plotPropertyEditor(new ComponentEditor(ComponentEditor::MiniTree))
     , m_accordion(new AccordionWidget)
     , m_maskModel(nullptr)
     , m_intensityDataItem(nullptr)
@@ -69,8 +69,6 @@ MaskEditorPropertyPanel::MaskEditorPropertyPanel(QWidget* parent)
     mainLayout->addWidget(m_accordion);
 
     setLayout(mainLayout);
-
-    m_plotPropertyEditor->setHeaderHidden(true);
 }
 
 QSize MaskEditorPropertyPanel::sizeHint() const

--- a/GUI/coregui/Views/MaskWidgets/MaskEditorPropertyPanel.h
+++ b/GUI/coregui/Views/MaskWidgets/MaskEditorPropertyPanel.h
@@ -23,7 +23,7 @@
 
 class QListView;
 class SessionModel;
-class ComponentTreeView;
+class ComponentEditor;
 class QItemSelection;
 class QItemSelectionModel;
 class IntensityDataItem;
@@ -62,8 +62,8 @@ private:
     void setup_PlotProperties(AccordionWidget* accordion);
 
     QListView* m_listView;
-    ComponentTreeView* m_maskPropertyEditor;
-    ComponentTreeView* m_plotPropertyEditor;
+    ComponentEditor* m_maskPropertyEditor;
+    ComponentEditor* m_plotPropertyEditor;
     AccordionWidget* m_accordion;
     SessionModel* m_maskModel;
     QModelIndex m_rootIndex;

--- a/GUI/coregui/Views/MaterialEditor/MaterialEditor.cpp
+++ b/GUI/coregui/Views/MaterialEditor/MaterialEditor.cpp
@@ -15,7 +15,7 @@
 // ************************************************************************** //
 
 #include "MaterialEditor.h"
-#include "ComponentTreeView.h"
+#include "ComponentEditor.h"
 #include "MaterialEditorToolBar.h"
 #include "MaterialItem.h"
 #include "MaterialModel.h"
@@ -30,7 +30,7 @@ MaterialEditor::MaterialEditor(MaterialModel* materialModel, QWidget* parent)
     , m_toolBar(new MaterialEditorToolBar(materialModel, this))
     , m_splitter(new QSplitter)
     , m_listView(new QListView)
-    , m_componentEditor(new ComponentTreeView)
+    , m_componentEditor(new ComponentEditor)
     , m_model_was_modified(false)
 {
     setWindowTitle("MaterialEditorWidget");

--- a/GUI/coregui/Views/MaterialEditor/MaterialEditor.h
+++ b/GUI/coregui/Views/MaterialEditor/MaterialEditor.h
@@ -24,7 +24,7 @@ class MaterialModel;
 class MaterialEditorToolBar;
 class QSplitter;
 class QListView;
-class ComponentTreeView;
+class ComponentEditor;
 class QItemSelection;
 class QItemSelectionModel;
 class MaterialItem;
@@ -63,7 +63,7 @@ private:
     MaterialEditorToolBar* m_toolBar;
     QSplitter* m_splitter;
     QListView* m_listView;
-    ComponentTreeView* m_componentEditor;
+    ComponentEditor* m_componentEditor;
     bool m_model_was_modified;
 };
 

--- a/GUI/coregui/Views/PropertyEditor/ComponentEditor.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ComponentEditor.cpp
@@ -1,0 +1,75 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Views/PropertyEditor/ComponentEditor.cpp
+//! @brief     Implements ComponentEditor class
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
+//! @authors   Walter Van Herck, Joachim Wuttke
+//
+// ************************************************************************** //
+
+#include "ComponentEditor.h"
+#include "ComponentView.h"
+#include "ComponentTreeView.h"
+#include "ComponentFlatView.h"
+#include <QGroupBox>
+#include <QBoxLayout>
+
+ComponentEditor::ComponentEditor(EditorType editorType)
+    : m_type(editorType)
+    , m_componentView(nullptr)
+{
+    m_componentView = createComponentView();
+
+    auto mainLayout = new QVBoxLayout;
+    mainLayout->setMargin(0);
+    mainLayout->setSpacing(0);
+
+    if (m_type.testFlag(GroupLayout)) {
+        auto box = new QGroupBox("Title");
+        auto boxlayout = new QVBoxLayout;
+
+        boxlayout->addWidget(m_componentView);
+        box->setLayout(boxlayout);
+
+        mainLayout->addWidget(box);
+    } else {
+        mainLayout->addWidget(m_componentView);
+    }
+
+    setLayout(mainLayout);
+}
+
+void ComponentEditor::setItem(SessionItem* item)
+{
+    m_componentView->setItem(item);
+}
+
+void ComponentEditor::clearEditor()
+{
+    m_componentView->clearEditor();
+}
+
+ComponentView* ComponentEditor::createComponentView()
+{
+    ComponentView* result(nullptr);
+
+    if (m_type.testFlag(Tree)) {
+        auto view = new ComponentTreeView;
+        view->setHeaderHidden(!m_type.testFlag(T_Header));
+        view->setShowRootItem(m_type.testFlag(T_Root));
+
+        result = view;
+    } else {
+        auto view = new ComponentFlatView;
+        result = view;
+    }
+
+    return result;
+}

--- a/GUI/coregui/Views/PropertyEditor/ComponentEditor.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ComponentEditor.cpp
@@ -62,7 +62,7 @@ ComponentView* ComponentEditor::createComponentView()
 
     if (m_type.testFlag(Tree)) {
         auto view = new ComponentTreeView;
-        view->setHeaderHidden(!m_type.testFlag(T_Header));
+        view->setShowHeader(m_type.testFlag(T_Header));
         view->setShowRootItem(m_type.testFlag(T_Root));
 
         result = view;

--- a/GUI/coregui/Views/PropertyEditor/ComponentEditor.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ComponentEditor.cpp
@@ -92,6 +92,7 @@ ComponentView* ComponentEditor::createComponentView()
         result = view;
     } else {
         auto view = new ComponentFlatView;
+        view->setShowChildren(!m_type.testFlag(W_NoChildren));
         result = view;
     }
 

--- a/GUI/coregui/Views/PropertyEditor/ComponentEditor.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ComponentEditor.cpp
@@ -79,6 +79,12 @@ void ComponentEditor::clearEditor()
     m_componentView->clearEditor();
 }
 
+void ComponentEditor::addItem(SessionItem* item)
+{
+    m_item = item;
+    m_componentView->addItem(item);
+}
+
 void ComponentEditor::onDialogRequest()
 {
     emit dialogRequest(m_item, m_title);

--- a/GUI/coregui/Views/PropertyEditor/ComponentEditor.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ComponentEditor.cpp
@@ -44,23 +44,26 @@ ComponentEditor::ComponentEditor(EditorType editorType, const QString& title)
     m_componentView = createComponentView();
 
     auto mainLayout = new QVBoxLayout;
-    mainLayout->setMargin(4);
     mainLayout->setSpacing(0);
+    mainLayout->setMargin(0);
 
     if (m_type.testFlag(GroupLayout)) {
         auto box = createGroupBox<QGroupBox>(m_componentView, title);
         mainLayout->addWidget(box);
+        mainLayout->setMargin(4);
+        mainLayout->addStretch();
 
     } else if(m_type.testFlag(InfoLayout)) {
         auto box = createGroupBox<GroupInfoBox>(m_componentView, title);
         connect(box, &GroupInfoBox::clicked, this, &ComponentEditor::onDialogRequest);
         mainLayout->addWidget(box);
+        mainLayout->setMargin(4);
+        mainLayout->addStretch();
 
     } else {
         mainLayout->addWidget(m_componentView);
     }
 
-    mainLayout->addStretch();
     setLayout(mainLayout);
 }
 

--- a/GUI/coregui/Views/PropertyEditor/ComponentEditor.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentEditor.h
@@ -1,0 +1,66 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Views/PropertyEditor/ComponentEditor.h
+//! @brief     Defines ComponentEditor class
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
+//! @authors   Walter Van Herck, Joachim Wuttke
+//
+// ************************************************************************** //
+
+#ifndef COMPONENTEDITOR_H
+#define COMPONENTEDITOR_H
+
+#include "WinDllMacros.h"
+#include <QWidget>
+
+class ComponentView;
+class SessionItem;
+class QBoxLayout;
+
+//! Component editor for SessionItem. Can have various appearance depending
+//! on EditorFlags
+
+class BA_CORE_API_ ComponentEditor : public QWidget
+{
+    Q_OBJECT
+public:
+    enum EditorFlags {
+        Tree      = 0x1000,
+        Widget    = 0x2000,
+
+        PlainLayout  = 0x0010,
+        GroupLayout  = 0x0020,
+        InfoLayout   = 0x0040,
+
+        T_Header     = 0x0100,
+        T_Root       = 0x0200,
+
+        FullTree     = Tree | PlainLayout | T_Header | T_Root,
+        HeaderTree   = Tree | PlainLayout | T_Header,
+        MiniTree     = Tree | PlainLayout,
+        PlainWidget  = Widget | PlainLayout,
+        GroupWidget  = Widget | GroupLayout,
+        InfoWidget   = Widget | InfoLayout,
+    };
+    Q_DECLARE_FLAGS(EditorType, EditorFlags)
+
+    ComponentEditor(EditorType editorType = HeaderTree);
+
+    void setItem(SessionItem* item);
+    void clearEditor();
+
+private:
+    ComponentView* createComponentView();
+
+    EditorType m_type;
+    ComponentView* m_componentView;
+};
+
+#endif  // COMPONENTEDITOR_H

--- a/GUI/coregui/Views/PropertyEditor/ComponentEditor.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentEditor.h
@@ -74,5 +74,4 @@ private:
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(ComponentEditor::EditorType)
 
-
 #endif  // COMPONENTEDITOR_H

--- a/GUI/coregui/Views/PropertyEditor/ComponentEditor.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentEditor.h
@@ -51,16 +51,24 @@ public:
     };
     Q_DECLARE_FLAGS(EditorType, EditorFlags)
 
-    ComponentEditor(EditorType editorType = HeaderTree);
+    ComponentEditor(EditorType editorType = HeaderTree, const QString& title = QString());
 
     void setItem(SessionItem* item);
     void clearEditor();
+
+signals:
+    void dialogRequest(SessionItem* item, const QString& names);
+
+private slots:
+    void onDialogRequest();
 
 private:
     ComponentView* createComponentView();
 
     EditorType m_type;
     ComponentView* m_componentView;
+    SessionItem* m_item;
+    QString m_title;
 };
 
 #endif  // COMPONENTEDITOR_H

--- a/GUI/coregui/Views/PropertyEditor/ComponentEditor.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentEditor.h
@@ -56,6 +56,7 @@ public:
 
     void setItem(SessionItem* item);
     void clearEditor();
+    void addItem(SessionItem* item);
 
 signals:
     void dialogRequest(SessionItem* item, const QString& names);

--- a/GUI/coregui/Views/PropertyEditor/ComponentEditor.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentEditor.h
@@ -35,12 +35,13 @@ public:
         Tree      = 0x1000,
         Widget    = 0x2000,
 
-        PlainLayout  = 0x0010,
-        GroupLayout  = 0x0020,
-        InfoLayout   = 0x0040,
+        PlainLayout  = 0x0010, // editor embedded in standard box layout
+        GroupLayout  = 0x0020, // editor embedded in QGroupBox
+        InfoLayout   = 0x0040, // editor embedded in GroupInfoBox
 
-        T_Header     = 0x0100,
-        T_Root       = 0x0200,
+        T_Header     = 0x0100, // to show QTreeView header (Tree mode only)
+        T_Root       = 0x0200, // to show root item  (Tree mode only)
+        W_NoChildren = 0x0400, // show no children (Widget mode only)
 
         FullTree     = Tree | PlainLayout | T_Header | T_Root,
         HeaderTree   = Tree | PlainLayout | T_Header,
@@ -70,5 +71,8 @@ private:
     SessionItem* m_item;
     QString m_title;
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(ComponentEditor::EditorType)
+
 
 #endif  // COMPONENTEDITOR_H

--- a/GUI/coregui/Views/PropertyEditor/ComponentFlatView.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ComponentFlatView.cpp
@@ -27,7 +27,7 @@
 #include <QDataWidgetMapper>
 
 ComponentFlatView::ComponentFlatView(QWidget* parent)
-    : QWidget(parent)
+    : ComponentView(parent)
     , m_mainLayout(new QVBoxLayout)
     , m_gridLayout(nullptr)
     , m_currentItem(nullptr)
@@ -41,6 +41,11 @@ ComponentFlatView::ComponentFlatView(QWidget* parent)
     initGridLayout();
 
     setLayout(m_mainLayout);
+}
+
+void ComponentFlatView::setItem(SessionItem* item)
+{
+    addItemProperties(item);
 }
 
 void ComponentFlatView::addItemProperties(SessionItem* item)

--- a/GUI/coregui/Views/PropertyEditor/ComponentFlatView.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ComponentFlatView.cpp
@@ -47,6 +47,8 @@ ComponentFlatView::ComponentFlatView(QWidget* parent)
     setLayout(m_mainLayout);
 }
 
+ComponentFlatView::~ComponentFlatView() = default;
+
 void ComponentFlatView::setItem(SessionItem* item)
 {
     clearEditor();

--- a/GUI/coregui/Views/PropertyEditor/ComponentFlatView.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ComponentFlatView.cpp
@@ -51,16 +51,6 @@ void ComponentFlatView::setItem(SessionItem* item)
     addItemProperties(item);
 }
 
-void ComponentFlatView::addItemProperties(SessionItem* item)
-{
-    Q_ASSERT(item);
-
-    m_currentItem = item;
-    setModel(m_currentItem->model());
-
-    updateItemProperties(m_currentItem);
-}
-
 void ComponentFlatView::setModel(SessionModel* model)
 {
     if (m_model) {
@@ -106,6 +96,17 @@ void ComponentFlatView::onDataChanged(const QModelIndex& topLeft, const QModelIn
     if (roles.contains(SessionModel::FlagRole))
         updateItemRoles(item);
 }
+
+void ComponentFlatView::addItemProperties(SessionItem* item)
+{
+    Q_ASSERT(item);
+
+    m_currentItem = item;
+    setModel(m_currentItem->model());
+
+    updateItemProperties(m_currentItem);
+}
+
 
 void ComponentFlatView::updateItemProperties(SessionItem* item)
 {

--- a/GUI/coregui/Views/PropertyEditor/ComponentFlatView.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ComponentFlatView.cpp
@@ -21,6 +21,7 @@
 #include "SessionModel.h"
 #include "LayoutUtils.h"
 #include "PropertyWidgetItem.h"
+#include "CustomEventFilters.h"
 #include <QLabel>
 #include <QVBoxLayout>
 #include <QGridLayout>
@@ -33,6 +34,7 @@ ComponentFlatView::ComponentFlatView(QWidget* parent)
     , m_currentItem(nullptr)
     , m_model(nullptr)
     , m_show_children(true)
+    , m_wheel_event_filter(new WheelEventEater)
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
@@ -148,6 +150,9 @@ PropertyWidgetItem* ComponentFlatView::createWidget(const SessionItem* item)
     auto editor = PropertyEditorFactory::CreateEditor(*item);
     if (!editor)
         return nullptr;
+
+    editor->installEventFilter(m_wheel_event_filter.get());
+    editor->setFocusPolicy(Qt::StrongFocus);
 
     auto result = new PropertyWidgetItem(this);
     result->setItemEditor(item, editor);

--- a/GUI/coregui/Views/PropertyEditor/ComponentFlatView.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ComponentFlatView.cpp
@@ -26,6 +26,8 @@
 #include <QVBoxLayout>
 #include <QGridLayout>
 #include <QDataWidgetMapper>
+#include <QSpinBox>
+#include <QComboBox>
 
 ComponentFlatView::ComponentFlatView(QWidget* parent)
     : ComponentView(parent)
@@ -152,11 +154,25 @@ PropertyWidgetItem* ComponentFlatView::createWidget(const SessionItem* item)
     if (!editor)
         return nullptr;
 
-    editor->installEventFilter(m_wheel_event_filter.get());
-    editor->setFocusPolicy(Qt::StrongFocus);
+    install_custom_filters(editor);
 
     auto result = new PropertyWidgetItem(this);
     result->setItemEditor(item, editor);
 
     return result;
+}
+
+void ComponentFlatView::install_custom_filters(QWidget* editor)
+{
+    editor->installEventFilter(m_wheel_event_filter.get());
+    editor->setFocusPolicy(Qt::StrongFocus);
+
+    for(auto w : editor->findChildren<QAbstractSpinBox *>()) {
+        w->installEventFilter(m_wheel_event_filter.get());
+        w->setFocusPolicy(Qt::StrongFocus);
+    }
+
+    for(auto w : editor->findChildren<QComboBox *>())
+        w->installEventFilter(m_wheel_event_filter.get());
+
 }

--- a/GUI/coregui/Views/PropertyEditor/ComponentFlatView.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ComponentFlatView.cpp
@@ -32,6 +32,7 @@ ComponentFlatView::ComponentFlatView(QWidget* parent)
     , m_gridLayout(nullptr)
     , m_currentItem(nullptr)
     , m_model(nullptr)
+    , m_show_children(true)
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
@@ -85,6 +86,12 @@ void ComponentFlatView::clearEditor()
 
 }
 
+void ComponentFlatView::setShowChildren(bool show)
+{
+    m_show_children = show;
+
+}
+
 void ComponentFlatView::onDataChanged(const QModelIndex& topLeft, const QModelIndex&bottomRight,
                                       const QVector<int>& roles)
 {
@@ -113,6 +120,9 @@ void ComponentFlatView::updateItemProperties(SessionItem* item)
 
         widget->addToGrid(m_gridLayout, ++nrow);
         m_widgetItems.push_back(widget);
+
+        if (!m_show_children)
+            break;
     }
 
 }

--- a/GUI/coregui/Views/PropertyEditor/ComponentFlatView.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentFlatView.h
@@ -56,6 +56,8 @@ private:
     void initGridLayout();
     PropertyWidgetItem* createWidget(const SessionItem* item);
 
+    void install_custom_filters(QWidget* editor);
+
     QBoxLayout* m_mainLayout;
     QGridLayout* m_gridLayout;
     QVector<PropertyWidgetItem*> m_widgetItems;

--- a/GUI/coregui/Views/PropertyEditor/ComponentFlatView.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentFlatView.h
@@ -42,6 +42,8 @@ public:
 
     void clearEditor();
 
+    void setShowChildren(bool show);
+
 public slots:
     void onDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight,
                        const QVector<int> &roles);
@@ -57,6 +59,7 @@ private:
     QVector<PropertyWidgetItem*> m_widgetItems;
     SessionItem* m_currentItem;
     SessionModel* m_model;
+    bool m_show_children;
 };
 
 #endif

--- a/GUI/coregui/Views/PropertyEditor/ComponentFlatView.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentFlatView.h
@@ -18,12 +18,14 @@
 #define COMPONENTFLATVIEW_H
 
 #include "ComponentView.h"
+#include <memory>
 
 class SessionItem;
 class SessionModel;
 class QGridLayout;
 class QBoxLayout;
 class PropertyWidgetItem;
+class WheelEventEater;
 
 //! Component property widget for SessionItems. On the contrary to ComponentTreeView
 //! properties are presented as widgets in grid layout.
@@ -60,6 +62,7 @@ private:
     SessionItem* m_currentItem;
     SessionModel* m_model;
     bool m_show_children;
+    std::unique_ptr<WheelEventEater> m_wheel_event_filter;
 };
 
 #endif

--- a/GUI/coregui/Views/PropertyEditor/ComponentFlatView.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentFlatView.h
@@ -38,6 +38,7 @@ public:
     ComponentFlatView(QWidget* parent = nullptr);
 
     void setItem(SessionItem* item);
+    void addItem(SessionItem* item);
 
     void setModel(SessionModel* model);
 
@@ -50,8 +51,8 @@ public slots:
                        const QVector<int> &roles);
 
 private:
-    void addItemProperties(SessionItem* item);
-    void updateItemProperties(SessionItem* item);
+    void clearLayout();
+    void updateItemProperties();
     void updateItemRoles(SessionItem* item);
     void initGridLayout();
     PropertyWidgetItem* createWidget(const SessionItem* item);
@@ -61,10 +62,10 @@ private:
     QBoxLayout* m_mainLayout;
     QGridLayout* m_gridLayout;
     QVector<PropertyWidgetItem*> m_widgetItems;
-    SessionItem* m_currentItem;
     SessionModel* m_model;
     bool m_show_children;
     std::unique_ptr<WheelEventEater> m_wheel_event_filter;
+    QVector<const SessionItem*> m_topItems;
 };
 
 #endif

--- a/GUI/coregui/Views/PropertyEditor/ComponentFlatView.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentFlatView.h
@@ -36,6 +36,7 @@ class BA_CORE_API_ ComponentFlatView : public ComponentView
     Q_OBJECT
 public:
     ComponentFlatView(QWidget* parent = nullptr);
+    ~ComponentFlatView();
 
     void setItem(SessionItem* item);
     void addItem(SessionItem* item);

--- a/GUI/coregui/Views/PropertyEditor/ComponentFlatView.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentFlatView.h
@@ -17,8 +17,7 @@
 #ifndef COMPONENTFLATVIEW_H
 #define COMPONENTFLATVIEW_H
 
-#include "WinDllMacros.h"
-#include <QWidget>
+#include "ComponentView.h"
 
 class SessionItem;
 class SessionModel;
@@ -30,12 +29,13 @@ class PropertyWidgetItem;
 //! properties are presented as widgets in grid layout.
 //! Shows only PropertyItems and current items of GroupProperties.
 
-class BA_CORE_API_ ComponentFlatView : public QWidget
+class BA_CORE_API_ ComponentFlatView : public ComponentView
 {
     Q_OBJECT
 public:
     ComponentFlatView(QWidget* parent = nullptr);
 
+    void setItem(SessionItem* item);
     void addItemProperties(SessionItem* item);
 
     void setModel(SessionModel* model);

--- a/GUI/coregui/Views/PropertyEditor/ComponentFlatView.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentFlatView.h
@@ -38,7 +38,6 @@ public:
     ComponentFlatView(QWidget* parent = nullptr);
 
     void setItem(SessionItem* item);
-    void addItemProperties(SessionItem* item);
 
     void setModel(SessionModel* model);
 
@@ -51,6 +50,7 @@ public slots:
                        const QVector<int> &roles);
 
 private:
+    void addItemProperties(SessionItem* item);
     void updateItemProperties(SessionItem* item);
     void updateItemRoles(SessionItem* item);
     void initGridLayout();

--- a/GUI/coregui/Views/PropertyEditor/ComponentTreeView.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ComponentTreeView.cpp
@@ -24,11 +24,12 @@
 #include <QStandardItemModel>
 
 ComponentTreeView::ComponentTreeView(QWidget* parent)
-    : QWidget(parent)
+    : ComponentView(parent)
     , m_tree(new QTreeView)
     , m_delegate(new SessionModelDelegate(this))
     , m_proxyModel(new ComponentProxyModel(this))
     , m_placeHolderModel(new QStandardItemModel)
+    , m_show_root_item(false)
 {
     auto layout = new QVBoxLayout;
 
@@ -48,11 +49,16 @@ ComponentTreeView::ComponentTreeView(QWidget* parent)
     m_tree->setEditTriggers(QAbstractItemView::AllEditTriggers);
 }
 
+void ComponentTreeView::setItem(SessionItem* item)
+{
+    setItemIntern(item, m_show_root_item);
+}
+
 //! Sets item to show in the tree together with its properties and group properties.
 //! @param item: Item to show in a tree.
 //! @param show_root_item: Tree will starts from item itself, if true.
 
-void ComponentTreeView::setItem(SessionItem* item, bool show_root_item)
+void ComponentTreeView::setItemIntern(SessionItem* item, bool show_root_item)
 {
     if (!item) {
         setModel(nullptr);
@@ -61,6 +67,11 @@ void ComponentTreeView::setItem(SessionItem* item, bool show_root_item)
     setModel(item->model());
     setRootIndex(item->index(), show_root_item);
     m_tree->expandAll();
+}
+
+void ComponentTreeView::clearEditor()
+{
+    m_tree->setModel(m_placeHolderModel);
 }
 
 void ComponentTreeView::setModel(SessionModel* model)
@@ -90,5 +101,10 @@ QTreeView* ComponentTreeView::treeView()
 void ComponentTreeView::setHeaderHidden(bool hide)
 {
     m_tree->setHeaderHidden(hide);
+}
+
+void ComponentTreeView::setShowRootItem(bool show)
+{
+    m_show_root_item = show;
 }
 

--- a/GUI/coregui/Views/PropertyEditor/ComponentTreeView.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ComponentTreeView.cpp
@@ -51,21 +51,12 @@ ComponentTreeView::ComponentTreeView(QWidget* parent)
 
 void ComponentTreeView::setItem(SessionItem* item)
 {
-    setItemIntern(item, m_show_root_item);
-}
-
-//! Sets item to show in the tree together with its properties and group properties.
-//! @param item: Item to show in a tree.
-//! @param show_root_item: Tree will starts from item itself, if true.
-
-void ComponentTreeView::setItemIntern(SessionItem* item, bool show_root_item)
-{
     if (!item) {
         setModel(nullptr);
         return;
     }
     setModel(item->model());
-    setRootIndex(item->index(), show_root_item);
+    setRootIndex(item->index(), m_show_root_item);
     m_tree->expandAll();
 }
 
@@ -93,14 +84,9 @@ void ComponentTreeView::setRootIndex(const QModelIndex& index, bool show_root_it
         m_tree->setRootIndex(m_proxyModel->mapFromSource(index));
 }
 
-QTreeView* ComponentTreeView::treeView()
+void ComponentTreeView::setShowHeader(bool show)
 {
-    return m_tree;
-}
-
-void ComponentTreeView::setHeaderHidden(bool hide)
-{
-    m_tree->setHeaderHidden(hide);
+    m_tree->setHeaderHidden(!show);
 }
 
 void ComponentTreeView::setShowRootItem(bool show)

--- a/GUI/coregui/Views/PropertyEditor/ComponentTreeView.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentTreeView.h
@@ -37,23 +37,20 @@ public:
     ComponentTreeView(QWidget* parent = nullptr);
 
     void setItem(SessionItem* item);
-    void setItemIntern(SessionItem* item, bool show_root_item = true);
     void clearEditor();
 
-    void setModel(SessionModel* model);
-    void setRootIndex(const QModelIndex& index, bool show_root_item = true);
-
-    QTreeView* treeView();
-
-    void setHeaderHidden(bool hide);
+    void setShowHeader(bool show);
     void setShowRootItem(bool show);
 
 private:
+    void setModel(SessionModel* model);
+    void setRootIndex(const QModelIndex& index, bool show_root_item = true);
+
     QTreeView* m_tree;
     SessionModelDelegate* m_delegate;
     ComponentProxyModel* m_proxyModel;
     QStandardItemModel* m_placeHolderModel;
-    bool m_show_root_item;
+    bool m_show_root_item; //!< Tree will starts from item itself, if true.
 };
 
 #endif  //  COMPONENTTREEVIEW_H

--- a/GUI/coregui/Views/PropertyEditor/ComponentTreeView.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentTreeView.h
@@ -17,8 +17,7 @@
 #ifndef COMPONENTTREEVIEW_H
 #define COMPONENTTREEVIEW_H
 
-#include "WinDllMacros.h"
-#include <QWidget>
+#include "ComponentView.h"
 
 class QTreeView;
 class SessionModel;
@@ -31,26 +30,30 @@ class QStandardItemModel;
 //! Component property tree for SessionItems.
 //! Shows only PropertyItems and current items of GroupProperties.
 
-class BA_CORE_API_ ComponentTreeView : public QWidget
+class BA_CORE_API_ ComponentTreeView : public ComponentView
 {
     Q_OBJECT
 public:
     ComponentTreeView(QWidget* parent = nullptr);
 
-    void setItem(SessionItem* item, bool show_root_item = false);
+    void setItem(SessionItem* item);
+    void setItemIntern(SessionItem* item, bool show_root_item = true);
+    void clearEditor();
 
     void setModel(SessionModel* model);
-    void setRootIndex(const QModelIndex& index, bool show_root_item = false);
+    void setRootIndex(const QModelIndex& index, bool show_root_item = true);
 
     QTreeView* treeView();
 
     void setHeaderHidden(bool hide);
+    void setShowRootItem(bool show);
 
 private:
     QTreeView* m_tree;
     SessionModelDelegate* m_delegate;
     ComponentProxyModel* m_proxyModel;
     QStandardItemModel* m_placeHolderModel;
+    bool m_show_root_item;
 };
 
 #endif  //  COMPONENTTREEVIEW_H

--- a/GUI/coregui/Views/PropertyEditor/ComponentView.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentView.h
@@ -32,6 +32,7 @@ public:
 
     virtual void clearEditor() = 0;
     virtual void setItem(SessionItem* item) = 0;
+    virtual void addItem(SessionItem*) {}
 };
 
 #endif  // COMPONENTVIEW_H

--- a/GUI/coregui/Views/PropertyEditor/ComponentView.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentView.h
@@ -1,0 +1,37 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Views/PropertyEditor/ComponentView.h
+//! @brief     Defines class ComponentView
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
+//! @authors   Walter Van Herck, Joachim Wuttke
+//
+// ************************************************************************** //
+
+#ifndef COMPONENTVIEW_H
+#define COMPONENTVIEW_H
+
+#include "WinDllMacros.h"
+#include <QWidget>
+
+class SessionItem;
+
+//! Base class for ComponentTreeView and ComponentFlatView.
+
+class BA_CORE_API_ ComponentView : public QWidget
+{
+    Q_OBJECT
+public:
+    ComponentView(QWidget* parent = nullptr) : QWidget(parent){}
+
+    virtual void clearEditor() = 0;
+    virtual void setItem(SessionItem* item) = 0;
+};
+
+#endif  // COMPONENTVIEW_H

--- a/GUI/coregui/Views/PropertyEditor/ObsoleteComponentBoxEditor.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ObsoleteComponentBoxEditor.cpp
@@ -2,8 +2,8 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/PropertyEditor/ComponentBoxEditor.cpp
-//! @brief     Implements class ComponentBoxEditor
+//! @file      GUI/coregui/Views/PropertyEditor/ObsoleteComponentBoxEditor.cpp
+//! @brief     Implements class ObsoleteComponentBoxEditor
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -13,27 +13,27 @@
 //! @authors   Walter Van Herck, Joachim Wuttke
 //
 // ************************************************************************** //
-#include "ComponentBoxEditor.h"
-#include "ComponentEditorPrivate.h"
+#include "ObsoleteComponentBoxEditor.h"
+#include "ObsoleteComponentEditorPrivate.h"
 #include "CustomEventFilters.h"
 #include "SessionModel.h"
 #include <QModelIndex>
 
-ComponentBoxEditor::ComponentBoxEditor(QWidget *parent)
-    : ComponentEditor(ComponentEditorFlags::BROWSER_GROUPBOX, parent)
+ObsoleteComponentBoxEditor::ObsoleteComponentBoxEditor(QWidget *parent)
+    : ObsoleteComponentEditor(ObsoleteComponentEditorFlags::BROWSER_GROUPBOX, parent)
 {
 
 }
 
 ////! adds all property items to thr PropertyGroup with given name
-void ComponentBoxEditor::addPropertyItems(SessionItem *item, const QString &group_name)
+void ObsoleteComponentBoxEditor::addPropertyItems(SessionItem *item, const QString &group_name)
 {
     Q_ASSERT(item);
     QtVariantProperty *groupProperty = m_d->processPropertyGroupForName(group_name);
     updatePropertyItems(item, groupProperty);
 }
 
-void ComponentBoxEditor::updatePropertyItems(SessionItem *item, QtVariantProperty *parentProperty)
+void ObsoleteComponentBoxEditor::updatePropertyItems(SessionItem *item, QtVariantProperty *parentProperty)
 {
     if(item->modelType() == Constants::PropertyType ||
             item->modelType() == Constants::GroupItemType) {
@@ -41,7 +41,7 @@ void ComponentBoxEditor::updatePropertyItems(SessionItem *item, QtVariantPropert
     }
 
     if(m_d->m_item_to_insert_mode.contains(item)) {
-        if(m_d->m_item_to_insert_mode[item] == ComponentEditorFlags::SINGLE) return;
+        if(m_d->m_item_to_insert_mode[item] == ObsoleteComponentEditorFlags::SINGLE) return;
     }
     foreach (SessionItem *childItem, componentItems(item)) {
         updateItem(childItem, parentProperty);
@@ -50,22 +50,22 @@ void ComponentBoxEditor::updatePropertyItems(SessionItem *item, QtVariantPropert
 }
 
 //! add single item to property group with given name
-void ComponentBoxEditor::addItem(SessionItem *item, const QString &group_name)
+void ObsoleteComponentBoxEditor::addItem(SessionItem *item, const QString &group_name)
 {
     Q_ASSERT(item);
     QtVariantProperty *groupProperty = m_d->processPropertyGroupForName(group_name);
     updateItem(item, groupProperty);
-    m_d->m_item_to_insert_mode[item] = ComponentEditorFlags::SINGLE;
+    m_d->m_item_to_insert_mode[item] = ObsoleteComponentEditorFlags::SINGLE;
 }
 
-void ComponentBoxEditor::updateItem(SessionItem *item, QtVariantProperty *parentProperty)
+void ObsoleteComponentBoxEditor::updateItem(SessionItem *item, QtVariantProperty *parentProperty)
 {
     connectModel(item->model());
     m_d->processPropertyForItem(item, parentProperty);
 
 }
 
-void ComponentBoxEditor::onDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles)
+void ObsoleteComponentBoxEditor::onDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles)
 {
     Q_UNUSED(bottomRight);
 //    if (topLeft != bottomRight)
@@ -99,7 +99,7 @@ void ComponentBoxEditor::onDataChanged(const QModelIndex &topLeft, const QModelI
 
 }
 
-void ComponentBoxEditor::onRowsInserted(const QModelIndex &, int , int )
+void ObsoleteComponentBoxEditor::onRowsInserted(const QModelIndex &, int , int )
 {
     // intentionally empty
 }

--- a/GUI/coregui/Views/PropertyEditor/ObsoleteComponentBoxEditor.h
+++ b/GUI/coregui/Views/PropertyEditor/ObsoleteComponentBoxEditor.h
@@ -2,8 +2,8 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/PropertyEditor/ComponentBoxEditor.h
-//! @brief     Defines class ComponentBoxEditor
+//! @file      GUI/coregui/Views/PropertyEditor/ObsoleteComponentBoxEditor.h
+//! @brief     Defines class ObsoleteComponentBoxEditor
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -14,19 +14,19 @@
 //
 // ************************************************************************** //
 
-#ifndef COMPONENTBOXEDITOR_H
-#define COMPONENTBOXEDITOR_H
+#ifndef OBSOLETECOMPONENTBOXEDITOR_H
+#define OBSOLETECOMPONENTBOXEDITOR_H
 
-#include "ComponentEditor.h"
+#include "ObsoleteComponentEditor.h"
 #include "WinDllMacros.h"
 
 //! Special version of editor to show property item as standard qt widgets
 
-class BA_CORE_API_ ComponentBoxEditor : public ComponentEditor
+class BA_CORE_API_ ObsoleteComponentBoxEditor : public ObsoleteComponentEditor
 {
     Q_OBJECT
 public:
-    ComponentBoxEditor(QWidget *parent = 0);
+    ObsoleteComponentBoxEditor(QWidget *parent = 0);
 
     void addPropertyItems(SessionItem *item, const QString &group_name=QString());
     void updatePropertyItems(SessionItem *item, QtVariantProperty *parentProperty=0);
@@ -40,4 +40,4 @@ public slots:
     void onRowsInserted(const QModelIndex &, int, int);
 };
 
-#endif // COMPONENTBOXEDITOR_H
+#endif // OBSOLETECOMPONENTBOXEDITOR_H

--- a/GUI/coregui/Views/PropertyEditor/ObsoleteComponentEditor.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ObsoleteComponentEditor.cpp
@@ -2,8 +2,8 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/PropertyEditor/ComponentEditor.cpp
-//! @brief     Implements class ComponentEditor
+//! @file      GUI/coregui/Views/PropertyEditor/ObsoleteComponentEditor.cpp
+//! @brief     Implements class ObsoleteComponentEditor
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -13,8 +13,8 @@
 //! @authors   Walter Van Herck, Joachim Wuttke
 //
 // ************************************************************************** //
-#include "ComponentEditor.h"
-#include "ComponentEditorPrivate.h"
+#include "ObsoleteComponentEditor.h"
+#include "ObsoleteComponentEditorPrivate.h"
 #include "GroupItem.h"
 #include "GroupProperty.h"
 #include "SessionItem.h"
@@ -24,9 +24,9 @@
 #include <QVariant>
 #include <QTreeView>
 
-ComponentEditor::ComponentEditor(ComponentEditorFlags::PresentationType flags, QWidget *parent)
+ObsoleteComponentEditor::ObsoleteComponentEditor(ObsoleteComponentEditorFlags::PresentationType flags, QWidget *parent)
     : QWidget(parent)
-    , m_d(new ComponentEditorPrivate(flags, this))
+    , m_d(new ObsoleteComponentEditorPrivate(flags, this))
 {
     setWindowTitle(QLatin1String("Property Editor"));
     setObjectName(QLatin1String("ComponentEditor"));
@@ -41,12 +41,12 @@ ComponentEditor::ComponentEditor(ComponentEditorFlags::PresentationType flags, Q
     connectManager();
 }
 
-ComponentEditor::~ComponentEditor()
+ObsoleteComponentEditor::~ObsoleteComponentEditor()
 {
 }
 
 //! Sets editor to display all recursive properties of given item
-void ComponentEditor::setItem(SessionItem *item, const QString &group_name)
+void ObsoleteComponentEditor::setItem(SessionItem *item, const QString &group_name)
 {
     if(item == m_d->m_topItem)
         return;
@@ -69,7 +69,7 @@ void ComponentEditor::setItem(SessionItem *item, const QString &group_name)
 
 //! Main function to run through SessionItem tree and fill editor with
 //! properties
-void ComponentEditor::updateEditor(SessionItem *item,
+void ObsoleteComponentEditor::updateEditor(SessionItem *item,
                                    QtVariantProperty *parentProperty)
 {
     if (QtVariantProperty *childProperty
@@ -83,7 +83,7 @@ void ComponentEditor::updateEditor(SessionItem *item,
 }
 
 //! Clear editor from all properties, ready to accept new items
-void ComponentEditor::clearEditor()
+void ObsoleteComponentEditor::clearEditor()
 {
     if(m_d->m_topItem)
         disconnectModel(m_d->m_topItem->model());
@@ -93,7 +93,7 @@ void ComponentEditor::clearEditor()
     connectManager();
 }
 
-void ComponentEditor::setHeaderHidden(bool hide)
+void ObsoleteComponentEditor::setHeaderHidden(bool hide)
 {
     const QObjectList list = m_d->m_browser->children();
     foreach(QObject *obj, list) {
@@ -105,7 +105,7 @@ void ComponentEditor::setHeaderHidden(bool hide)
 }
 
 //! Propagates data from SessionItem to editor
-void ComponentEditor::onDataChanged(const QModelIndex &topLeft,
+void ObsoleteComponentEditor::onDataChanged(const QModelIndex &topLeft,
                                     const QModelIndex &bottomRight,
                                     const QVector<int> &roles)
 {
@@ -144,7 +144,7 @@ void ComponentEditor::onDataChanged(const QModelIndex &topLeft,
 //! Updates the editor starting from given SessionItem's parent.
 //! Editor should know already about given item (i.e. corresponding
 //! QtVariantProperty should exist.
-void ComponentEditor::onRowsInserted(const QModelIndex &parent, int,
+void ObsoleteComponentEditor::onRowsInserted(const QModelIndex &parent, int,
                                      int )
 {
     SessionModel *model = qobject_cast<SessionModel *>(sender());
@@ -159,7 +159,7 @@ void ComponentEditor::onRowsInserted(const QModelIndex &parent, int,
 }
 
 //! Propagates value from the editor to SessionItem
-void ComponentEditor::onQtPropertyChanged(QtProperty *property,
+void ObsoleteComponentEditor::onQtPropertyChanged(QtProperty *property,
                                           const QVariant &value)
 {
     if (SessionItem *item = m_d->getItemForProperty(property)) {
@@ -174,7 +174,7 @@ void ComponentEditor::onQtPropertyChanged(QtProperty *property,
 
 //! Returns list of children suitable for displaying in ComponentEditor.
 QList<SessionItem *>
-ComponentEditor::componentItems(SessionItem *item) const
+ObsoleteComponentEditor::componentItems(SessionItem *item) const
 {
     QList<SessionItem *> result;
     foreach (SessionItem *child, item->children()) {
@@ -215,7 +215,7 @@ ComponentEditor::componentItems(SessionItem *item) const
 }
 
 
-void ComponentEditor::disconnectModel(SessionModel *model)
+void ObsoleteComponentEditor::disconnectModel(SessionModel *model)
 {
     if(!model) return;
 
@@ -229,7 +229,7 @@ void ComponentEditor::disconnectModel(SessionModel *model)
                SLOT(onRowsInserted(const QModelIndex &, int, int)));
 }
 
-void ComponentEditor::connectModel(SessionModel *model)
+void ObsoleteComponentEditor::connectModel(SessionModel *model)
 {
     if(!model) return;
 
@@ -244,14 +244,14 @@ void ComponentEditor::connectModel(SessionModel *model)
             Qt::UniqueConnection);
 }
 
-void ComponentEditor::disconnectManager()
+void ObsoleteComponentEditor::disconnectManager()
 {
     disconnect(m_d->m_manager,
                SIGNAL(valueChanged(QtProperty *, const QVariant &)), this,
                SLOT(onQtPropertyChanged(QtProperty *, const QVariant &)));
 }
 
-void ComponentEditor::connectManager()
+void ObsoleteComponentEditor::connectManager()
 {
     connect(m_d->m_manager,
             SIGNAL(valueChanged(QtProperty *, const QVariant &)), this,

--- a/GUI/coregui/Views/PropertyEditor/ObsoleteComponentEditor.h
+++ b/GUI/coregui/Views/PropertyEditor/ObsoleteComponentEditor.h
@@ -2,8 +2,8 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/PropertyEditor/ComponentEditor.h
-//! @brief     Defines class ComponentEditor
+//! @file      GUI/coregui/Views/PropertyEditor/ObsoleteComponentEditor.h
+//! @brief     Defines class ObsoleteComponentEditor
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -14,27 +14,27 @@
 //
 // ************************************************************************** //
 
-#ifndef COMPONENTEDITOR_H
-#define COMPONENTEDITOR_H
+#ifndef OBSOLETECOMPONENTEDITOR_H
+#define OBSOLETECOMPONENTEDITOR_H
 
-#include "ComponentEditorFlags.h"
+#include "ObsoleteComponentEditorFlags.h"
 #include "WinDllMacros.h"
 #include <QWidget>
 #include <memory>
 
-class ComponentEditorPrivate;
+class ObsoleteComponentEditorPrivate;
 class SessionItem;
 class SessionModel;
 class QtVariantProperty;
 class QtProperty;
 
-class BA_CORE_API_ ComponentEditor : public QWidget
+class BA_CORE_API_ ObsoleteComponentEditor : public QWidget
 {
     Q_OBJECT
 public:
-    ComponentEditor(ComponentEditorFlags::PresentationType flags = ComponentEditorFlags::BROWSER_TABLE, QWidget *parent = 0);
+    ObsoleteComponentEditor(ObsoleteComponentEditorFlags::PresentationType flags = ObsoleteComponentEditorFlags::BROWSER_TABLE, QWidget *parent = 0);
 
-    virtual ~ComponentEditor();
+    virtual ~ObsoleteComponentEditor();
 
     void setItem(SessionItem *item, const QString &group_name=QString());
 
@@ -60,8 +60,8 @@ protected:
     void disconnectManager();
     void connectManager();
 
-    std::unique_ptr<ComponentEditorPrivate> m_d;
+    std::unique_ptr<ObsoleteComponentEditorPrivate> m_d;
 };
 
 
-#endif // COMPONENTEDITOR_H
+#endif // OBSOLETECOMPONENTEDITOR_H

--- a/GUI/coregui/Views/PropertyEditor/ObsoleteComponentEditorFlags.h
+++ b/GUI/coregui/Views/PropertyEditor/ObsoleteComponentEditorFlags.h
@@ -2,8 +2,8 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/PropertyEditor/ComponentEditorFlags.h
-//! @brief     Defines class ComponentEditorFlags
+//! @file      GUI/coregui/Views/PropertyEditor/ObsoleteComponentEditorFlags.h
+//! @brief     Defines class ObsoleteComponentEditorFlags
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -14,13 +14,13 @@
 //
 // ************************************************************************** //
 
-#ifndef COMPONENTEDITORFLAGS_H
-#define COMPONENTEDITORFLAGS_H
+#ifndef OBSOLETECOMPONENTEDITORFLAGS_H
+#define OBSOLETECOMPONENTEDITORFLAGS_H
 
 #include "WinDllMacros.h"
 #include <QObject>
 
-class BA_CORE_API_ ComponentEditorFlags
+class BA_CORE_API_ ObsoleteComponentEditorFlags
 {
 public:
     enum EPresentationType {
@@ -39,7 +39,7 @@ public:
 
 };
 
-Q_DECLARE_OPERATORS_FOR_FLAGS(ComponentEditorFlags::PresentationType)
+Q_DECLARE_OPERATORS_FOR_FLAGS(ObsoleteComponentEditorFlags::PresentationType)
 
 
-#endif // COMPONENTEDITORFLAGS_H
+#endif // OBSOLETECOMPONENTEDITORFLAGS_H

--- a/GUI/coregui/Views/PropertyEditor/ObsoleteComponentEditorPrivate.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ObsoleteComponentEditorPrivate.cpp
@@ -2,8 +2,8 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/PropertyEditor/ComponentEditorPrivate.cpp
-//! @brief     Implements class ComponentEditorPrivate
+//! @file      GUI/coregui/Views/PropertyEditor/ObsoleteComponentEditorPrivate.cpp
+//! @brief     Implements class ObsoleteComponentEditorPrivate
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -14,31 +14,31 @@
 //
 // ************************************************************************** //
 
-#include "ComponentEditorPrivate.h"
+#include "ObsoleteComponentEditorPrivate.h"
 #include "CustomEventFilters.h"
 #include "GUIHelpers.h"
 #include <QComboBox>
 #include <QString>
 #include <cmath>
 
-ComponentEditorPrivate::ComponentEditorPrivate(ComponentEditorFlags::PresentationType flags, QWidget *parent)
+ObsoleteComponentEditorPrivate::ObsoleteComponentEditorPrivate(ObsoleteComponentEditorFlags::PresentationType flags, QWidget *parent)
     : m_browser(0), m_manager(0), m_read_only_manager(0)
-    , m_propertyFactory(new PropertyVariantFactory(parent))
+    , m_propertyFactory(new ObsoletePropertyVariantFactory(parent))
     , m_presentationType(flags)
     , m_wheel_event_filter(new WheelEventEater)
     , m_topItem(0)
 {
-    m_read_only_manager = new PropertyVariantManager(parent);
-    m_manager = new PropertyVariantManager(parent);
+    m_read_only_manager = new ObsoletePropertyVariantManager(parent);
+    m_manager = new ObsoletePropertyVariantManager(parent);
     init_browser();
 }
 
-ComponentEditorPrivate::~ComponentEditorPrivate()
+ObsoleteComponentEditorPrivate::~ObsoleteComponentEditorPrivate()
 {
     clear();
 }
 
-void ComponentEditorPrivate::clear()
+void ObsoleteComponentEditorPrivate::clear()
 {
     m_browser->clear();
 
@@ -56,23 +56,23 @@ void ComponentEditorPrivate::clear()
     m_changedItems.clear();
 }
 
-void ComponentEditorPrivate::init_browser()
+void ObsoleteComponentEditorPrivate::init_browser()
 {
     delete m_browser;
     m_browser = 0;
 
-    if (m_presentationType & ComponentEditorFlags::BROWSER_TABLE) {
+    if (m_presentationType & ObsoleteComponentEditorFlags::BROWSER_TABLE) {
         QtTreePropertyBrowser *browser = new QtTreePropertyBrowser;
         browser->setResizeMode(QtTreePropertyBrowser::Interactive);
         browser->setRootIsDecorated(false);
         m_browser = browser;
     }
 
-    else if (m_presentationType & ComponentEditorFlags::BROWSER_GROUPBOX) {
+    else if (m_presentationType & ObsoleteComponentEditorFlags::BROWSER_GROUPBOX) {
         m_browser = new QtGroupBoxPropertyBrowser;
     }
 
-    else if (m_presentationType & ComponentEditorFlags::BROWSER_BUTTON) {
+    else if (m_presentationType & ObsoleteComponentEditorFlags::BROWSER_BUTTON) {
         m_browser = new QtButtonPropertyBrowser;
 
     } else {
@@ -86,7 +86,7 @@ void ComponentEditorPrivate::init_browser()
 }
 
 //! Creates, if necessary, qtVariantProperty for given item and place it in the editor
-QtVariantProperty *ComponentEditorPrivate::
+QtVariantProperty *ObsoleteComponentEditorPrivate::
     processPropertyForItem(SessionItem *item, QtVariantProperty *parentProperty)
 {
     QtVariantProperty *itemProperty = getPropertyForItem(item);
@@ -113,7 +113,7 @@ QtVariantProperty *ComponentEditorPrivate::
 }
 
 //! Returns QtVariantProperty representing given item in ComponentEditor.
-QtVariantProperty *ComponentEditorPrivate::getPropertyForItem(SessionItem *item)
+QtVariantProperty *ObsoleteComponentEditorPrivate::getPropertyForItem(SessionItem *item)
 {
     if (m_item_to_qtvariantproperty.contains(item)) {
         return m_item_to_qtvariantproperty[item];
@@ -122,7 +122,7 @@ QtVariantProperty *ComponentEditorPrivate::getPropertyForItem(SessionItem *item)
 }
 
 //! Returns SessionItem corresponding to QtVariantProperty representation
-SessionItem *ComponentEditorPrivate::getItemForProperty(QtProperty *property)
+SessionItem *ObsoleteComponentEditorPrivate::getItemForProperty(QtProperty *property)
 {
     if (m_qtproperty_to_item.contains(property)) {
         return m_qtproperty_to_item[property];
@@ -131,7 +131,7 @@ SessionItem *ComponentEditorPrivate::getItemForProperty(QtProperty *property)
 }
 
 //! creates QtVariantProperty for given SessionItem's property
-QtVariantProperty *ComponentEditorPrivate::createQtVariantProperty(SessionItem *item)
+QtVariantProperty *ObsoleteComponentEditorPrivate::createQtVariantProperty(SessionItem *item)
 {
     QtVariantProperty *result(0);
 
@@ -162,7 +162,7 @@ QtVariantProperty *ComponentEditorPrivate::createQtVariantProperty(SessionItem *
     return result;
 }
 
-QtVariantProperty *ComponentEditorPrivate::processPropertyGroupForName(const QString &name)
+QtVariantProperty *ObsoleteComponentEditorPrivate::processPropertyGroupForName(const QString &name)
 {
     QtVariantProperty *result = getPropertyForGroupName(name);
     if(result == nullptr && name.size()) {
@@ -173,7 +173,7 @@ QtVariantProperty *ComponentEditorPrivate::processPropertyGroupForName(const QSt
     return result;
 }
 
-QtVariantProperty *ComponentEditorPrivate::getPropertyForGroupName(const QString &name)
+QtVariantProperty *ObsoleteComponentEditorPrivate::getPropertyForGroupName(const QString &name)
 {
     if (m_groupname_to_qtvariant.contains(name)) {
         return m_groupname_to_qtvariant[name];
@@ -182,7 +182,7 @@ QtVariantProperty *ComponentEditorPrivate::getPropertyForGroupName(const QString
 }
 
 //! removes given qtVariantProperty from browser and all maps
-void ComponentEditorPrivate::removeQtVariantProperty(QtVariantProperty *property)
+void ObsoleteComponentEditorPrivate::removeQtVariantProperty(QtVariantProperty *property)
 {
     m_browser->removeProperty(property);
     delete property;
@@ -197,7 +197,7 @@ void ComponentEditorPrivate::removeQtVariantProperty(QtVariantProperty *property
 }
 
 //! update visual apperance of qtVariantProperty using SessionItem's attribute
-void ComponentEditorPrivate::updatePropertyAppearance(QtVariantProperty *property,
+void ObsoleteComponentEditorPrivate::updatePropertyAppearance(QtVariantProperty *property,
                                                       SessionItem* item)
 {
     Q_ASSERT(property);
@@ -236,7 +236,7 @@ void ComponentEditorPrivate::updatePropertyAppearance(QtVariantProperty *propert
 }
 
 //! removes properties of all child items
-void ComponentEditorPrivate::cleanChildren(SessionItem *item)
+void ObsoleteComponentEditorPrivate::cleanChildren(SessionItem *item)
 {
     foreach(SessionItem *child, item->children()) {
         if (QtVariantProperty *property = getPropertyForItem(child)) {
@@ -249,9 +249,9 @@ void ComponentEditorPrivate::cleanChildren(SessionItem *item)
 //! installs WheelEventEater on all comboxes
 // hack to change behaviour of ComboBoxes and SpinBoxes produced by QtGroupBoxPropertyBrowser
 // with the goal to react on mouse wheel event only when there is keyboard focus
-void ComponentEditorPrivate::install_custom_filters()
+void ObsoleteComponentEditorPrivate::install_custom_filters()
 {
-    if(m_presentationType & ComponentEditorFlags::BROWSER_GROUPBOX) {
+    if(m_presentationType & ObsoleteComponentEditorFlags::BROWSER_GROUPBOX) {
         QList<QAbstractSpinBox*> spinboxes = m_browser->findChildren<QAbstractSpinBox *>();
         QList<QComboBox*> comboboxes = m_browser->findChildren<QComboBox *>();
         foreach(QAbstractSpinBox *w, spinboxes) {

--- a/GUI/coregui/Views/PropertyEditor/ObsoleteComponentEditorPrivate.h
+++ b/GUI/coregui/Views/PropertyEditor/ObsoleteComponentEditorPrivate.h
@@ -2,8 +2,8 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/PropertyEditor/ComponentEditorPrivate.h
-//! @brief     Defines class ComponentEditorPrivate
+//! @file      GUI/coregui/Views/PropertyEditor/ObsoleteComponentEditorPrivate.h
+//! @brief     Defines class ObsoleteComponentEditorPrivate
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -14,12 +14,12 @@
 //
 // ************************************************************************** //
 
-#ifndef COMPONENTEDITORPRIVATE_H
-#define COMPONENTEDITORPRIVATE_H
+#ifndef OBSOLETECOMPONENTEDITORPRIVATE_H
+#define OBSOLETECOMPONENTEDITORPRIVATE_H
 
-#include "ComponentEditorFlags.h"
-#include "PropertyVariantFactory.h"
-#include "PropertyVariantManager.h"
+#include "ObsoleteComponentEditorFlags.h"
+#include "ObsoletePropertyVariantFactory.h"
+#include "ObsoletePropertyVariantManager.h"
 #include "SessionItem.h"
 #include "WinDllMacros.h"
 #include "qtbuttonpropertybrowser.h"
@@ -32,15 +32,15 @@ class WheelEventEater;
 
 //! Holds logic for ComponentEditor
 
-class BA_CORE_API_ ComponentEditorPrivate
+class BA_CORE_API_ ObsoleteComponentEditorPrivate
 {
 public:
-    ComponentEditorPrivate(ComponentEditorFlags::PresentationType flags
-                           = ComponentEditorFlags::BROWSER_TABLE,
+    ObsoleteComponentEditorPrivate(ObsoleteComponentEditorFlags::PresentationType flags
+                           = ObsoleteComponentEditorFlags::BROWSER_TABLE,
                            QWidget *parent = 0);
 
 
-    ~ComponentEditorPrivate();
+    ~ObsoleteComponentEditorPrivate();
 
     void clear();
     void init_browser();
@@ -65,18 +65,18 @@ public:
     QtAbstractPropertyBrowser *m_browser;
     QtVariantPropertyManager *m_manager;
     QtVariantPropertyManager *m_read_only_manager;
-    PropertyVariantFactory *m_propertyFactory;
+    ObsoletePropertyVariantFactory *m_propertyFactory;
 
     QMap<QtProperty *, SessionItem *> m_qtproperty_to_item;
     QMap<SessionItem *, QtVariantProperty *> m_item_to_qtvariantproperty;
     QMap<QString, QtVariantProperty *> m_groupname_to_qtvariant;
     QMap<SessionItem *, QtVariantProperty *> m_item_to_qtparent;
-    QMap<SessionItem *, ComponentEditorFlags::InsertMode> m_item_to_insert_mode;
+    QMap<SessionItem *, ObsoleteComponentEditorFlags::InsertMode> m_item_to_insert_mode;
 
-    ComponentEditorFlags::PresentationType m_presentationType;
+    ObsoleteComponentEditorFlags::PresentationType m_presentationType;
     QList<SessionItem *> m_changedItems;
     std::unique_ptr<WheelEventEater> m_wheel_event_filter;
     SessionItem *m_topItem;
 };
 
-#endif // COMPONENTEDITORPRIVATE_H
+#endif // OBSOLETECOMPONENTEDITORPRIVATE_H

--- a/GUI/coregui/Views/PropertyEditor/ObsoletePropertyBrowserUtils.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ObsoletePropertyBrowserUtils.cpp
@@ -2,8 +2,8 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/PropertyEditor/PropertyBrowserUtils.cpp
-//! @brief     Implements class PropertyBrowserUtils
+//! @file      GUI/coregui/Views/PropertyEditor/ObsoletePropertyBrowserUtils.cpp
+//! @brief     Implements class ObsoletePropertyBrowserUtils
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -14,7 +14,7 @@
 //
 // ************************************************************************** //
 
-#include "PropertyBrowserUtils.h"
+#include "ObsoletePropertyBrowserUtils.h"
 #include "MaterialSvc.h"
 #include "CustomEventFilters.h"
 #include <QColorDialog>
@@ -34,7 +34,7 @@
 // MaterialPropertyEdit
 // -----------------------------------------------------------------------------
 
-MaterialPropertyEdit::MaterialPropertyEdit(QWidget *parent)
+ObsoleteMaterialPropertyEdit::ObsoleteMaterialPropertyEdit(QWidget *parent)
     : QWidget(parent)
     , m_focusFilter(new LostFocusFilter(this))
 {
@@ -66,7 +66,7 @@ MaterialPropertyEdit::MaterialPropertyEdit(QWidget *parent)
     setLayout(layout);
 }
 
-void MaterialPropertyEdit::buttonClicked()
+void ObsoleteMaterialPropertyEdit::buttonClicked()
 {
     // temporarily installing filter to prevent loss of focus caused by too  insistent dialog
     installEventFilter(m_focusFilter);
@@ -80,7 +80,7 @@ void MaterialPropertyEdit::buttonClicked()
 }
 
 
-void MaterialPropertyEdit::setMaterialProperty(
+void ObsoleteMaterialPropertyEdit::setMaterialProperty(
         const MaterialProperty &materialProperty)
 {
     m_materialProperty = materialProperty;
@@ -92,7 +92,7 @@ void MaterialPropertyEdit::setMaterialProperty(
 // -----------------------------------------------------------------------------
 // GroupPropertyEdit
 // -----------------------------------------------------------------------------
-GroupPropertyEdit::GroupPropertyEdit(QWidget *parent)
+ObsoleteGroupPropertyEdit::ObsoleteGroupPropertyEdit(QWidget *parent)
     : QWidget(parent)
     , m_box(new QComboBox())
     , m_label(new QLabel())
@@ -114,11 +114,11 @@ GroupPropertyEdit::GroupPropertyEdit(QWidget *parent)
     setLayout(layout);
 }
 
-GroupPropertyEdit::~GroupPropertyEdit()
+ObsoleteGroupPropertyEdit::~ObsoleteGroupPropertyEdit()
 {
 }
 
-void GroupPropertyEdit::setGroupProperty(GroupProperty_t groupProperty)
+void ObsoleteGroupPropertyEdit::setGroupProperty(GroupProperty_t groupProperty)
 {
     if(groupProperty) {
         m_groupProperty = groupProperty;
@@ -126,7 +126,7 @@ void GroupPropertyEdit::setGroupProperty(GroupProperty_t groupProperty)
     }
 }
 
-void GroupPropertyEdit::processGroup()
+void ObsoleteGroupPropertyEdit::processGroup()
 {
     disconnect(m_box, SIGNAL(currentIndexChanged(int)),
             this, SLOT(indexChanged(int)));
@@ -141,12 +141,12 @@ void GroupPropertyEdit::processGroup()
             this, SLOT(indexChanged(int)), Qt::UniqueConnection);
 }
 
-void GroupPropertyEdit::indexChanged(int index)
+void ObsoleteGroupPropertyEdit::indexChanged(int index)
 {
     m_groupProperty->setCurrentIndex(index);
 }
 
-QSize GroupPropertyEdit::sizeHint() const
+QSize ObsoleteGroupPropertyEdit::sizeHint() const
 {
     if(m_box)
         return m_box->sizeHint();
@@ -157,7 +157,7 @@ QSize GroupPropertyEdit::sizeHint() const
     return QSize(100,10);
 }
 
-QSize GroupPropertyEdit::minimumSizeHint() const
+QSize ObsoleteGroupPropertyEdit::minimumSizeHint() const
 {
     if(m_box)
         return m_box->minimumSizeHint();
@@ -168,12 +168,12 @@ QSize GroupPropertyEdit::minimumSizeHint() const
     return QSize(100,10);
 }
 
-GroupProperty_t GroupPropertyEdit::group() const
+GroupProperty_t ObsoleteGroupPropertyEdit::group() const
 {
     return m_groupProperty;
 }
 
-void GroupPropertyEdit::setGroup(GroupProperty_t group)
+void ObsoleteGroupPropertyEdit::setGroup(GroupProperty_t group)
 {
     setGroupProperty(group);
 }
@@ -183,7 +183,7 @@ void GroupPropertyEdit::setGroup(GroupProperty_t group)
 // ColorPropertyEdit
 // -----------------------------------------------------------------------------
 
-ColorPropertyEdit::ColorPropertyEdit(QWidget *parent)
+ObsoleteColorPropertyEdit::ObsoleteColorPropertyEdit(QWidget *parent)
     : QWidget(parent)
 {
     setAutoFillBackground(true);
@@ -215,7 +215,7 @@ ColorPropertyEdit::ColorPropertyEdit(QWidget *parent)
 }
 
 
-void ColorPropertyEdit::buttonClicked()
+void ObsoleteColorPropertyEdit::buttonClicked()
 {
     bool ok = false;
     QRgb oldRgba = m_colorProperty.getColor().rgba();
@@ -228,7 +228,7 @@ void ColorPropertyEdit::buttonClicked()
 
 }
 
-void ColorPropertyEdit::setColorProperty(
+void ObsoleteColorPropertyEdit::setColorProperty(
         const ColorProperty &colorProperty)
 {
     m_colorProperty = colorProperty;
@@ -236,7 +236,7 @@ void ColorPropertyEdit::setColorProperty(
     m_pixmapLabel->setPixmap(m_colorProperty.getPixmap());
 }
 
-QString ColorPropertyEdit::colorValueText(const QColor &c)
+QString ObsoleteColorPropertyEdit::colorValueText(const QColor &c)
 {
     return QString("[%1, %2, %3] (%4)")
            .arg(c.red()).arg(c.green()).arg(c.blue()).arg(c.alpha());
@@ -248,7 +248,7 @@ QString ColorPropertyEdit::colorValueText(const QColor &c)
 // -----------------------------------------------------------------------------
 
 
-ScientificDoublePropertyEdit::ScientificDoublePropertyEdit(QWidget *parent)
+ObsoleteScientificDoublePropertyEdit::ObsoleteScientificDoublePropertyEdit(QWidget *parent)
     : QWidget(parent)
 {
     setAutoFillBackground(true);
@@ -271,14 +271,14 @@ ScientificDoublePropertyEdit::ScientificDoublePropertyEdit(QWidget *parent)
     setLayout(layout);
 }
 
-void ScientificDoublePropertyEdit::setScientificDoubleProperty(
+void ObsoleteScientificDoublePropertyEdit::setScientificDoubleProperty(
         const ScientificDoubleProperty &doubleProperty)
 {
     m_lineEdit->setText(doubleProperty.getText());
     m_scientificDoubleProperty = doubleProperty;
 }
 
-void ScientificDoublePropertyEdit::onEditingFinished()
+void ObsoleteScientificDoublePropertyEdit::onEditingFinished()
 {
     double new_value = m_lineEdit->text().toDouble();
     if(new_value != m_scientificDoubleProperty.getValue()) {
@@ -288,12 +288,12 @@ void ScientificDoublePropertyEdit::onEditingFinished()
     }
 }
 
-QSize ScientificDoublePropertyEdit::sizeHint() const
+QSize ObsoleteScientificDoublePropertyEdit::sizeHint() const
 {
     return m_lineEdit->sizeHint();
 }
 
-QSize ScientificDoublePropertyEdit::minimumSizeHint() const
+QSize ObsoleteScientificDoublePropertyEdit::minimumSizeHint() const
 {
     return m_lineEdit->minimumSizeHint();
 }
@@ -309,7 +309,7 @@ QSize ScientificDoublePropertyEdit::minimumSizeHint() const
 //    m_comboBox->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 //}
 
-ComboPropertyEdit::ComboPropertyEdit(QWidget *parent)
+ObsoleteComboPropertyEdit::ObsoleteComboPropertyEdit(QWidget *parent)
     : QComboBox(parent)
 {
     setAutoFillBackground(true);
@@ -319,7 +319,7 @@ ComboPropertyEdit::ComboPropertyEdit(QWidget *parent)
 //{
 //}
 
-void ComboPropertyEdit::setComboProperty(
+void ObsoleteComboPropertyEdit::setComboProperty(
         const ComboProperty &combo_property)
 {
     m_combo_property = combo_property;
@@ -348,7 +348,7 @@ void ComboPropertyEdit::setComboProperty(
             this, SLOT(onCurrentIndexChanged(QString)));
 }
 
-QString ComboPropertyEdit::comboValueText()
+QString ObsoleteComboPropertyEdit::comboValueText()
 {
     return m_combo_property.getValue();
 }
@@ -366,7 +366,7 @@ QString ComboPropertyEdit::comboValueText()
 //    return m_comboBox->minimumSizeHint();
 //}
 
-void ComboPropertyEdit::onCurrentIndexChanged(QString current_value)
+void ObsoleteComboPropertyEdit::onCurrentIndexChanged(QString current_value)
 {
     m_combo_property.setValue(current_value);
     emit comboPropertyChanged(m_combo_property);

--- a/GUI/coregui/Views/PropertyEditor/ObsoletePropertyBrowserUtils.h
+++ b/GUI/coregui/Views/PropertyEditor/ObsoletePropertyBrowserUtils.h
@@ -2,8 +2,8 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/PropertyEditor/PropertyBrowserUtils.h
-//! @brief     Defines class PropertyBrowserUtils
+//! @file      GUI/coregui/Views/PropertyEditor/ObsoletePropertyBrowserUtils.h
+//! @brief     Defines class ObsoletePropertyBrowserUtils
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -14,8 +14,8 @@
 //
 // ************************************************************************** //
 
-#ifndef PROPERTYBROWSERUTILS_H
-#define PROPERTYBROWSERUTILS_H
+#ifndef OBSOLETEPROPERTYBROWSERUTILS_H
+#define OBSOLETEPROPERTYBROWSERUTILS_H
 
 #include <QWidget>
 #include "MaterialProperty.h"
@@ -33,11 +33,11 @@ class LostFocusFilter;
 
 //! The MaterialPropertyEdit class provides PropertyVariantFactory with editing
 //! widget for MaterialProperty.
-class BA_CORE_API_ MaterialPropertyEdit : public QWidget
+class BA_CORE_API_ ObsoleteMaterialPropertyEdit : public QWidget
 {
     Q_OBJECT
 public:
-    MaterialPropertyEdit(QWidget *parent = 0);
+    ObsoleteMaterialPropertyEdit(QWidget *parent = 0);
 
     void setMaterialProperty(const MaterialProperty &materialProperty);
     MaterialProperty getMaterialProperty() const {return m_materialProperty; }
@@ -53,15 +53,15 @@ private:
 };
 
 
-class BA_CORE_API_ GroupPropertyEdit : public QWidget
+class BA_CORE_API_ ObsoleteGroupPropertyEdit : public QWidget
 {
     Q_OBJECT
 
     Q_PROPERTY(GroupProperty_t group READ group WRITE setGroup USER true)
 
 public:
-    GroupPropertyEdit(QWidget *parent = 0);
-    virtual ~GroupPropertyEdit();
+    ObsoleteGroupPropertyEdit(QWidget *parent = 0);
+    virtual ~ObsoleteGroupPropertyEdit();
 
     void setGroupProperty(GroupProperty_t groupProperty);
     GroupProperty_t getGroupProperty() const;
@@ -85,7 +85,7 @@ private:
     GroupProperty_t m_groupProperty;
 };
 
-inline GroupProperty_t GroupPropertyEdit::getGroupProperty() const
+inline GroupProperty_t ObsoleteGroupPropertyEdit::getGroupProperty() const
 {
     return m_groupProperty;
 }
@@ -93,11 +93,11 @@ inline GroupProperty_t GroupPropertyEdit::getGroupProperty() const
 
 //! The ColorPropertyEdit class provides PropertyVariantFactory with editing
 //! widget for ColorProperty
-class BA_CORE_API_ ColorPropertyEdit : public QWidget
+class BA_CORE_API_ ObsoleteColorPropertyEdit : public QWidget
 {
     Q_OBJECT
 public:
-    ColorPropertyEdit(QWidget *parent = 0);
+    ObsoleteColorPropertyEdit(QWidget *parent = 0);
 
     void setColorProperty(const ColorProperty &colorProperty);
     ColorProperty getColorProperty() const {return m_colorProperty; }
@@ -118,11 +118,11 @@ private:
 
 //! The ScientificDoublePropertyEdit class provides PropertyVariantFactory with editing
 //! widget for ScientificDoubleProperty
-class BA_CORE_API_ ScientificDoublePropertyEdit : public QWidget
+class BA_CORE_API_ ObsoleteScientificDoublePropertyEdit : public QWidget
 {
     Q_OBJECT
 public:
-    ScientificDoublePropertyEdit(QWidget *parent = 0);
+    ObsoleteScientificDoublePropertyEdit(QWidget *parent = 0);
 
     void setScientificDoubleProperty(const ScientificDoubleProperty &doubleProperty);
     ScientificDoubleProperty getScientificDoubleProperty() const {
@@ -146,11 +146,11 @@ private:
 
 //! The ComboPropertyEdit class provides PropertyVariantFactory with editing
 //! widget for ComboProperty
-class BA_CORE_API_ ComboPropertyEdit : public QComboBox
+class BA_CORE_API_ ObsoleteComboPropertyEdit : public QComboBox
 {
     Q_OBJECT
 public:
-    ComboPropertyEdit(QWidget *parent = 0);
+    ObsoleteComboPropertyEdit(QWidget *parent = 0);
 
     void setComboProperty(const ComboProperty &combo_property);
     ComboProperty getComboProperty() const {return m_combo_property; }
@@ -166,4 +166,4 @@ private:
     ComboProperty m_combo_property;
 };
 
-#endif // PROPERTYBROWSERUTILS_H
+#endif // OBSOLETEPROPERTYBROWSERUTILS_H

--- a/GUI/coregui/Views/PropertyEditor/ObsoletePropertyVariantFactory.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ObsoletePropertyVariantFactory.cpp
@@ -2,8 +2,8 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/PropertyEditor/PropertyVariantFactory.cpp
-//! @brief     Implements class PropertyVariantFactory
+//! @file      GUI/coregui/Views/PropertyEditor/ObsoletePropertyVariantFactory.cpp
+//! @brief     Implements class ObsoletePropertyVariantFactory
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -14,44 +14,44 @@
 //
 // ************************************************************************** //
 
-#include "PropertyVariantFactory.h"
-#include "PropertyBrowserUtils.h"
-#include "PropertyVariantManager.h"
+#include "ObsoletePropertyVariantFactory.h"
+#include "ObsoletePropertyBrowserUtils.h"
+#include "ObsoletePropertyVariantManager.h"
 
-PropertyVariantFactory::~PropertyVariantFactory()
+ObsoletePropertyVariantFactory::~ObsoletePropertyVariantFactory()
 {
-    QList<MaterialPropertyEdit *> mat_editors =
+    QList<ObsoleteMaterialPropertyEdit *> mat_editors =
             m_material_editor_to_property.keys();
-    QListIterator<MaterialPropertyEdit *> mat_it(mat_editors);
+    QListIterator<ObsoleteMaterialPropertyEdit *> mat_it(mat_editors);
     while (mat_it.hasNext())
         delete mat_it.next();
 
-    QList<ColorPropertyEdit *> color_editors =
+    QList<ObsoleteColorPropertyEdit *> color_editors =
             m_color_editor_to_property.keys();
-    QListIterator<ColorPropertyEdit *> color_it(color_editors);
+    QListIterator<ObsoleteColorPropertyEdit *> color_it(color_editors);
     while (color_it.hasNext())
         delete color_it.next();
 
-    QList<ScientificDoublePropertyEdit *> scdouble_editors =
+    QList<ObsoleteScientificDoublePropertyEdit *> scdouble_editors =
             m_scdouble_editor_to_property.keys();
-    QListIterator<ScientificDoublePropertyEdit *> scdouble_it(scdouble_editors);
+    QListIterator<ObsoleteScientificDoublePropertyEdit *> scdouble_it(scdouble_editors);
     while (scdouble_it.hasNext())
         delete scdouble_it.next();
 
-    QList<GroupPropertyEdit *> fancy_editors =
+    QList<ObsoleteGroupPropertyEdit *> fancy_editors =
             m_fancygroup_editor_to_property.keys();
-    QListIterator<GroupPropertyEdit *> fancy_it(fancy_editors);
+    QListIterator<ObsoleteGroupPropertyEdit *> fancy_it(fancy_editors);
     while (fancy_it.hasNext())
         delete fancy_it.next();
 
-    QList<ComboPropertyEdit *> combo_editors =
+    QList<ObsoleteComboPropertyEdit *> combo_editors =
             m_combo_editor_to_property.keys();
-    QListIterator<ComboPropertyEdit *> combo_it(combo_editors);
+    QListIterator<ObsoleteComboPropertyEdit *> combo_it(combo_editors);
     while (combo_it.hasNext())
         delete combo_it.next();
 }
 
-void PropertyVariantFactory::connectPropertyManager(
+void ObsoletePropertyVariantFactory::connectPropertyManager(
         QtVariantPropertyManager *manager)
 {
     connect(manager, SIGNAL(valueChanged(QtProperty *, const QVariant &)),
@@ -65,12 +65,12 @@ void PropertyVariantFactory::connectPropertyManager(
 }
 
 
-QWidget *PropertyVariantFactory::createEditor(QtVariantPropertyManager *manager,
+QWidget *ObsoletePropertyVariantFactory::createEditor(QtVariantPropertyManager *manager,
         QtProperty *property, QWidget *parent)
 {
     if (manager->propertyType(property) ==
-            PropertyVariantManager::materialTypeId()) {
-        MaterialPropertyEdit *editor = new MaterialPropertyEdit(parent);
+            ObsoletePropertyVariantManager::materialTypeId()) {
+        ObsoleteMaterialPropertyEdit *editor = new ObsoleteMaterialPropertyEdit(parent);
         QVariant var = manager->value(property);
         MaterialProperty mat = var.value<MaterialProperty>();
         editor->setMaterialProperty(mat);
@@ -86,8 +86,8 @@ QWidget *PropertyVariantFactory::createEditor(QtVariantPropertyManager *manager,
     }
 
     if (manager->propertyType(property) ==
-            PropertyVariantManager::colorPropertyTypeId()) {
-        ColorPropertyEdit *editor = new ColorPropertyEdit(parent);
+            ObsoletePropertyVariantManager::colorPropertyTypeId()) {
+        ObsoleteColorPropertyEdit *editor = new ObsoleteColorPropertyEdit(parent);
         QVariant var = manager->value(property);
         ColorProperty mat = var.value<ColorProperty>();
         editor->setColorProperty(mat);
@@ -103,8 +103,8 @@ QWidget *PropertyVariantFactory::createEditor(QtVariantPropertyManager *manager,
     }
 
     if (manager->propertyType(property) ==
-            PropertyVariantManager::scientificDoubleTypeId()) {
-        ScientificDoublePropertyEdit *editor = new ScientificDoublePropertyEdit(parent);
+            ObsoletePropertyVariantManager::scientificDoubleTypeId()) {
+        ObsoleteScientificDoublePropertyEdit *editor = new ObsoleteScientificDoublePropertyEdit(parent);
         QVariant var = manager->value(property);
         ScientificDoubleProperty sc = var.value<ScientificDoubleProperty>();
         editor->setScientificDoubleProperty(sc);
@@ -121,8 +121,8 @@ QWidget *PropertyVariantFactory::createEditor(QtVariantPropertyManager *manager,
     }
 
     if (manager->propertyType(property) ==
-            PropertyVariantManager::fancyGroupTypeId()) {
-        GroupPropertyEdit *editor = new GroupPropertyEdit(parent);
+            ObsoletePropertyVariantManager::fancyGroupTypeId()) {
+        ObsoleteGroupPropertyEdit *editor = new ObsoleteGroupPropertyEdit(parent);
         QVariant var = manager->value(property);
         GroupProperty_t ff = var.value<GroupProperty_t>();
         editor->setGroupProperty(ff);
@@ -140,8 +140,8 @@ QWidget *PropertyVariantFactory::createEditor(QtVariantPropertyManager *manager,
     }
 
     if (manager->propertyType(property) ==
-            PropertyVariantManager::comboPropertyTypeId()) {
-        ComboPropertyEdit *editor = new ComboPropertyEdit(parent);
+            ObsoletePropertyVariantManager::comboPropertyTypeId()) {
+        ObsoleteComboPropertyEdit *editor = new ObsoleteComboPropertyEdit(parent);
 
         QVariant var = manager->value(property);
         ComboProperty combo = var.value<ComboProperty>();
@@ -161,7 +161,7 @@ QWidget *PropertyVariantFactory::createEditor(QtVariantPropertyManager *manager,
 }
 
 
-void PropertyVariantFactory::disconnectPropertyManager(
+void ObsoletePropertyVariantFactory::disconnectPropertyManager(
         QtVariantPropertyManager *manager)
 {
     disconnect(manager, SIGNAL(valueChanged(QtProperty *, const QVariant &)),
@@ -174,49 +174,49 @@ void PropertyVariantFactory::disconnectPropertyManager(
 }
 
 
-void PropertyVariantFactory::slotPropertyChanged(QtProperty *property,
+void ObsoletePropertyVariantFactory::slotPropertyChanged(QtProperty *property,
                 const QVariant &value)
 {
     if (m_property_to_material_editors.contains(property)) {
-        QList<MaterialPropertyEdit *> editors =
+        QList<ObsoleteMaterialPropertyEdit *> editors =
                 m_property_to_material_editors[property];
-        QListIterator<MaterialPropertyEdit *> itEditor(editors);
+        QListIterator<ObsoleteMaterialPropertyEdit *> itEditor(editors);
         while (itEditor.hasNext()) {
             MaterialProperty mat = value.value<MaterialProperty>();
             itEditor.next()->setMaterialProperty(mat);
         }
     }
     else if (m_property_to_color_editors.contains(property)) {
-        QList<ColorPropertyEdit *> editors =
+        QList<ObsoleteColorPropertyEdit *> editors =
                 m_property_to_color_editors[property];
-        QListIterator<ColorPropertyEdit *> itEditor(editors);
+        QListIterator<ObsoleteColorPropertyEdit *> itEditor(editors);
         while (itEditor.hasNext()) {
             ColorProperty mat = value.value<ColorProperty>();
             itEditor.next()->setColorProperty(mat);
         }
     }
     else if (m_property_to_scdouble_editors.contains(property)) {
-        QList<ScientificDoublePropertyEdit *> editors =
+        QList<ObsoleteScientificDoublePropertyEdit *> editors =
                 m_property_to_scdouble_editors[property];
-        QListIterator<ScientificDoublePropertyEdit *> itEditor(editors);
+        QListIterator<ObsoleteScientificDoublePropertyEdit *> itEditor(editors);
         while (itEditor.hasNext()) {
             ScientificDoubleProperty mat = value.value<ScientificDoubleProperty>();
             itEditor.next()->setScientificDoubleProperty(mat);
         }
     }
     else if (m_property_to_fancygroup_editors.contains(property)) {
-        QList<GroupPropertyEdit *> editors =
+        QList<ObsoleteGroupPropertyEdit *> editors =
                 m_property_to_fancygroup_editors[property];
-        QListIterator<GroupPropertyEdit *> itEditor(editors);
+        QListIterator<ObsoleteGroupPropertyEdit *> itEditor(editors);
         while (itEditor.hasNext()) {
             GroupProperty_t mat = value.value<GroupProperty_t>();
             itEditor.next()->setGroupProperty(mat);
         }
     }
     else if (m_property_to_combo_editors.contains(property)) {
-        QList<ComboPropertyEdit *> editors =
+        QList<ObsoleteComboPropertyEdit *> editors =
                 m_property_to_combo_editors[property];
-        QListIterator<ComboPropertyEdit *> itEditor(editors);
+        QListIterator<ObsoleteComboPropertyEdit *> itEditor(editors);
         while (itEditor.hasNext()) {
             ComboProperty combo = value.value<ComboProperty>();
             itEditor.next()->setComboProperty(combo);
@@ -225,10 +225,10 @@ void PropertyVariantFactory::slotPropertyChanged(QtProperty *property,
 }
 
 
-void PropertyVariantFactory::slotSetValue(const MaterialProperty &value)
+void ObsoletePropertyVariantFactory::slotSetValue(const MaterialProperty &value)
 {
     QObject *object = sender();
-    QMap<MaterialPropertyEdit *, QtProperty *>::ConstIterator itEditor =
+    QMap<ObsoleteMaterialPropertyEdit *, QtProperty *>::ConstIterator itEditor =
                 m_material_editor_to_property.constBegin();
     while (itEditor != m_material_editor_to_property.constEnd()) {
         if (itEditor.key() == object) {
@@ -244,10 +244,10 @@ void PropertyVariantFactory::slotSetValue(const MaterialProperty &value)
     }
 }
 
-void PropertyVariantFactory::slotSetValue(const ColorProperty &value)
+void ObsoletePropertyVariantFactory::slotSetValue(const ColorProperty &value)
 {
     QObject *object = sender();
-    QMap<ColorPropertyEdit *, QtProperty *>::ConstIterator itEditor =
+    QMap<ObsoleteColorPropertyEdit *, QtProperty *>::ConstIterator itEditor =
                 m_color_editor_to_property.constBegin();
     while (itEditor != m_color_editor_to_property.constEnd()) {
         if (itEditor.key() == object) {
@@ -263,10 +263,10 @@ void PropertyVariantFactory::slotSetValue(const ColorProperty &value)
     }
 }
 
-void PropertyVariantFactory::slotSetValue(const ScientificDoubleProperty &value)
+void ObsoletePropertyVariantFactory::slotSetValue(const ScientificDoubleProperty &value)
 {
     QObject *object = sender();
-    QMap<ScientificDoublePropertyEdit *, QtProperty *>::ConstIterator itEditor =
+    QMap<ObsoleteScientificDoublePropertyEdit *, QtProperty *>::ConstIterator itEditor =
                 m_scdouble_editor_to_property.constBegin();
     while (itEditor != m_scdouble_editor_to_property.constEnd()) {
         if (itEditor.key() == object) {
@@ -282,10 +282,10 @@ void PropertyVariantFactory::slotSetValue(const ScientificDoubleProperty &value)
     }
 }
 
-void PropertyVariantFactory::slotSetValue(const GroupProperty_t &value)
+void ObsoletePropertyVariantFactory::slotSetValue(const GroupProperty_t &value)
 {
     QObject *object = sender();
-    QMap<GroupPropertyEdit *, QtProperty *>::ConstIterator itEditor =
+    QMap<ObsoleteGroupPropertyEdit *, QtProperty *>::ConstIterator itEditor =
                 m_fancygroup_editor_to_property.constBegin();
     while (itEditor != m_fancygroup_editor_to_property.constEnd()) {
         if (itEditor.key() == object) {
@@ -301,10 +301,10 @@ void PropertyVariantFactory::slotSetValue(const GroupProperty_t &value)
     }
 }
 
-void PropertyVariantFactory::slotSetValue(const ComboProperty &value)
+void ObsoletePropertyVariantFactory::slotSetValue(const ComboProperty &value)
 {
     QObject *object = sender();
-    QMap<ComboPropertyEdit *, QtProperty *>::ConstIterator itEditor =
+    QMap<ObsoleteComboPropertyEdit *, QtProperty *>::ConstIterator itEditor =
                 m_combo_editor_to_property.constBegin();
     while (itEditor != m_combo_editor_to_property.constEnd()) {
         if (itEditor.key() == object) {
@@ -322,13 +322,13 @@ void PropertyVariantFactory::slotSetValue(const ComboProperty &value)
     }
 }
 
-void PropertyVariantFactory::slotEditorDestroyed(QObject *object)
+void ObsoletePropertyVariantFactory::slotEditorDestroyed(QObject *object)
 {
-    QMap<MaterialPropertyEdit *, QtProperty *>::ConstIterator mat_it_editor =
+    QMap<ObsoleteMaterialPropertyEdit *, QtProperty *>::ConstIterator mat_it_editor =
                 m_material_editor_to_property.constBegin();
     while (mat_it_editor != m_material_editor_to_property.constEnd()) {
         if (mat_it_editor.key() == object) {
-            MaterialPropertyEdit *editor = mat_it_editor.key();
+            ObsoleteMaterialPropertyEdit *editor = mat_it_editor.key();
             QtProperty *property = mat_it_editor.value();
             m_material_editor_to_property.remove(editor);
             m_property_to_material_editors[property].removeAll(editor);
@@ -339,11 +339,11 @@ void PropertyVariantFactory::slotEditorDestroyed(QObject *object)
         mat_it_editor++;
     }
 
-    QMap<ColorPropertyEdit *, QtProperty *>::ConstIterator color_it_editor =
+    QMap<ObsoleteColorPropertyEdit *, QtProperty *>::ConstIterator color_it_editor =
                 m_color_editor_to_property.constBegin();
     while (color_it_editor != m_color_editor_to_property.constEnd()) {
         if (color_it_editor.key() == object) {
-            ColorPropertyEdit *editor = color_it_editor.key();
+            ObsoleteColorPropertyEdit *editor = color_it_editor.key();
             QtProperty *property = color_it_editor.value();
             m_color_editor_to_property.remove(editor);
             m_property_to_color_editors[property].removeAll(editor);
@@ -354,11 +354,11 @@ void PropertyVariantFactory::slotEditorDestroyed(QObject *object)
         color_it_editor++;
     }
 
-    QMap<ScientificDoublePropertyEdit *, QtProperty *>::ConstIterator scdouble_it_editor =
+    QMap<ObsoleteScientificDoublePropertyEdit *, QtProperty *>::ConstIterator scdouble_it_editor =
                 m_scdouble_editor_to_property.constBegin();
     while (scdouble_it_editor != m_scdouble_editor_to_property.constEnd()) {
         if (scdouble_it_editor.key() == object) {
-            ScientificDoublePropertyEdit *editor = scdouble_it_editor.key();
+            ObsoleteScientificDoublePropertyEdit *editor = scdouble_it_editor.key();
             QtProperty *property = scdouble_it_editor.value();
             m_scdouble_editor_to_property.remove(editor);
             m_property_to_scdouble_editors[property].removeAll(editor);
@@ -369,11 +369,11 @@ void PropertyVariantFactory::slotEditorDestroyed(QObject *object)
         scdouble_it_editor++;
     }
 
-    QMap<GroupPropertyEdit *, QtProperty *>::ConstIterator fancygroup_editor_it =
+    QMap<ObsoleteGroupPropertyEdit *, QtProperty *>::ConstIterator fancygroup_editor_it =
                 m_fancygroup_editor_to_property.constBegin();
     while (fancygroup_editor_it != m_fancygroup_editor_to_property.constEnd()) {
         if (fancygroup_editor_it.key() == object) {
-            GroupPropertyEdit *editor = fancygroup_editor_it.key();
+            ObsoleteGroupPropertyEdit *editor = fancygroup_editor_it.key();
             QtProperty *property = fancygroup_editor_it.value();
             m_fancygroup_editor_to_property.remove(editor);
             m_property_to_fancygroup_editors[property].removeAll(editor);
@@ -384,11 +384,11 @@ void PropertyVariantFactory::slotEditorDestroyed(QObject *object)
         fancygroup_editor_it++;
     }
 
-    QMap<ComboPropertyEdit *, QtProperty *>::ConstIterator combo_it_editor =
+    QMap<ObsoleteComboPropertyEdit *, QtProperty *>::ConstIterator combo_it_editor =
                 m_combo_editor_to_property.constBegin();
     while (combo_it_editor != m_combo_editor_to_property.constEnd()) {
         if (combo_it_editor.key() == object) {
-            ComboPropertyEdit *editor = combo_it_editor.key();
+            ObsoleteComboPropertyEdit *editor = combo_it_editor.key();
             QtProperty *property = combo_it_editor.value();
             m_combo_editor_to_property.remove(editor);
             m_property_to_combo_editors[property].removeAll(editor);
@@ -400,7 +400,7 @@ void PropertyVariantFactory::slotEditorDestroyed(QObject *object)
     }
 }
 
-void PropertyVariantFactory::slotPropertyAttributeChanged(QtProperty *, const QString &, const QVariant &)
+void ObsoletePropertyVariantFactory::slotPropertyAttributeChanged(QtProperty *, const QString &, const QVariant &)
 {
 
 }

--- a/GUI/coregui/Views/PropertyEditor/ObsoletePropertyVariantFactory.h
+++ b/GUI/coregui/Views/PropertyEditor/ObsoletePropertyVariantFactory.h
@@ -2,8 +2,8 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/PropertyEditor/PropertyVariantFactory.h
-//! @brief     Defines class PropertyVariantFactory
+//! @file      GUI/coregui/Views/PropertyEditor/ObsoletePropertyVariantFactory.h
+//! @brief     Defines class ObsoletePropertyVariantFactory
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -22,27 +22,27 @@
 #include "GroupProperty.h"
 #include <QtVariantEditorFactory>
 
-class MaterialPropertyEdit;
+class ObsoleteMaterialPropertyEdit;
 class MaterialProperty;
-class ColorPropertyEdit;
+class ObsoleteColorPropertyEdit;
 class ColorProperty;
-class ScientificDoublePropertyEdit;
+class ObsoleteScientificDoublePropertyEdit;
 class ScientificDoubleProperty;
-class GroupPropertyEdit;
-class ComboPropertyEdit;
+class ObsoleteGroupPropertyEdit;
+class ObsoleteComboPropertyEdit;
 class ComboProperty;
 
 //! The PropertyVariantFactory class provides and manages user defined
 //! QVariant based properties.
-class BA_CORE_API_ PropertyVariantFactory : public QtVariantEditorFactory
+class BA_CORE_API_ ObsoletePropertyVariantFactory : public QtVariantEditorFactory
 {
     Q_OBJECT
 public:
-    PropertyVariantFactory(QObject *parent = 0)
+    ObsoletePropertyVariantFactory(QObject *parent = 0)
         : QtVariantEditorFactory(parent)
             { }
 
-    virtual ~PropertyVariantFactory();
+    virtual ~ObsoletePropertyVariantFactory();
 protected:
     virtual void connectPropertyManager(QtVariantPropertyManager *manager);
     using QtVariantEditorFactory::createEditor;
@@ -60,29 +60,29 @@ private slots:
     void slotPropertyAttributeChanged(QtProperty *, const QString &, const QVariant &);
 
 private:
-    QMap<QtProperty *, QList<MaterialPropertyEdit *> >
+    QMap<QtProperty *, QList<ObsoleteMaterialPropertyEdit *> >
         m_property_to_material_editors;
-    QMap<MaterialPropertyEdit *, QtProperty *>
+    QMap<ObsoleteMaterialPropertyEdit *, QtProperty *>
         m_material_editor_to_property;
 
-    QMap<QtProperty *, QList<ColorPropertyEdit *> >
+    QMap<QtProperty *, QList<ObsoleteColorPropertyEdit *> >
         m_property_to_color_editors;
-    QMap<ColorPropertyEdit *, QtProperty *>
+    QMap<ObsoleteColorPropertyEdit *, QtProperty *>
         m_color_editor_to_property;
 
-    QMap<QtProperty *, QList<ScientificDoublePropertyEdit *> >
+    QMap<QtProperty *, QList<ObsoleteScientificDoublePropertyEdit *> >
         m_property_to_scdouble_editors;
-    QMap<ScientificDoublePropertyEdit *, QtProperty *>
+    QMap<ObsoleteScientificDoublePropertyEdit *, QtProperty *>
         m_scdouble_editor_to_property;
 
-    QMap<QtProperty *, QList<GroupPropertyEdit *> >
+    QMap<QtProperty *, QList<ObsoleteGroupPropertyEdit *> >
         m_property_to_fancygroup_editors;
-    QMap<GroupPropertyEdit *, QtProperty *>
+    QMap<ObsoleteGroupPropertyEdit *, QtProperty *>
         m_fancygroup_editor_to_property;
 
-    QMap<QtProperty *, QList<ComboPropertyEdit *> >
+    QMap<QtProperty *, QList<ObsoleteComboPropertyEdit *> >
         m_property_to_combo_editors;
-    QMap<ComboPropertyEdit *, QtProperty *>
+    QMap<ObsoleteComboPropertyEdit *, QtProperty *>
         m_combo_editor_to_property;
 
 };

--- a/GUI/coregui/Views/PropertyEditor/ObsoletePropertyVariantManager.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ObsoletePropertyVariantManager.cpp
@@ -2,8 +2,8 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/PropertyEditor/PropertyVariantManager.cpp
-//! @brief     Implements class PropertyVariantManager
+//! @file      GUI/coregui/Views/PropertyEditor/ObsoletePropertyVariantManager.cpp
+//! @brief     Implements class ObsoletePropertyVariantManager
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -14,48 +14,48 @@
 //
 // ************************************************************************** //
 
-#include "PropertyVariantManager.h"
+#include "ObsoletePropertyVariantManager.h"
 #include "DesignerHelper.h"
 #include "SessionItem.h"
 
-PropertyVariantManager::PropertyVariantManager(QObject *parent)
+ObsoletePropertyVariantManager::ObsoletePropertyVariantManager(QObject *parent)
     : QtVariantPropertyManager(parent)
 {
 
 }
 
 
-int PropertyVariantManager::materialTypeId()
+int ObsoletePropertyVariantManager::materialTypeId()
 {
     int result = qMetaTypeId<MaterialProperty>();
     return result;
 }
 
-int PropertyVariantManager::colorPropertyTypeId()
+int ObsoletePropertyVariantManager::colorPropertyTypeId()
 {
     int result = qMetaTypeId<ColorProperty>();
     return result;
 }
 
-int PropertyVariantManager::scientificDoubleTypeId()
+int ObsoletePropertyVariantManager::scientificDoubleTypeId()
 {
     int result = qMetaTypeId<ScientificDoubleProperty>();
     return result;
 }
 
-int PropertyVariantManager::fancyGroupTypeId()
+int ObsoletePropertyVariantManager::fancyGroupTypeId()
 {
     int result = qMetaTypeId<GroupProperty_t>();
     return result;
 }
 
-int PropertyVariantManager::comboPropertyTypeId()
+int ObsoletePropertyVariantManager::comboPropertyTypeId()
 {
     int result = qMetaTypeId<ComboProperty>();
     return result;
 }
 
-bool PropertyVariantManager::isPropertyTypeSupported(int propertyType) const
+bool ObsoletePropertyVariantManager::isPropertyTypeSupported(int propertyType) const
 {
     if (propertyType == materialTypeId())
         return true;
@@ -71,7 +71,7 @@ bool PropertyVariantManager::isPropertyTypeSupported(int propertyType) const
 }
 
 
-int PropertyVariantManager::valueType(int propertyType) const
+int ObsoletePropertyVariantManager::valueType(int propertyType) const
 {
     if (propertyType == materialTypeId())
         return materialTypeId();
@@ -87,7 +87,7 @@ int PropertyVariantManager::valueType(int propertyType) const
 }
 
 
-QVariant PropertyVariantManager::value(const QtProperty *property) const
+QVariant ObsoletePropertyVariantManager::value(const QtProperty *property) const
 {
     if (m_theMaterialValues.contains(property)) {
         QVariant v;
@@ -119,7 +119,7 @@ QVariant PropertyVariantManager::value(const QtProperty *property) const
 }
 
 
-QString PropertyVariantManager::valueText(const QtProperty *property) const
+QString ObsoletePropertyVariantManager::valueText(const QtProperty *property) const
 {
     if (m_theMaterialValues.contains(property)) {
         return m_theMaterialValues[property].getName();
@@ -140,7 +140,7 @@ QString PropertyVariantManager::valueText(const QtProperty *property) const
 }
 
 
-QIcon PropertyVariantManager::valueIcon(const QtProperty *property) const
+QIcon ObsoletePropertyVariantManager::valueIcon(const QtProperty *property) const
 {
     if (m_theMaterialValues.contains(property)) {
         return QIcon(m_theMaterialValues[property].getPixmap());
@@ -152,7 +152,7 @@ QIcon PropertyVariantManager::valueIcon(const QtProperty *property) const
 }
 
 
-void PropertyVariantManager::setValue(QtProperty *property, const QVariant &val)
+void ObsoletePropertyVariantManager::setValue(QtProperty *property, const QVariant &val)
 {
     if (m_theMaterialValues.contains(property)) {
         if( val.userType() != materialTypeId() ) return;
@@ -209,7 +209,7 @@ void PropertyVariantManager::setValue(QtProperty *property, const QVariant &val)
 }
 
 
-void PropertyVariantManager::initializeProperty(QtProperty *property)
+void ObsoletePropertyVariantManager::initializeProperty(QtProperty *property)
 {
     if (propertyType(property) == materialTypeId()) {
         MaterialProperty m;
@@ -236,7 +236,7 @@ void PropertyVariantManager::initializeProperty(QtProperty *property)
 }
 
 
-void PropertyVariantManager::uninitializeProperty(QtProperty *property)
+void ObsoletePropertyVariantManager::uninitializeProperty(QtProperty *property)
 {
     m_theMaterialValues.remove(property);
     m_theColorValues.remove(property);

--- a/GUI/coregui/Views/PropertyEditor/ObsoletePropertyVariantManager.h
+++ b/GUI/coregui/Views/PropertyEditor/ObsoletePropertyVariantManager.h
@@ -2,8 +2,8 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/PropertyEditor/PropertyVariantManager.h
-//! @brief     Defines class PropertyVariantManager
+//! @file      GUI/coregui/Views/PropertyEditor/ObsoletePropertyVariantManager.h
+//! @brief     Defines class ObsoletePropertyVariantManager
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -14,8 +14,8 @@
 //
 // ************************************************************************** //
 
-#ifndef PROPERTYVARIANTMANAGER_H
-#define PROPERTYVARIANTMANAGER_H
+#ifndef OBSOLETEPROPERTYVARIANTMANAGER_H
+#define OBSOLETEPROPERTYVARIANTMANAGER_H
 
 //! collection of classes extending QtPropertyBrowser functionality
 
@@ -30,11 +30,11 @@ class QObject;
 
 //! The ObjectVariantManager class provides and manages user defined
 //! QVariant based properties.
-class BA_CORE_API_ PropertyVariantManager : public QtVariantPropertyManager
+class BA_CORE_API_ ObsoletePropertyVariantManager : public QtVariantPropertyManager
 {
     Q_OBJECT
 public:
-    PropertyVariantManager(QObject *parent = 0);
+    ObsoletePropertyVariantManager(QObject *parent = 0);
 
     virtual QVariant value(const QtProperty *property) const;
     using QtVariantPropertyManager::valueType;
@@ -63,4 +63,4 @@ private:
     QMap<const QtProperty *, ComboProperty> m_theComboValues;
 };
 
-#endif // PROPERTYVARIANTMANAGER_H
+#endif // OBSOLETEPROPERTYVARIANTMANAGER_H

--- a/GUI/coregui/Views/PropertyEditor/PropertyEditorFactory.cpp
+++ b/GUI/coregui/Views/PropertyEditor/PropertyEditorFactory.cpp
@@ -193,6 +193,8 @@ QWidget* createCustomDoubleEditor(const SessionItem& item)
     auto result = new QDoubleSpinBox;
     result->setKeyboardTracking(false);
 
+    result->setMaximum(std::numeric_limits<double>::max());
+
     result->setDecimals(item.decimals());
     result->setSingleStep(singleStep(item));
 

--- a/GUI/coregui/Views/PropertyEditor/TestComponentView.cpp
+++ b/GUI/coregui/Views/PropertyEditor/TestComponentView.cpp
@@ -33,6 +33,7 @@
 #include "MaterialItem.h"
 #include "MaterialDataItem.h"
 #include "MaterialItemUtils.h"
+#include "ComponentEditor.h"
 #include <QTreeView>
 #include <QBoxLayout>
 #include <QItemSelectionModel>
@@ -44,8 +45,8 @@ TestComponentView::TestComponentView(MainWindow* mainWindow)
     : m_mainWindow(mainWindow)
     , m_sourceModel(new SampleModel(this))
     , m_sourceTree(new QTreeView)
-    , m_componentTree(new ComponentTreeView)
-    , m_componentFlat(new ComponentFlatView)
+    , m_componentTree(new ComponentEditor(ComponentEditor::FullTree))
+    , m_componentFlat(new ComponentEditor(ComponentEditor::PlainWidget))
     , m_updateButton(new QPushButton("Update models"))
     , m_addItemButton(new QPushButton("Add item"))
     , m_expandButton(new QPushButton("Expand tree"))
@@ -91,7 +92,7 @@ TestComponentView::TestComponentView(MainWindow* mainWindow)
 
 void TestComponentView::onUpdateRequest()
 {
-    m_componentTree->setModel(m_sourceModel);
+//    m_componentTree->setModel(m_sourceModel);
 }
 
 void TestComponentView::onAddItemRequest()
@@ -105,12 +106,12 @@ void TestComponentView::onExpandRequest()
         m_sourceTree->expandAll();
         m_sourceTree->resizeColumnToContents(0);
         m_sourceTree->resizeColumnToContents(1);
-        m_componentTree->treeView()->expandAll();
-        m_componentTree->treeView()->resizeColumnToContents(0);
-        m_componentTree->treeView()->resizeColumnToContents(1);
+//        m_componentTree->treeView()->expandAll();
+//        m_componentTree->treeView()->resizeColumnToContents(0);
+//        m_componentTree->treeView()->resizeColumnToContents(1);
     } else {
         m_sourceTree->collapseAll();
-        m_componentTree->treeView()->collapseAll();
+//        m_componentTree->treeView()->collapseAll();
     }
 
 //    const auto imax = std::numeric_limits<int>::max();
@@ -159,16 +160,17 @@ void TestComponentView::onSelectionChanged(const QItemSelection& selected, const
     QModelIndexList indices = selected.indexes();
 
     if (indices.size()) {
-        QModelIndex selectedIndex = indices.front();
-        m_componentTree->setRootIndex(selectedIndex);
-        m_componentTree->treeView()->expandAll();
+//        QModelIndex selectedIndex = indices.front();
+//        m_componentTree->setRootIndex(selectedIndex);
+//        m_componentTree->treeView()->expandAll();
 
         auto item = m_sourceModel->itemForIndex(indices.front());
+        m_componentTree->setItem(item);
         m_obsoleteEditor->setItem(item, item->modelType());
         m_obsoleteBoxEditor->clearEditor();
         m_obsoleteBoxEditor->addPropertyItems(item);
 
-        m_componentFlat->addItemProperties(item);
+        m_componentFlat->setItem(item);
     }
 
 }

--- a/GUI/coregui/Views/PropertyEditor/TestComponentView.cpp
+++ b/GUI/coregui/Views/PropertyEditor/TestComponentView.cpp
@@ -26,9 +26,9 @@
 #include "MultiLayer.h"
 #include "SampleModel.h"
 #include "ComponentTreeView.h"
-#include "ComponentEditor.h"
+#include "ObsoleteComponentEditor.h"
 #include "minisplitter.h"
-#include "ComponentBoxEditor.h"
+#include "ObsoleteComponentBoxEditor.h"
 #include "ComponentFlatView.h"
 #include "MaterialItem.h"
 #include "MaterialDataItem.h"
@@ -49,8 +49,8 @@ TestComponentView::TestComponentView(MainWindow* mainWindow)
     , m_updateButton(new QPushButton("Update models"))
     , m_addItemButton(new QPushButton("Add item"))
     , m_expandButton(new QPushButton("Expand tree"))
-    , m_obsoleteEditor(new ComponentEditor)
-    , m_obsoleteBoxEditor(new ComponentBoxEditor)
+    , m_obsoleteEditor(new ObsoleteComponentEditor)
+    , m_obsoleteBoxEditor(new ObsoleteComponentBoxEditor)
     , m_splitter(new Manhattan::MiniSplitter)
     , m_delegate(new SessionModelDelegate(this))
     , m_isExpaned(false)

--- a/GUI/coregui/Views/PropertyEditor/TestComponentView.h
+++ b/GUI/coregui/Views/PropertyEditor/TestComponentView.h
@@ -26,6 +26,7 @@ class QTreeView;
 class SampleModel;
 class SessionModelDelegate;
 class QItemSelection;
+class ComponentEditor;
 class ComponentTreeView;
 namespace Manhattan { class MiniSplitter; }
 class QBoxLayout;
@@ -55,8 +56,8 @@ private:
     MainWindow* m_mainWindow;
     SampleModel* m_sourceModel;
     QTreeView* m_sourceTree;
-    ComponentTreeView* m_componentTree;
-    ComponentFlatView* m_componentFlat;
+    ComponentEditor* m_componentTree;
+    ComponentEditor* m_componentFlat;
     QPushButton* m_updateButton;
     QPushButton* m_addItemButton;
     QPushButton* m_expandButton;

--- a/GUI/coregui/Views/PropertyEditor/TestComponentView.h
+++ b/GUI/coregui/Views/PropertyEditor/TestComponentView.h
@@ -29,8 +29,8 @@ class QItemSelection;
 class ComponentTreeView;
 namespace Manhattan { class MiniSplitter; }
 class QBoxLayout;
-class ComponentEditor;
-class ComponentBoxEditor;
+class ObsoleteComponentEditor;
+class ObsoleteComponentBoxEditor;
 class ComponentFlatView;
 
 //! View to tests QListView working with ComponentProxyModel.
@@ -60,8 +60,8 @@ private:
     QPushButton* m_updateButton;
     QPushButton* m_addItemButton;
     QPushButton* m_expandButton;
-    ComponentEditor *m_obsoleteEditor;
-    ComponentBoxEditor* m_obsoleteBoxEditor;
+    ObsoleteComponentEditor *m_obsoleteEditor;
+    ObsoleteComponentBoxEditor* m_obsoleteBoxEditor;
     Manhattan::MiniSplitter* m_splitter;
     SessionModelDelegate* m_delegate;
     bool m_isExpaned;

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpacePanel.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpacePanel.cpp
@@ -16,7 +16,7 @@
 
 #include "RealSpacePanel.h"
 #include "mainwindow_constants.h"
-#include "ComponentTreeView.h"
+#include "ComponentEditor.h"
 #include "FilterPropertyProxy.h"
 #include "SampleModel.h"
 #include <QTreeView>
@@ -27,7 +27,7 @@
 RealSpacePanel::RealSpacePanel(QWidget* parent)
     : QWidget(parent)
     , m_treeView(new QTreeView)
-    , m_componentEditor(new ComponentTreeView)
+    , m_componentEditor(new ComponentEditor)
     , m_model(nullptr)
     , m_proxy(nullptr)
 {

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpacePanel.h
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpacePanel.h
@@ -21,7 +21,7 @@
 #include <QWidget>
 
 class QTreeView;
-class ComponentTreeView;
+class ComponentEditor;
 class SampleModel;
 class FilterPropertyProxy;
 class QItemSelection;
@@ -48,7 +48,7 @@ public slots:
 
 private:
     QTreeView* m_treeView;
-    ComponentTreeView* m_componentEditor;
+    ComponentEditor* m_componentEditor;
     SampleModel* m_model;
     FilterPropertyProxy* m_proxy;
 };

--- a/GUI/coregui/Views/SampleDesigner/SamplePropertyWidget.cpp
+++ b/GUI/coregui/Views/SampleDesigner/SamplePropertyWidget.cpp
@@ -15,7 +15,7 @@
 // ************************************************************************** //
 
 #include "SamplePropertyWidget.h"
-#include "ComponentTreeView.h"
+#include "ComponentEditor.h"
 #include "SessionItem.h"
 #include <QItemSelection>
 #include <QModelIndexList>
@@ -25,7 +25,7 @@
 SamplePropertyWidget::SamplePropertyWidget(QItemSelectionModel* selection_model, QWidget* parent)
     : QWidget(parent)
     , m_selection_model(nullptr)
-    , m_propertyEditor(new ComponentTreeView)
+    , m_propertyEditor(new ComponentEditor(ComponentEditor::FullTree))
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     setWindowTitle(QLatin1String("Property Editor"));
@@ -85,7 +85,7 @@ void SamplePropertyWidget::selectionChanged(const QItemSelection& selected,
 
         SessionItem* item = static_cast<SessionItem*>(index.internalPointer());
         if (item)
-            m_propertyEditor->setItem(item, true);
+            m_propertyEditor->setItem(item);
 
     } else {
         m_propertyEditor->setItem(nullptr);

--- a/GUI/coregui/Views/SampleDesigner/SamplePropertyWidget.cpp
+++ b/GUI/coregui/Views/SampleDesigner/SamplePropertyWidget.cpp
@@ -16,7 +16,6 @@
 
 #include "SamplePropertyWidget.h"
 #include "ComponentTreeView.h"
-#include "ComponentEditor.h"
 #include "SessionItem.h"
 #include <QItemSelection>
 #include <QModelIndexList>

--- a/GUI/coregui/Views/SampleDesigner/SamplePropertyWidget.h
+++ b/GUI/coregui/Views/SampleDesigner/SamplePropertyWidget.h
@@ -22,7 +22,7 @@
 
 class QItemSelectionModel;
 class QItemSelection;
-class ComponentTreeView;
+class ComponentEditor;
 
 //! Property editor to modify property of the object currently selected on the
 //! graphics scene. Located in the bottom right corner of SampleView.
@@ -43,7 +43,7 @@ public slots:
 
 private:
     QItemSelectionModel* m_selection_model;
-    ComponentTreeView* m_propertyEditor;
+    ComponentEditor* m_propertyEditor;
 };
 
 #endif // SAMPLEPROPERTYWIDGET_H

--- a/GUI/coregui/Views/SessionModelView.cpp
+++ b/GUI/coregui/Views/SessionModelView.cpp
@@ -29,7 +29,7 @@
 #include <QVBoxLayout>
 
 namespace {
-const bool show_test_view = true;
+const bool show_test_view = false;
 }
 
 SessionModelView::SessionModelView(MainWindow *mainWindow)

--- a/GUI/coregui/Views/SimulationWidgets/SimulationOptionsWidget.cpp
+++ b/GUI/coregui/Views/SimulationWidgets/SimulationOptionsWidget.cpp
@@ -41,5 +41,5 @@ SimulationOptionsWidget::SimulationOptionsWidget(QWidget *parent)
 void SimulationOptionsWidget::setItem(SimulationOptionsItem* item)
 {
     m_boxEditor->clearEditor();
-    m_boxEditor->addItemProperties(item);
+    m_boxEditor->setItem(item);
 }


### PR DESCRIPTION
* New version of ComponentEditor not depending on qtpropertybrowser framework
* Old editors removed from everywhere.
* The code of old editor and the code of qtpropertybrowser framework are still in-place and has to be removed at the end of sprint