### PR TITLE
ScientificDoubleProperty is removed

### DIFF
--- a/GUI/coregui/Models/ApplicationModels.cpp
+++ b/GUI/coregui/Models/ApplicationModels.cpp
@@ -34,6 +34,8 @@
 #include "IntensityDataItem.h"
 #include "ImportDataAssistant.h"
 #include "StandardSimulations.h"
+#include <QtCore/QXmlStreamWriter>
+
 
 ApplicationModels::ApplicationModels(QObject *parent)
     : QObject(parent)

--- a/GUI/coregui/Models/BeamItem.cpp
+++ b/GUI/coregui/Models/BeamItem.cpp
@@ -21,7 +21,6 @@
 #include "BeamWavelengthItem.h"
 #include "BornAgainNamespace.h"
 #include "ParameterTranslators.h"
-#include "ScientificDoubleProperty.h"
 #include "SessionItemUtils.h"
 #include "Units.h"
 
@@ -40,9 +39,10 @@ const QString BeamItem::P_POLARIZATION = QString("Polarization");
 
 BeamItem::BeamItem() : SessionItem(Constants::BeamType)
 {
-    ScientificDoubleProperty intensity(1e+08);
-    addProperty(P_INTENSITY, intensity.getVariant())->setLimits(RealLimits::limited(0.0, 1e+32))
-            .setToolTip("Beam intensity in neutrons (or gammas) per sec.");
+    addProperty(P_INTENSITY, 1e+08)->setLimits(RealLimits::limited(0.0, 1e+32))
+            .setToolTip("Beam intensity in neutrons (or gammas) per sec.")
+            .setEditorType(Constants::ScientificEditorType);
+
     addGroupProperty(P_WAVELENGTH, Constants::BeamWavelengthType);
     addGroupProperty(P_INCLINATION_ANGLE, Constants::BeamInclinationAngleType);
     addGroupProperty(P_AZIMUTHAL_ANGLE, Constants::BeamAzimuthalAngleType);
@@ -55,17 +55,12 @@ BeamItem::~BeamItem(){}
 
 double BeamItem::getIntensity() const
 {
-    ScientificDoubleProperty intensity
-        = getItemValue(P_INTENSITY).value<ScientificDoubleProperty>();
-    return intensity.getValue();
+    return getItemValue(P_INTENSITY).toDouble();
 }
 
 void BeamItem::setIntensity(double value)
 {
-    ScientificDoubleProperty intensity
-        = getItemValue(P_INTENSITY).value<ScientificDoubleProperty>();
-    intensity.setValue(value);
-    setItemValue(P_INTENSITY, intensity.getVariant());
+    setItemValue(P_INTENSITY, value);
 }
 
 double BeamItem::getWavelength() const

--- a/GUI/coregui/Models/ComponentProxyModel.cpp
+++ b/GUI/coregui/Models/ComponentProxyModel.cpp
@@ -141,7 +141,7 @@ int ComponentProxyModel::columnCount(const QModelIndex& parent) const
 {
     if (parent.isValid() && parent.column() != 0)
         return 0;
-    return SessionModel::MAX_COLUMNS;
+    return SessionFlags::MAX_COLUMNS;
 }
 
 bool ComponentProxyModel::hasChildren(const QModelIndex& parent) const

--- a/GUI/coregui/Models/FilterPropertyProxy.cpp
+++ b/GUI/coregui/Models/FilterPropertyProxy.cpp
@@ -37,7 +37,7 @@ bool FilterPropertyProxy::filterAcceptsRow(int sourceRow, const QModelIndex &sou
     QModelIndex index = sourceModel()->index(sourceRow, 1, sourceParent);
     if (!sourceParent.isValid())
         return true;
-    const QString modelType = index.data(SessionModel::ModelTypeRole).toString();
+    const QString modelType = index.data(SessionFlags::ModelTypeRole).toString();
     if (modelType == Constants::PropertyType || modelType == Constants::GroupItemType
         || modelType == Constants::VectorType)
         return false;

--- a/GUI/coregui/Models/MaterialDataItem.cpp
+++ b/GUI/coregui/Models/MaterialDataItem.cpp
@@ -22,8 +22,8 @@ const QString MaterialDataItem::P_IMAG = "imag";
 MaterialDataItem::MaterialDataItem()
     : SessionItem(Constants::MaterialDataType)
 {
-    addProperty(P_REAL, 0.0)->setEditorType(Constants::ScientificDoublePropertyType);
-    addProperty(P_IMAG, 0.0)->setEditorType(Constants::ScientificDoublePropertyType);
+    addProperty(P_REAL, 0.0)->setEditorType(Constants::ScientificEditorType);
+    addProperty(P_IMAG, 0.0)->setEditorType(Constants::ScientificEditorType);
 
     mapper()->setOnPropertyChange(
         [this](const QString &){

--- a/GUI/coregui/Models/MaterialDataItem.cpp
+++ b/GUI/coregui/Models/MaterialDataItem.cpp
@@ -16,21 +16,14 @@
 
 #include "MaterialDataItem.h"
 
-#include "ScientificDoubleProperty.h"
-
-
 const QString MaterialDataItem::P_REAL = "real";
 const QString MaterialDataItem::P_IMAG = "imag";
-
 
 MaterialDataItem::MaterialDataItem()
     : SessionItem(Constants::MaterialDataType)
 {
-    ScientificDoubleProperty real(0.0);
-    addProperty(P_REAL, real.getVariant());
-
-    ScientificDoubleProperty imag(0.0);
-    addProperty(P_IMAG, imag.getVariant());
+    addProperty(P_REAL, 0.0)->setEditorType(Constants::ScientificDoublePropertyType);
+    addProperty(P_IMAG, 0.0)->setEditorType(Constants::ScientificDoublePropertyType);
 
     mapper()->setOnPropertyChange(
         [this](const QString &){
@@ -49,24 +42,20 @@ QString MaterialDataItem::itemLabel() const
 
 double MaterialDataItem::getReal() const
 {
-    return getItemValue(P_REAL).value<ScientificDoubleProperty>().getValue();
+    return getItemValue(P_REAL).toDouble();
 }
 
 void MaterialDataItem::setReal(double real)
 {
-    ScientificDoubleProperty property = getItemValue(P_REAL).value<ScientificDoubleProperty>();
-    property.setValue(real);
-    setItemValue(P_REAL, property.getVariant());
+    setItemValue(P_REAL, real);
 }
 
 double MaterialDataItem::getImag() const
 {
-    return getItemValue(P_IMAG).value<ScientificDoubleProperty>().getValue();
+    return getItemValue(P_IMAG).toDouble();
 }
 
 void MaterialDataItem::setImag(double imag)
 {
-    ScientificDoubleProperty property = getItemValue(P_IMAG).value<ScientificDoubleProperty>();
-    property.setValue(imag);
-    setItemValue(P_IMAG, property.getVariant());
+    setItemValue(P_IMAG, imag);
 }

--- a/GUI/coregui/Models/ObsoleteScientificDoubleProperty.h
+++ b/GUI/coregui/Models/ObsoleteScientificDoubleProperty.h
@@ -2,8 +2,8 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Models/ScientificDoubleProperty.h
-//! @brief     Defines class ScientificDoubleProperty
+//! @file      GUI/coregui/Models/ObsoleteScientificDoubleProperty.h
+//! @brief     Defines class ObsoleteScientificDoubleProperty
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -14,8 +14,8 @@
 //
 // ************************************************************************** //
 
-#ifndef SCIENTIFICDOUBLEPROPERTY_H
-#define SCIENTIFICDOUBLEPROPERTY_H
+#ifndef OBSOLETESCIENTIFICDOUBLEPROPERTY_H
+#define OBSOLETESCIENTIFICDOUBLEPROPERTY_H
 
 #include "WinDllMacros.h"
 #include <QString>
@@ -26,10 +26,10 @@
 //! The reason is to have simple editor for doubles in scientific notation
 //! in PropertyEditor instead of inconvenient QDoubleSpinBox
 
-class BA_CORE_API_ ScientificDoubleProperty
+class BA_CORE_API_ ObsoleteScientificDoubleProperty
 {
 public:
-    explicit ScientificDoubleProperty(double value = 0) : m_value(value) { }
+    explicit ObsoleteScientificDoubleProperty(double value = 0) : m_value(value) { }
 
     double getValue() const { return m_value; }
 
@@ -48,7 +48,7 @@ private:
     double m_value;
 };
 
-Q_DECLARE_METATYPE(ScientificDoubleProperty)
+Q_DECLARE_METATYPE(ObsoleteScientificDoubleProperty)
 
-#endif // SCIENTIFICDOUBLEPROPERTY_H
+#endif // OBSOLETESCIENTIFICDOUBLEPROPERTY_H
 

--- a/GUI/coregui/Models/ParameterTreeItems.cpp
+++ b/GUI/coregui/Models/ParameterTreeItems.cpp
@@ -18,7 +18,6 @@
 #include "ModelPath.h"
 #include "SessionModel.h"
 #include "FitParameterHelper.h"
-#include "ScientificDoubleProperty.h"
 
 // ----------------------------------------------------------------------------
 

--- a/GUI/coregui/Models/ParameterTreeItems.cpp
+++ b/GUI/coregui/Models/ParameterTreeItems.cpp
@@ -53,16 +53,8 @@ void ParameterItem::propagateValueToLink(double newValue)
 {
     setValue(newValue);
 
-    if (SessionItem *item = linkedItem()) {
-        if(item->value().typeName() == Constants::ScientificDoublePropertyType) {
-            ScientificDoubleProperty intensity = item->value().value<ScientificDoubleProperty>();
-            intensity.setValue(newValue);
-            item->setValue(intensity.getVariant());
-
-        } else {
+    if (SessionItem *item = linkedItem())
             item->setValue(newValue);
-        }
-    }
 }
 
 //! Returns corresponding linked item in MultiLayerItem/IsntrumentItem

--- a/GUI/coregui/Models/ParameterTreeUtils.cpp
+++ b/GUI/coregui/Models/ParameterTreeUtils.cpp
@@ -22,7 +22,6 @@
 #include "MultiLayerItem.h"
 #include "ParameterTreeItems.h"
 #include "SampleModel.h"
-#include "ScientificDoubleProperty.h"
 #include "GUIHelpers.h"
 #include "FitParameterHelper.h"
 #include "SampleModel.h"
@@ -238,11 +237,6 @@ void handleItem(SessionItem* tree, const SessionItem* source)
         tree->setDisplayName(source->itemName());
 
         double sourceValue = source->value().toDouble();
-        if (source->value().typeName() == Constants::ScientificDoublePropertyType) {
-            ScientificDoubleProperty intensity = source->value().value<ScientificDoubleProperty>();
-            sourceValue = intensity.getValue();
-        }
-
         tree->setValue(QVariant(sourceValue));
         QString path = ModelPath::getPathFromIndex(source->index());
         int firstSlash = path.indexOf('/');
@@ -260,10 +254,6 @@ void handleItem(SessionItem* tree, const SessionItem* source)
         if (child->isVisible() && child->isEnabled()) {
             if (child->modelType() == Constants::PropertyType) {
                 if (child->value().type() == QVariant::Double) {
-                    SessionItem* branch
-                        = tree->model()->insertNewItem(Constants::ParameterType, tree->index());
-                    handleItem(branch, child);
-                } else if (child->value().typeName() == Constants::ScientificDoublePropertyType) {
                     SessionItem* branch
                         = tree->model()->insertNewItem(Constants::ParameterType, tree->index());
                     handleItem(branch, child);

--- a/GUI/coregui/Models/ParameterTuningModel.cpp
+++ b/GUI/coregui/Models/ParameterTuningModel.cpp
@@ -32,9 +32,9 @@ Qt::ItemFlags ParameterTuningModel::flags(const QModelIndex &proxyIndex) const
 
     QModelIndex sourceIndex = toSourceIndex(proxyIndex);
     if(sourceIndex.isValid()) {
-        if (sourceIndex.column() == SessionModel::ITEM_VALUE) result |= Qt::ItemIsEditable;
+        if (sourceIndex.column() == SessionFlags::ITEM_VALUE) result |= Qt::ItemIsEditable;
 
-        const QString modelType = sourceIndex.data(SessionModel::ModelTypeRole).toString();
+        const QString modelType = sourceIndex.data(SessionFlags::ModelTypeRole).toString();
         if(modelType == Constants::ParameterType) {
             if(ParameterItem *parameterItem = getParameterItem(proxyIndex)) {
                 if(parameterItem->isFittable())

--- a/GUI/coregui/Models/SessionFlags.h
+++ b/GUI/coregui/Models/SessionFlags.h
@@ -44,6 +44,7 @@ public:
         LimitsRole,
         DecimalRole,
         DefaultTagRole,
+        CustomEditorRole,
         EndSessionRoles
     };
     Q_DECLARE_FLAGS(ItemDataRole, ERoles)

--- a/GUI/coregui/Models/SessionFlags.h
+++ b/GUI/coregui/Models/SessionFlags.h
@@ -1,0 +1,65 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Models/SessionFlags.h
+//! @brief     Defines class SessionFlags
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
+//! @authors   Walter Van Herck, Joachim Wuttke
+//
+// ************************************************************************** //
+
+#ifndef SESSIONFLAGS_H
+#define SESSIONFLAGS_H
+
+#include "WinDllMacros.h"
+#include <qnamespace.h>
+
+//! Collection of flags for SessionModel and SessionItem.
+
+class BA_CORE_API_ SessionFlags
+{
+public:
+
+    // SessionModel columns
+    enum EColumn
+    {
+        ITEM_NAME,
+        ITEM_VALUE,
+        MAX_COLUMNS
+    };
+    Q_DECLARE_FLAGS(ModelColumn, EColumn)
+
+    // SessionItem data roles
+    enum ERoles
+    {
+        ModelTypeRole = Qt::UserRole + 1,
+        FlagRole,
+        DisplayNameRole,
+        LimitsRole,
+        DecimalRole,
+        DefaultTagRole,
+        EndSessionRoles
+    };
+    Q_DECLARE_FLAGS(ItemDataRole, ERoles)
+
+    // SessionItem appearance
+    enum EAppearance {
+        VISIBLE = 0x001,
+        ENABLED = 0x002,
+        EDITABLE = 0x004
+    };
+    Q_DECLARE_FLAGS(ItemAppearance, EAppearance)
+
+};
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(SessionFlags::ModelColumn)
+Q_DECLARE_OPERATORS_FOR_FLAGS(SessionFlags::ItemDataRole)
+Q_DECLARE_OPERATORS_FOR_FLAGS(SessionFlags::ItemAppearance)
+
+#endif  // SESSIONFLAGS_H

--- a/GUI/coregui/Models/SessionItem.cpp
+++ b/GUI/coregui/Models/SessionItem.cpp
@@ -614,6 +614,18 @@ SessionItem& SessionItem::setToolTip(const QString& tooltip)
     return *this;
 }
 
+QString SessionItem::editorType() const
+{
+    auto variant = data(SessionFlags::CustomEditorRole);
+    return variant.isValid() ? variant.toString() : Constants::DefaultEditorType;
+}
+
+SessionItem& SessionItem::setEditorType(const QString& editorType)
+{
+    setData(SessionFlags::CustomEditorRole, editorType);
+    return *this;
+}
+
 //! Returns label of item shown in property editor.
 QString SessionItem::itemLabel() const
 {

--- a/GUI/coregui/Models/SessionItem.cpp
+++ b/GUI/coregui/Models/SessionItem.cpp
@@ -43,7 +43,7 @@ SessionItem::SessionItem(const QString& modelType)
 {
     Q_ASSERT(!modelType.isEmpty());
 
-    setData(SessionModel::ModelTypeRole, modelType);
+    setData(SessionFlags::ModelTypeRole, modelType);
     setDisplayName(modelType);
     setDecimals(3);
     setLimits(RealLimits::nonnegative());
@@ -452,7 +452,7 @@ void SessionItem::emitDataChanged(int role)
 //! Get model type
 QString SessionItem::modelType() const
 {
-    return data(SessionModel::ModelTypeRole).toString();
+    return data(SessionFlags::ModelTypeRole).toString();
 }
 
 //! Get value
@@ -480,19 +480,19 @@ bool SessionItem::setValue(QVariant value)
 //! Get default tag
 QString SessionItem::defaultTag() const
 {
-    return data(SessionModel::DefaultTagRole).toString();
+    return data(SessionFlags::DefaultTagRole).toString();
 }
 
 //! Set default tag
 void SessionItem::setDefaultTag(const QString& tag)
 {
-    setData(SessionModel::DefaultTagRole, tag);
+    setData(SessionFlags::DefaultTagRole, tag);
 }
 
 //! Get display name of item, append index if ambigue.
 QString SessionItem::displayName() const
 {
-    QString result = data(SessionModel::DisplayNameRole).toString();
+    QString result = data(SessionFlags::DisplayNameRole).toString();
 
     if(modelType() == Constants::PropertyType || modelType() == Constants::GroupItemType ||
        modelType() == Constants::ParameterType || modelType() == Constants::ParameterLabelType)
@@ -517,7 +517,7 @@ QString SessionItem::displayName() const
 //! Set display name
 void SessionItem::setDisplayName(const QString& display_name)
 {
-    setData(SessionModel::DisplayNameRole, display_name);
+    setData(SessionFlags::DisplayNameRole, display_name);
 }
 
 //! Get item name, return display name if no name is set.
@@ -551,55 +551,55 @@ void SessionItem::setItemName(const QString& name)
 
 void SessionItem::setVisible(bool enabled)
 {
-    changeFlags(enabled, SessionModel::VISIBLE);
+    changeFlags(enabled, SessionFlags::VISIBLE);
 }
 
 void SessionItem::setEnabled(bool enabled)
 {
-    changeFlags(enabled, SessionModel::ENABLED);
+    changeFlags(enabled, SessionFlags::ENABLED);
 }
 
 void SessionItem::setEditable(bool enabled)
 {
-    changeFlags(enabled, SessionModel::EDITABLE);
+    changeFlags(enabled, SessionFlags::EDITABLE);
 }
 
 bool SessionItem::isVisible() const
 {
-    return flags() & SessionModel::VISIBLE;
+    return flags() & SessionFlags::VISIBLE;
 }
 
 bool SessionItem::isEnabled() const
 {
-    return flags() & SessionModel::ENABLED;
+    return flags() & SessionFlags::ENABLED;
 }
 
 bool SessionItem::isEditable() const
 {
-    return flags() & SessionModel::EDITABLE;
+    return flags() & SessionFlags::EDITABLE;
 }
 
 // more roles
 
 RealLimits SessionItem::limits() const
 {
-    return data(SessionModel::LimitsRole).value<RealLimits>();
+    return data(SessionFlags::LimitsRole).value<RealLimits>();
 }
 
 SessionItem& SessionItem::setLimits(const RealLimits& value)
 {
-    this->setData(SessionModel::LimitsRole, QVariant::fromValue<RealLimits>(value));
+    this->setData(SessionFlags::LimitsRole, QVariant::fromValue<RealLimits>(value));
     return *this;
 }
 
 int SessionItem::decimals() const
 {
-    return data(SessionModel::DecimalRole).toInt();
+    return data(SessionFlags::DecimalRole).toInt();
 }
 
 SessionItem& SessionItem::setDecimals(int n)
 {
-    setData(SessionModel::DecimalRole, n);
+    setData(SessionFlags::DecimalRole, n);
     return *this;
 }
 
@@ -691,9 +691,9 @@ int SessionItem::tagStartIndex(const QString& name) const
 //! internal
 int SessionItem::flags() const
 {
-    QVariant flags = data(SessionModel::FlagRole);
+    QVariant flags = data(SessionFlags::FlagRole);
     if (!flags.isValid())
-        return SessionModel::VISIBLE | SessionModel::EDITABLE | SessionModel::ENABLED;
+        return SessionFlags::VISIBLE | SessionFlags::EDITABLE | SessionFlags::ENABLED;
 
     return flags.toInt();
 }
@@ -707,7 +707,7 @@ void SessionItem::changeFlags(bool enabled, int flag)
     } else {
         flags &= ~flag;
     }
-    setData(SessionModel::FlagRole, flags);
+    setData(SessionFlags::FlagRole, flags);
 }
 
 //! internal

--- a/GUI/coregui/Models/SessionItem.h
+++ b/GUI/coregui/Models/SessionItem.h
@@ -131,6 +131,9 @@ public:
     QString toolTip() const;
     SessionItem& setToolTip(const QString& tooltip);
 
+    QString editorType() const;
+    SessionItem& setEditorType(const QString& editorType);
+
     // helper functions
     virtual QString itemLabel() const;
     ModelMapper* mapper();

--- a/GUI/coregui/Models/SessionModel.cpp
+++ b/GUI/coregui/Models/SessionModel.cpp
@@ -20,6 +20,7 @@
 #include "SessionItemUtils.h"
 #include <QFile>
 #include <QMimeData>
+#include <QtCore/QXmlStreamWriter>
 
 using SessionItemUtils::ParentRow;
 

--- a/GUI/coregui/Models/SessionModel.cpp
+++ b/GUI/coregui/Models/SessionModel.cpp
@@ -57,7 +57,7 @@ Qt::ItemFlags SessionModel::flags(const QModelIndex& index) const
         result_flags |= Qt::ItemIsSelectable | Qt::ItemIsEnabled
                         | Qt::ItemIsDragEnabled;
         SessionItem* item = itemForIndex(index);
-        if (index.column() == ITEM_VALUE && item->value().isValid() && item->isEditable() && item->isEnabled())
+        if (index.column() == SessionFlags::ITEM_VALUE && item->value().isValid() && item->isEditable() && item->isEnabled())
             result_flags |= Qt::ItemIsEditable;
         QVector<QString> acceptable_child_items = getAcceptableDefaultItemTypes(index);
         if (acceptable_child_items.contains(m_dragged_item_type)) {
@@ -76,18 +76,18 @@ QVariant SessionModel::data(const QModelIndex& index, int role) const
     }
     if (SessionItem* item = itemForIndex(index)) {
         if (role == Qt::DisplayRole || role == Qt::EditRole) {
-            if (index.column() == ITEM_VALUE)
+            if (index.column() == SessionFlags::ITEM_VALUE)
                 return item->data(Qt::DisplayRole);
-            if (index.column() == ITEM_NAME)
+            if (index.column() == SessionFlags::ITEM_NAME)
                 return item->itemName();
         } else if(role == Qt::ToolTipRole) {
             return SessionItemUtils::ToolTipRole(*item, index.column());
 
         } else if(role == Qt::TextColorRole) {
             return SessionItemUtils::TextColorRole(*item);
-        } else if(role == Qt::DecorationRole && index.column() == ITEM_VALUE) {
+        } else if(role == Qt::DecorationRole && index.column() == SessionFlags::ITEM_VALUE) {
             return SessionItemUtils::DecorationRole(*item);
-        } else if(role == Qt::CheckStateRole && index.column() == ITEM_VALUE) {
+        } else if(role == Qt::CheckStateRole && index.column() == SessionFlags::ITEM_VALUE) {
             return SessionItemUtils::CheckStateRole(*item);
         } else {
             return item->data(role);
@@ -100,9 +100,9 @@ QVariant SessionModel::headerData(int section, Qt::Orientation orientation, int 
 {
     if (orientation == Qt::Horizontal && role == Qt::DisplayRole) {
         switch (section) {
-        case ITEM_NAME:
+        case SessionFlags::ITEM_NAME:
             return "Name";
-        case ITEM_VALUE:
+        case SessionFlags::ITEM_VALUE:
             return "Value";
         }
     }
@@ -121,7 +121,7 @@ int SessionModel::columnCount(const QModelIndex& parent) const
 {
     if (parent.isValid() && parent.column() != 0)
         return 0;
-    return MAX_COLUMNS;
+    return SessionFlags::MAX_COLUMNS;
 }
 
 QModelIndex SessionModel::index(int row, int column, const QModelIndex& parent) const

--- a/GUI/coregui/Models/SessionModel.h
+++ b/GUI/coregui/Models/SessionModel.h
@@ -19,6 +19,7 @@
 
 #include "SessionItem.h"
 #include "SessionXML.h"
+#include "SessionFlags.h"
 #include <QStringList>
 #include <QtCore/QXmlStreamWriter>
 
@@ -32,18 +33,7 @@ public:
     virtual ~SessionModel();
     void createRootItem(); //NEW
 
-    enum EColumn {ITEM_NAME, ITEM_VALUE, MAX_COLUMNS}; // NEW column usage
-
-    enum ERoles {ModelTypeRole = Qt::UserRole + 1, FlagRole, DisplayNameRole, LimitsRole,
-                 DecimalRole, DefaultTagRole, EndSessionRoles}; // NEW roles
-
-    enum EAppearance {
-        VISIBLE = 0x001,
-        ENABLED = 0x002,
-        EDITABLE = 0x004
-    };
-
-//    // Begin overriden methods from QAbstractItemModel
+    // Begin overriden methods from QAbstractItemModel
     virtual Qt::ItemFlags flags(const QModelIndex &index) const;
     virtual QVariant data(const QModelIndex &index, int role) const;
     virtual QVariant headerData(int section, Qt::Orientation orientation, int role) const;

--- a/GUI/coregui/Models/SessionModel.h
+++ b/GUI/coregui/Models/SessionModel.h
@@ -21,7 +21,6 @@
 #include "SessionXML.h"
 #include "SessionFlags.h"
 #include <QStringList>
-#include <QtCore/QXmlStreamWriter>
 
 
 class BA_CORE_API_ SessionModel : public QAbstractItemModel

--- a/GUI/coregui/Models/SessionModelDelegate.cpp
+++ b/GUI/coregui/Models/SessionModelDelegate.cpp
@@ -28,11 +28,6 @@ bool isDoubleProperty(const QModelIndex& index)
     return index.data().type() == QVariant::Double;
 }
 
-bool isIntProperty(const QModelIndex& index)
-{
-    return index.data().type() == QVariant::Int;
-}
-
 //! Returns text representation of double value depending on user defined editor type.
 //! FIXME Remove this temporary function after getting rid from ScientificDoubleProperty
 QString doubleToString(const SessionItem& item)
@@ -103,27 +98,20 @@ QWidget* SessionModelDelegate::createEditor(QWidget* parent, const QStyleOptionV
 void SessionModelDelegate::setModelData(QWidget* editor, QAbstractItemModel* model,
                                         const QModelIndex& index) const
 {
-    if (PropertyEditorFactory::IsCustomVariant(index.data())) {
-        CustomEditor* customEditor = qobject_cast<CustomEditor*>(editor);
-        Q_ASSERT(customEditor);
+    if (auto customEditor = qobject_cast<CustomEditor*>(editor))
         model->setData(index, customEditor->editorData());
-
-    } else {
+    else
         QStyledItemDelegate::setModelData(editor, model, index);
-    }
 }
 
 //! Propagates the data change from the model to the editor (if it is still opened).
 
 void SessionModelDelegate::setEditorData(QWidget* editor, const QModelIndex& index) const
 {
-    if (PropertyEditorFactory::IsCustomVariant(index.data())) {
-        auto customEditor = dynamic_cast<CustomEditor*>(editor);
-        Q_ASSERT(customEditor);
+    if (auto customEditor = dynamic_cast<CustomEditor*>(editor))
         customEditor->setData(index.data());
-    } else {
+    else
         QStyledItemDelegate::setEditorData(editor, index);
-    }
 }
 
 //! Increases height of the row by 20% wrt the default.

--- a/GUI/coregui/Models/SessionModelDelegate.h
+++ b/GUI/coregui/Models/SessionModelDelegate.h
@@ -21,11 +21,6 @@
 #include "GroupProperty.h"
 #include <QStyledItemDelegate>
 
-class ComboProperty;
-class MaterialProperty;
-class ColorProperty;
-class ScientificDoubleProperty;
-
 //! The SessionModelDelegate class presents the content of SessionModel items in
 //! standard QTreeView. Extents base QItemDelegate with possibility to show/edit
 //! our custom QVariant's.

--- a/GUI/coregui/Models/SessionXML.cpp
+++ b/GUI/coregui/Models/SessionXML.cpp
@@ -20,7 +20,6 @@
 #include "GroupItem.h"
 #include "ItemFactory.h"
 #include "MaterialProperty.h"
-#include "ScientificDoubleProperty.h"
 #include "SessionModel.h"
 #include "WarningMessageService.h"
 #include <QtCore/QXmlStreamWriter>
@@ -115,12 +114,6 @@ void SessionWriter::writeVariant(QXmlStreamWriter *writer, QVariant variant, int
                                    QString::number(currentIndex));
             writer->writeAttribute(SessionXML::ParameterExtAttribute,
                                    variant.value<ComboProperty>().stringOfValues());
-
-        }
-
-        else if (type_name == Constants::ScientificDoublePropertyType) {
-            writer->writeAttribute(SessionXML::ParameterValueAttribute,
-                                   variant.value<ScientificDoubleProperty>().getText());
 
         }
 
@@ -302,16 +295,6 @@ QString SessionReader::readProperty(QXmlStreamReader *reader,
         combo_property.setCurrentIndex(parameter_value);
 
         variant = combo_property.getVariant();
-    }
-
-    else if (parameter_type == Constants::ScientificDoublePropertyType) {
-        double parameter_value
-            = reader->attributes().value(SessionXML::ParameterValueAttribute).toDouble();
-
-        ScientificDoubleProperty scdouble_property(parameter_value);
-        QVariant v;
-        v.setValue(scdouble_property);
-        variant = v;
     }
 
     else if (parameter_type == Constants::GroupPropertyType) {

--- a/GUI/coregui/Models/SessionXML.cpp
+++ b/GUI/coregui/Models/SessionXML.cpp
@@ -56,7 +56,7 @@ void SessionWriter::writeItemAndChildItems(QXmlStreamWriter *writer, const Sessi
         if (tag == item->parent()->defaultTag())
             tag = "";
         writer->writeAttribute(SessionXML::TagAttribute, tag);
-        writer->writeAttribute(SessionXML::DisplayNameAttribute, item->data(SessionModel::DisplayNameRole).toString());
+        writer->writeAttribute(SessionXML::DisplayNameAttribute, item->data(SessionFlags::DisplayNameRole).toString());
         QVector<int> roles = item->getRoles();
         foreach(int role, roles) {
             if (role == Qt::DisplayRole || role == Qt::EditRole)

--- a/GUI/coregui/Models/SessionXML.cpp
+++ b/GUI/coregui/Models/SessionXML.cpp
@@ -23,6 +23,7 @@
 #include "ScientificDoubleProperty.h"
 #include "SessionModel.h"
 #include "WarningMessageService.h"
+#include <QtCore/QXmlStreamWriter>
 
 namespace
 {

--- a/GUI/coregui/Models/item_constants.h
+++ b/GUI/coregui/Models/item_constants.h
@@ -269,6 +269,9 @@ const ModelType ComboPropertyType = "ComboProperty";
 const ModelType ColorPropertyType = "ColorProperty";
 const ModelType GroupPropertyType = "GroupProperty_t";
 
+// --- Custom editors for variant propertues ---
+const ModelType DefaultEditorType = "Default";
+const ModelType ScientificEditorType = "SceintificDouble";
 }
 
 #endif // ITEM_CONSTANTS_H

--- a/GUI/coregui/Models/item_constants.h
+++ b/GUI/coregui/Models/item_constants.h
@@ -263,7 +263,6 @@ const QString MaskEditorPresentation = "Mask Editor";
 
 // --- Custom variants ----------------------------------------------------------
 
-const ModelType ScientificDoublePropertyType = "ScientificDoubleProperty";
 const ModelType MaterialPropertyType = "MaterialProperty";
 const ModelType ComboPropertyType = "ComboProperty";
 const ModelType ColorPropertyType = "ColorProperty";

--- a/GUI/coregui/Views/PropertyEditor/ComponentFlatView.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ComponentFlatView.cpp
@@ -112,7 +112,7 @@ void ComponentFlatView::onDataChanged(const QModelIndex& topLeft, const QModelIn
     if (item->modelType() == Constants::GroupItemType)
         updateItemProperties();
 
-    if (roles.contains(SessionModel::FlagRole))
+    if (roles.contains(SessionFlags::FlagRole))
         updateItemRoles(item);
 }
 

--- a/GUI/coregui/Views/PropertyEditor/ComponentTreeActions.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ComponentTreeActions.cpp
@@ -1,0 +1,73 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Views/PropertyEditor/ComponentTreeActions.cpp
+//! @brief     Implements class ComponentTreeActions
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
+//! @authors   Walter Van Herck, Joachim Wuttke
+//
+// ************************************************************************** //
+
+#include "ComponentTreeActions.h"
+#include "SessionItem.h"
+#include "item_constants.h"
+#include <QMenu>
+#include <QAction>
+#include <QSignalMapper>
+
+ComponentTreeActions::ComponentTreeActions(QObject* parent)
+    : QObject(parent)
+{
+}
+
+//! Creates right-mouse-click context menu on top of ComponentTreeView
+//! which will allow user to switch between scientific notation and the notation
+//! with specifid number of decimals.
+
+void ComponentTreeActions::onCustomContextMenuRequested(const QPoint& point, SessionItem& item)
+{
+    bool sc_editor = item.editorType() == Constants::ScientificEditorType;
+
+    std::unique_ptr<QSignalMapper> mapper(new QSignalMapper);
+
+    QMenu menu;
+    QAction* scientificAction = menu.addAction("Scientific presentation");
+    scientificAction->setCheckable(true);
+    auto doubleMenu = menu.addMenu("Double presentation");
+
+    // To select scientific notation
+    scientificAction->setChecked(sc_editor);
+    connect(scientificAction, &QAction::triggered, [&]()
+    {
+        if (scientificAction->isChecked())
+            item.setEditorType(Constants::ScientificEditorType);
+        else
+            item.setEditorType(Constants::DefaultEditorType);
+    });
+
+    // to select number of decimals
+    const int nmaxdigits = 8;
+    for (int i=1; i<=nmaxdigits; ++i) {
+        auto action = doubleMenu->addAction(QString("%1 digits").arg(i));
+        if (!sc_editor && item.decimals() == i)
+            action->setChecked(true);
+        connect(action, SIGNAL(triggered()), mapper.get(), SLOT(map()));
+        mapper->setMapping(action, i);
+    }
+
+    connect(mapper.get(),  static_cast<void (QSignalMapper::*)(int)>(&QSignalMapper::mapped),
+            [&](int decimals)
+    {
+        item.setEditorType(Constants::DefaultEditorType);
+        item.setDecimals(decimals);
+    });
+
+    menu.exec(point);
+}
+

--- a/GUI/coregui/Views/PropertyEditor/ComponentTreeActions.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentTreeActions.h
@@ -1,0 +1,37 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Views/PropertyEditor/ComponentTreeActions.h
+//! @brief     Defines class ComponentTreeActions
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2016
+//! @authors   Scientific Computing Group at MLZ Garching
+//! @authors   Céline Durniak, Marina Ganeva, David Li, Gennady Pospelov
+//! @authors   Walter Van Herck, Joachim Wuttke
+//
+// ************************************************************************** //
+
+#ifndef COMPONENTREEACTIONS_H
+#define COMPONENTREEACTIONS_H
+
+#include "WinDllMacros.h"
+#include <QObject>
+
+class SessionItem;
+
+//! Additional action for ComponentTreeView.
+
+class BA_CORE_API_ ComponentTreeActions : public QObject
+{
+    Q_OBJECT
+public:
+    ComponentTreeActions(QObject* parent = nullptr);
+
+public slots:
+    void onCustomContextMenuRequested(const QPoint &point, SessionItem& item);
+};
+
+#endif  // COMPONENTREEACTIONS_H

--- a/GUI/coregui/Views/PropertyEditor/ComponentTreeView.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ComponentTreeView.cpp
@@ -19,6 +19,7 @@
 #include "StyleUtils.h"
 #include "SessionModelDelegate.h"
 #include "SessionModel.h"
+#include "CustomEventFilters.h"
 #include <QTreeView>
 #include <QBoxLayout>
 #include <QStandardItemModel>
@@ -29,6 +30,7 @@ ComponentTreeView::ComponentTreeView(QWidget* parent)
     , m_delegate(new SessionModelDelegate(this))
     , m_proxyModel(new ComponentProxyModel(this))
     , m_placeHolderModel(new QStandardItemModel)
+    , m_eventFilter(new RightMouseButtonEater)
     , m_show_root_item(false)
 {
     auto layout = new QVBoxLayout;
@@ -46,7 +48,16 @@ ComponentTreeView::ComponentTreeView(QWidget* parent)
     m_tree->setRootIsDecorated(false);
     m_tree->setModel(m_placeHolderModel);
     m_tree->setItemDelegate(m_delegate);
+
+    // provide one click editing, but still keeping custom context menu alive
     m_tree->setEditTriggers(QAbstractItemView::AllEditTriggers);
+    m_tree->viewport()->installEventFilter(m_eventFilter.get());
+
+    // custom context menu setup
+    m_tree->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(m_tree, &QTreeView::customContextMenuRequested,
+            this, &ComponentTreeView::onCustomContextMenuRequested);
+
 }
 
 void ComponentTreeView::setItem(SessionItem* item)
@@ -93,4 +104,12 @@ void ComponentTreeView::setShowRootItem(bool show)
 {
     m_show_root_item = show;
 }
+
+#include <QDebug>
+
+void ComponentTreeView::onCustomContextMenuRequested(const QPoint& pos)
+{
+    qDebug() << "ComponentTreeView::onContextMenuRequest";
+}
+
 

--- a/GUI/coregui/Views/PropertyEditor/ComponentTreeView.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ComponentTreeView.cpp
@@ -62,6 +62,8 @@ ComponentTreeView::ComponentTreeView(QWidget* parent)
 
 }
 
+ComponentTreeView::~ComponentTreeView() = default;
+
 void ComponentTreeView::setItem(SessionItem* item)
 {
     if (!item) {

--- a/GUI/coregui/Views/PropertyEditor/ComponentTreeView.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ComponentTreeView.cpp
@@ -20,6 +20,7 @@
 #include "SessionModelDelegate.h"
 #include "SessionModel.h"
 #include "CustomEventFilters.h"
+#include "ComponentTreeActions.h"
 #include <QTreeView>
 #include <QBoxLayout>
 #include <QStandardItemModel>
@@ -31,6 +32,7 @@ ComponentTreeView::ComponentTreeView(QWidget* parent)
     , m_proxyModel(new ComponentProxyModel(this))
     , m_placeHolderModel(new QStandardItemModel)
     , m_eventFilter(new RightMouseButtonEater)
+    , m_actions(new ComponentTreeActions(this))
     , m_show_root_item(false)
 {
     auto layout = new QVBoxLayout;
@@ -105,11 +107,16 @@ void ComponentTreeView::setShowRootItem(bool show)
     m_show_root_item = show;
 }
 
-#include <QDebug>
-
 void ComponentTreeView::onCustomContextMenuRequested(const QPoint& pos)
 {
-    qDebug() << "ComponentTreeView::onContextMenuRequest";
+    auto point = m_tree->mapToGlobal(pos);
+    auto index = m_proxyModel->mapToSource(m_tree->indexAt(pos));
+
+    SessionItem* item = static_cast<SessionItem*>(index.internalPointer());
+    if (item->value().type() != QVariant::Double)
+        return;
+
+    m_actions->onCustomContextMenuRequested(point, *item);
 }
 
 

--- a/GUI/coregui/Views/PropertyEditor/ComponentTreeView.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentTreeView.h
@@ -18,6 +18,7 @@
 #define COMPONENTTREEVIEW_H
 
 #include "ComponentView.h"
+#include <memory>
 
 class QTreeView;
 class SessionModel;
@@ -26,6 +27,7 @@ class ComponentProxyModel;
 class QModelIndex;
 class SessionItem;
 class QStandardItemModel;
+class RightMouseButtonEater;
 
 //! Component property tree for SessionItems.
 //! Shows only PropertyItems and current items of GroupProperties.
@@ -42,6 +44,9 @@ public:
     void setShowHeader(bool show);
     void setShowRootItem(bool show);
 
+private slots:
+    void onCustomContextMenuRequested(const QPoint &pos);
+
 private:
     void setModel(SessionModel* model);
     void setRootIndex(const QModelIndex& index, bool show_root_item = true);
@@ -50,6 +55,7 @@ private:
     SessionModelDelegate* m_delegate;
     ComponentProxyModel* m_proxyModel;
     QStandardItemModel* m_placeHolderModel;
+    std::unique_ptr<RightMouseButtonEater> m_eventFilter;
     bool m_show_root_item; //!< Tree will starts from item itself, if true.
 };
 

--- a/GUI/coregui/Views/PropertyEditor/ComponentTreeView.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentTreeView.h
@@ -38,6 +38,7 @@ class BA_CORE_API_ ComponentTreeView : public ComponentView
     Q_OBJECT
 public:
     ComponentTreeView(QWidget* parent = nullptr);
+    ~ComponentTreeView();
 
     void setItem(SessionItem* item);
     void clearEditor();

--- a/GUI/coregui/Views/PropertyEditor/ComponentTreeView.h
+++ b/GUI/coregui/Views/PropertyEditor/ComponentTreeView.h
@@ -28,6 +28,7 @@ class QModelIndex;
 class SessionItem;
 class QStandardItemModel;
 class RightMouseButtonEater;
+class ComponentTreeActions;
 
 //! Component property tree for SessionItems.
 //! Shows only PropertyItems and current items of GroupProperties.
@@ -56,6 +57,7 @@ private:
     ComponentProxyModel* m_proxyModel;
     QStandardItemModel* m_placeHolderModel;
     std::unique_ptr<RightMouseButtonEater> m_eventFilter;
+    ComponentTreeActions* m_actions;
     bool m_show_root_item; //!< Tree will starts from item itself, if true.
 };
 

--- a/GUI/coregui/Views/PropertyEditor/CustomEditors.cpp
+++ b/GUI/coregui/Views/PropertyEditor/CustomEditors.cpp
@@ -21,7 +21,6 @@
 #include "GroupProperty.h"
 #include "ComboProperty.h"
 #include "ColorProperty.h"
-#include "ScientificDoubleProperty.h"
 #include <QBoxLayout>
 #include <QLabel>
 #include <QToolButton>
@@ -315,35 +314,17 @@ ScientificDoublePropertyEditor::ScientificDoublePropertyEditor(QWidget* parent)
 
 void ScientificDoublePropertyEditor::onEditingFinished()
 {
-    if (m_data.canConvert<ScientificDoubleProperty>()) {
-        // TODO Remove this branch as soon ScientificDoubleProperty is gone
-        double new_value = m_lineEdit->text().toDouble();
-        ScientificDoubleProperty doubleProperty = m_data.value<ScientificDoubleProperty>();
+    double new_value = m_lineEdit->text().toDouble();
 
-        if(new_value != doubleProperty.getValue()) {
-            doubleProperty.setValue(new_value);
-            setDataIntern(doubleProperty.getVariant());
-        }
-    } else {
-        double new_value = m_lineEdit->text().toDouble();
-
-        if(new_value != m_data.toDouble()) {
-            setDataIntern(QVariant::fromValue(new_value));
-        }
-
-    }
+    if(new_value != m_data.toDouble())
+        setDataIntern(QVariant::fromValue(new_value));
 
 }
 
 void ScientificDoublePropertyEditor::initEditor()
 {
-    if (m_data.canConvert<ScientificDoubleProperty>()) {
-        // TODO Remove this branch as soon ScientificDoubleProperty is gone
-        ScientificDoubleProperty doubleProperty = m_data.value<ScientificDoubleProperty>();
-        m_lineEdit->setText(doubleProperty.getText());
-    } else {
-        m_lineEdit->setText(QString::number(m_data.toDouble(), 'g'));
-    }
+    Q_ASSERT(m_data.type() == QVariant::Double);
+    m_lineEdit->setText(QString::number(m_data.toDouble(), 'g'));
 }
 
 // --- BoolEditor ---

--- a/GUI/coregui/Views/PropertyEditor/CustomEditors.cpp
+++ b/GUI/coregui/Views/PropertyEditor/CustomEditors.cpp
@@ -315,20 +315,35 @@ ScientificDoublePropertyEditor::ScientificDoublePropertyEditor(QWidget* parent)
 
 void ScientificDoublePropertyEditor::onEditingFinished()
 {
-    double new_value = m_lineEdit->text().toDouble();
-    ScientificDoubleProperty doubleProperty = m_data.value<ScientificDoubleProperty>();
+    if (m_data.canConvert<ScientificDoubleProperty>()) {
+        // TODO Remove this branch as soon ScientificDoubleProperty is gone
+        double new_value = m_lineEdit->text().toDouble();
+        ScientificDoubleProperty doubleProperty = m_data.value<ScientificDoubleProperty>();
 
-    if(new_value != doubleProperty.getValue()) {
-        doubleProperty.setValue(new_value);
-        setDataIntern(doubleProperty.getVariant());
+        if(new_value != doubleProperty.getValue()) {
+            doubleProperty.setValue(new_value);
+            setDataIntern(doubleProperty.getVariant());
+        }
+    } else {
+        double new_value = m_lineEdit->text().toDouble();
+
+        if(new_value != m_data.toDouble()) {
+            setDataIntern(QVariant::fromValue(new_value));
+        }
+
     }
+
 }
 
 void ScientificDoublePropertyEditor::initEditor()
 {
-    Q_ASSERT(m_data.canConvert<ScientificDoubleProperty>());
-    ScientificDoubleProperty doubleProperty = m_data.value<ScientificDoubleProperty>();
-    m_lineEdit->setText(doubleProperty.getText());
+    if (m_data.canConvert<ScientificDoubleProperty>()) {
+        // TODO Remove this branch as soon ScientificDoubleProperty is gone
+        ScientificDoubleProperty doubleProperty = m_data.value<ScientificDoubleProperty>();
+        m_lineEdit->setText(doubleProperty.getText());
+    } else {
+        m_lineEdit->setText(QString::number(m_data.toDouble(), 'g'));
+    }
 }
 
 // --- BoolEditor ---

--- a/GUI/coregui/Views/PropertyEditor/ObsoleteComponentBoxEditor.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ObsoleteComponentBoxEditor.cpp
@@ -78,7 +78,7 @@ void ObsoleteComponentBoxEditor::onDataChanged(const QModelIndex &topLeft, const
 
     if (QtVariantProperty *property = m_d->getPropertyForItem(item)) {
         // updating editor's property appearance (tooltips, limits)
-        if (roles.contains(SessionModel::FlagRole)) {
+        if (roles.contains(SessionFlags::FlagRole)) {
             m_d->updatePropertyAppearance(property, item);
         }
 

--- a/GUI/coregui/Views/PropertyEditor/ObsoleteComponentEditor.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ObsoleteComponentEditor.cpp
@@ -122,7 +122,7 @@ void ObsoleteComponentEditor::onDataChanged(const QModelIndex &topLeft,
 
     if (QtVariantProperty *property = m_d->getPropertyForItem(item)) {
         // updating editor's property appearance (tooltips, limits)
-        if (roles.contains(SessionModel::FlagRole)) {
+        if (roles.contains(SessionFlags::FlagRole)) {
             m_d->updatePropertyAppearance(property, item);
         }
 

--- a/GUI/coregui/Views/PropertyEditor/ObsoletePropertyBrowserUtils.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ObsoletePropertyBrowserUtils.cpp
@@ -272,7 +272,7 @@ ObsoleteScientificDoublePropertyEdit::ObsoleteScientificDoublePropertyEdit(QWidg
 }
 
 void ObsoleteScientificDoublePropertyEdit::setScientificDoubleProperty(
-        const ScientificDoubleProperty &doubleProperty)
+        const ObsoleteScientificDoubleProperty &doubleProperty)
 {
     m_lineEdit->setText(doubleProperty.getText());
     m_scientificDoubleProperty = doubleProperty;
@@ -282,7 +282,7 @@ void ObsoleteScientificDoublePropertyEdit::onEditingFinished()
 {
     double new_value = m_lineEdit->text().toDouble();
     if(new_value != m_scientificDoubleProperty.getValue()) {
-        ScientificDoubleProperty doubleProperty(new_value);
+        ObsoleteScientificDoubleProperty doubleProperty(new_value);
         setScientificDoubleProperty(doubleProperty);
         emit scientificDoublePropertyChanged(m_scientificDoubleProperty);
     }

--- a/GUI/coregui/Views/PropertyEditor/ObsoletePropertyBrowserUtils.h
+++ b/GUI/coregui/Views/PropertyEditor/ObsoletePropertyBrowserUtils.h
@@ -20,7 +20,7 @@
 #include <QWidget>
 #include "MaterialProperty.h"
 #include "ColorProperty.h"
-#include "ScientificDoubleProperty.h"
+#include "ObsoleteScientificDoubleProperty.h"
 #include "GroupProperty.h"
 #include "ComboProperty.h"
 
@@ -124,8 +124,8 @@ class BA_CORE_API_ ObsoleteScientificDoublePropertyEdit : public QWidget
 public:
     ObsoleteScientificDoublePropertyEdit(QWidget *parent = 0);
 
-    void setScientificDoubleProperty(const ScientificDoubleProperty &doubleProperty);
-    ScientificDoubleProperty getScientificDoubleProperty() const {
+    void setScientificDoubleProperty(const ObsoleteScientificDoubleProperty &doubleProperty);
+    ObsoleteScientificDoubleProperty getScientificDoubleProperty() const {
         return m_scientificDoubleProperty;
     }
 
@@ -133,13 +133,13 @@ public:
     QSize minimumSizeHint() const;
 
 signals:
-    void scientificDoublePropertyChanged(const ScientificDoubleProperty &doubleProperty);
+    void scientificDoublePropertyChanged(const ObsoleteScientificDoubleProperty &doubleProperty);
 private slots:
     void onEditingFinished();
 private:
     QLineEdit *m_lineEdit;
     QDoubleValidator *m_validator;
-    ScientificDoubleProperty m_scientificDoubleProperty;
+    ObsoleteScientificDoubleProperty m_scientificDoubleProperty;
 };
 
 #include <QComboBox>

--- a/GUI/coregui/Views/PropertyEditor/ObsoletePropertyVariantFactory.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ObsoletePropertyVariantFactory.cpp
@@ -106,15 +106,15 @@ QWidget *ObsoletePropertyVariantFactory::createEditor(QtVariantPropertyManager *
             ObsoletePropertyVariantManager::scientificDoubleTypeId()) {
         ObsoleteScientificDoublePropertyEdit *editor = new ObsoleteScientificDoublePropertyEdit(parent);
         QVariant var = manager->value(property);
-        ScientificDoubleProperty sc = var.value<ScientificDoubleProperty>();
+        ObsoleteScientificDoubleProperty sc = var.value<ObsoleteScientificDoubleProperty>();
         editor->setScientificDoubleProperty(sc);
 
         m_property_to_scdouble_editors[property].append(editor);
         m_scdouble_editor_to_property[editor] = property;
 
         connect(editor,
-                SIGNAL(scientificDoublePropertyChanged(const ScientificDoubleProperty &)),
-                this, SLOT(slotSetValue(const ScientificDoubleProperty &)));
+                SIGNAL(scientificDoublePropertyChanged(const ObsoleteScientificDoubleProperty &)),
+                this, SLOT(slotSetValue(const ObsoleteScientificDoubleProperty &)));
         connect(editor, SIGNAL(destroyed(QObject *)),
                 this, SLOT(slotEditorDestroyed(QObject *)));
         return editor;
@@ -200,7 +200,7 @@ void ObsoletePropertyVariantFactory::slotPropertyChanged(QtProperty *property,
                 m_property_to_scdouble_editors[property];
         QListIterator<ObsoleteScientificDoublePropertyEdit *> itEditor(editors);
         while (itEditor.hasNext()) {
-            ScientificDoubleProperty mat = value.value<ScientificDoubleProperty>();
+            ObsoleteScientificDoubleProperty mat = value.value<ObsoleteScientificDoubleProperty>();
             itEditor.next()->setScientificDoubleProperty(mat);
         }
     }
@@ -263,7 +263,7 @@ void ObsoletePropertyVariantFactory::slotSetValue(const ColorProperty &value)
     }
 }
 
-void ObsoletePropertyVariantFactory::slotSetValue(const ScientificDoubleProperty &value)
+void ObsoletePropertyVariantFactory::slotSetValue(const ObsoleteScientificDoubleProperty &value)
 {
     QObject *object = sender();
     QMap<ObsoleteScientificDoublePropertyEdit *, QtProperty *>::ConstIterator itEditor =

--- a/GUI/coregui/Views/PropertyEditor/ObsoletePropertyVariantFactory.h
+++ b/GUI/coregui/Views/PropertyEditor/ObsoletePropertyVariantFactory.h
@@ -27,7 +27,7 @@ class MaterialProperty;
 class ObsoleteColorPropertyEdit;
 class ColorProperty;
 class ObsoleteScientificDoublePropertyEdit;
-class ScientificDoubleProperty;
+class ObsoleteScientificDoubleProperty;
 class ObsoleteGroupPropertyEdit;
 class ObsoleteComboPropertyEdit;
 class ComboProperty;
@@ -53,7 +53,7 @@ private slots:
     void slotPropertyChanged(QtProperty *property, const QVariant &value);
     void slotSetValue(const MaterialProperty &value);
     void slotSetValue(const ColorProperty &value);
-    void slotSetValue(const ScientificDoubleProperty &value);
+    void slotSetValue(const ObsoleteScientificDoubleProperty &value);
     void slotSetValue(const GroupProperty_t &value);
     void slotSetValue(const ComboProperty &value);
     void slotEditorDestroyed(QObject *object);

--- a/GUI/coregui/Views/PropertyEditor/ObsoletePropertyVariantManager.cpp
+++ b/GUI/coregui/Views/PropertyEditor/ObsoletePropertyVariantManager.cpp
@@ -39,7 +39,7 @@ int ObsoletePropertyVariantManager::colorPropertyTypeId()
 
 int ObsoletePropertyVariantManager::scientificDoubleTypeId()
 {
-    int result = qMetaTypeId<ScientificDoubleProperty>();
+    int result = qMetaTypeId<ObsoleteScientificDoubleProperty>();
     return result;
 }
 
@@ -176,7 +176,7 @@ void ObsoletePropertyVariantManager::setValue(QtProperty *property, const QVaria
     }
     if (m_theScientificDoubleValues.contains(property)) {
         if( val.userType() != scientificDoubleTypeId() ) return;
-        ScientificDoubleProperty double_prop = val.value<ScientificDoubleProperty>();
+        ObsoleteScientificDoubleProperty double_prop = val.value<ObsoleteScientificDoubleProperty>();
         m_theScientificDoubleValues[property] = double_prop;
         QVariant v2;
         v2.setValue(double_prop);
@@ -220,7 +220,7 @@ void ObsoletePropertyVariantManager::initializeProperty(QtProperty *property)
         m_theColorValues[property] = m;
     }
     if (propertyType(property) == scientificDoubleTypeId()) {
-        ScientificDoubleProperty m;
+        ObsoleteScientificDoubleProperty m;
         m_theScientificDoubleValues[property] = m;
     }
     if (propertyType(property) == fancyGroupTypeId()) {

--- a/GUI/coregui/Views/PropertyEditor/ObsoletePropertyVariantManager.h
+++ b/GUI/coregui/Views/PropertyEditor/ObsoletePropertyVariantManager.h
@@ -23,7 +23,7 @@
 #include "ComboProperty.h"
 #include "GroupProperty.h"
 #include "MaterialProperty.h"
-#include "ScientificDoubleProperty.h"
+#include "ObsoleteScientificDoubleProperty.h"
 #include <QtVariantPropertyManager>
 
 class QObject;
@@ -58,7 +58,7 @@ protected:
 private:
     QMap<const QtProperty *, MaterialProperty> m_theMaterialValues;
     QMap<const QtProperty *, ColorProperty> m_theColorValues;
-    QMap<const QtProperty *, ScientificDoubleProperty> m_theScientificDoubleValues;
+    QMap<const QtProperty *, ObsoleteScientificDoubleProperty> m_theScientificDoubleValues;
     QMap<const QtProperty *, GroupProperty_t> m_theFancyGroupValues;
     QMap<const QtProperty *, ComboProperty> m_theComboValues;
 };

--- a/GUI/coregui/Views/PropertyEditor/PropertyEditorFactory.cpp
+++ b/GUI/coregui/Views/PropertyEditor/PropertyEditorFactory.cpp
@@ -22,7 +22,6 @@
 #include "CustomEditors.h"
 #include "ComboProperty.h"
 #include "ColorProperty.h"
-#include "ScientificDoubleProperty.h"
 #include <QDoubleSpinBox>
 #include <QSpinBox>
 #include <QLineEdit>
@@ -71,11 +70,6 @@ bool isComboProperty(const QVariant& variant)
     return variant.canConvert<ComboProperty>();
 }
 
-bool isScientificDoubleProperty(const QVariant& variant)
-{
-    return variant.canConvert<ScientificDoubleProperty>();
-}
-
 bool isStringProperty(const QVariant& variant)
 {
     return variant.type() == QVariant::String;
@@ -98,8 +92,6 @@ bool PropertyEditorFactory::IsCustomVariant(const QVariant& variant)
         return true;
     if (isComboProperty(variant))
         return true;
-    if (isScientificDoubleProperty(variant))
-        return true;
     if (isBoolProperty(variant))
         return true;
 
@@ -117,8 +109,6 @@ QString PropertyEditorFactory::ToString(const QVariant& variant)
         return variant.value<GroupProperty_t>()->currentLabel();
     if (isComboProperty(variant))
         return variant.value<ComboProperty>().getValue();
-    if (isScientificDoubleProperty(variant))
-        return variant.value<ScientificDoubleProperty>().getText();
     if (isBoolProperty(variant))
         return variant.toBool() ? "True" : "False";
 
@@ -174,12 +164,6 @@ QWidget* PropertyEditorFactory::CreateEditor(const SessionItem& item, QWidget* p
 
     else if(isComboProperty(item.value())) {
         auto editor = new ComboPropertyEditor;
-        editor->setData(item.value());
-        result = editor;
-    }
-
-    else if(isScientificDoubleProperty(item.value())) {
-        auto editor = new ScientificDoublePropertyEditor;
         editor->setData(item.value());
         result = editor;
     }

--- a/GUI/coregui/Views/PropertyEditor/PropertyEditorFactory.cpp
+++ b/GUI/coregui/Views/PropertyEditor/PropertyEditorFactory.cpp
@@ -131,7 +131,13 @@ QWidget* PropertyEditorFactory::CreateEditor(const SessionItem& item, QWidget* p
     QWidget* result(nullptr);
 
     if (isDoubleProperty(item.value())) {
-        result = createCustomDoubleEditor(item);
+        if (item.editorType() == Constants::ScientificEditorType) {
+            auto editor = new ScientificDoublePropertyEditor;
+            editor->setData(item.value());
+            result = editor;
+        } else {
+            result = createCustomDoubleEditor(item);
+        }
     }
 
     else if(isIntProperty(item.value())) {

--- a/GUI/coregui/Views/SampleDesigner/ItemTreeView.cpp
+++ b/GUI/coregui/Views/SampleDesigner/ItemTreeView.cpp
@@ -18,6 +18,7 @@
 #include "SessionModel.h"
 #include <QDragMoveEvent>
 #include <QMimeData>
+#include <QtCore/QXmlStreamWriter>
 
 ItemTreeView::ItemTreeView(QWidget *parent)
     : QTreeView(parent)

--- a/GUI/coregui/Views/SessionModelView.cpp
+++ b/GUI/coregui/Views/SessionModelView.cpp
@@ -29,7 +29,7 @@
 #include <QVBoxLayout>
 
 namespace {
-const bool show_test_view = false;
+const bool show_test_view = true;
 }
 
 SessionModelView::SessionModelView(MainWindow *mainWindow)

--- a/GUI/coregui/utils/CustomEventFilters.cpp
+++ b/GUI/coregui/utils/CustomEventFilters.cpp
@@ -136,13 +136,11 @@ RightMouseButtonEater::RightMouseButtonEater(QObject* parent)
 {
 }
 
-#include <QDebug>
 bool RightMouseButtonEater::eventFilter(QObject* obj, QEvent* event)
 {
     if (event->type() == QEvent::MouseButtonPress) {
         QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
         if (mouseEvent->button() == Qt::RightButton) {
-            qDebug() << "Ignoring right mouse";
             event->ignore();
             return true;
         } else {

--- a/GUI/coregui/utils/CustomEventFilters.cpp
+++ b/GUI/coregui/utils/CustomEventFilters.cpp
@@ -130,3 +130,27 @@ bool ShortcodeFilter::eventFilter(QObject* obj, QEvent* event)
     }
     return false;
 }
+
+RightMouseButtonEater::RightMouseButtonEater(QObject* parent)
+    : QObject(parent)
+{
+}
+
+#include <QDebug>
+bool RightMouseButtonEater::eventFilter(QObject* obj, QEvent* event)
+{
+    if (event->type() == QEvent::MouseButtonPress) {
+        QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
+        if (mouseEvent->button() == Qt::RightButton) {
+            qDebug() << "Ignoring right mouse";
+            event->ignore();
+            return true;
+        } else {
+            event->accept();
+            return false;
+        }
+    } else {
+        // standard event processing
+        return QObject::eventFilter(obj, event);
+    }
+}

--- a/GUI/coregui/utils/CustomEventFilters.h
+++ b/GUI/coregui/utils/CustomEventFilters.h
@@ -90,4 +90,17 @@ protected:
     int m_index;
 };
 
+//! Filter out right mouse button events.
+
+class BA_CORE_API_ RightMouseButtonEater : public QObject
+{
+    Q_OBJECT
+public:
+    RightMouseButtonEater(QObject* parent = 0);
+
+protected:
+    bool eventFilter(QObject* obj, QEvent* event);
+};
+
+
 #endif // CUSTOMEVENTFILTERS_H

--- a/Tests/UnitTests/GUI/TestComponentProxyModel.h
+++ b/Tests/UnitTests/GUI/TestComponentProxyModel.h
@@ -37,7 +37,7 @@ inline void TestComponentProxyModel::test_emptyModel()
 {
     ComponentProxyModel proxy;
     QCOMPARE(proxy.rowCount(QModelIndex()), 0);
-    QCOMPARE(proxy.columnCount(QModelIndex()), static_cast<int>(SessionModel::MAX_COLUMNS));
+    QCOMPARE(proxy.columnCount(QModelIndex()), static_cast<int>(SessionFlags::MAX_COLUMNS));
     QVERIFY(proxy.sourceModel() == nullptr);
 }
 
@@ -53,7 +53,7 @@ inline void TestComponentProxyModel::test_setModel()
 
     QCOMPARE(spy.count(), 1);
     QCOMPARE(proxy.rowCount(QModelIndex()), 0);
-    QCOMPARE(proxy.columnCount(QModelIndex()), static_cast<int>(SessionModel::MAX_COLUMNS));
+    QCOMPARE(proxy.columnCount(QModelIndex()), static_cast<int>(SessionFlags::MAX_COLUMNS));
     QCOMPARE(proxy.sourceModel(), &model);
 }
 
@@ -68,16 +68,16 @@ inline void TestComponentProxyModel::test_setModelWithItem()
     proxy.setSessionModel(&model);
 
     QCOMPARE(model.rowCount(QModelIndex()), 1);
-    QCOMPARE(model.columnCount(QModelIndex()), static_cast<int>(SessionModel::MAX_COLUMNS));
+    QCOMPARE(model.columnCount(QModelIndex()), static_cast<int>(SessionFlags::MAX_COLUMNS));
     QCOMPARE(proxy.rowCount(QModelIndex()), 1);
-    QCOMPARE(proxy.columnCount(QModelIndex()), static_cast<int>(SessionModel::MAX_COLUMNS));
+    QCOMPARE(proxy.columnCount(QModelIndex()), static_cast<int>(SessionFlags::MAX_COLUMNS));
 }
 
 //! Set model to proxy. Model already contains VectorItem.
 
 inline void TestComponentProxyModel::test_setModelWithVector()
 {
-    const int ncols = static_cast<int>(SessionModel::MAX_COLUMNS);
+    const int ncols = static_cast<int>(SessionFlags::MAX_COLUMNS);
 
     SessionModel model("TestModel");
     SessionItem* item = model.insertNewItem(Constants::VectorType);
@@ -329,7 +329,7 @@ inline void TestComponentProxyModel::test_componentStrategyFormFactorChanges()
 
 inline void TestComponentProxyModel::test_setRootPropertyItem()
 {
-    const int ncols = static_cast<int>(SessionModel::MAX_COLUMNS);
+    const int ncols = static_cast<int>(SessionFlags::MAX_COLUMNS);
     SessionModel model("TestModel");
 
     ComponentProxyModel proxy;

--- a/Tests/UnitTests/GUI/TestSessionItem.h
+++ b/Tests/UnitTests/GUI/TestSessionItem.h
@@ -140,9 +140,9 @@ inline void TestSessionItem::test_data_roles()
     QVERIFY(item->data(Qt::DisplayRole) == 5432);
     QVERIFY(item->data(Qt::EditRole) == 5432);
     for (int i = 0; i < 10; i++) {
-        QVERIFY(item->data(SessionModel::EndSessionRoles + i).isValid() == false);
-        item->setData(SessionModel::EndSessionRoles + i, i);
-        QVERIFY(item->data(SessionModel::EndSessionRoles + i) == i);
+        QVERIFY(item->data(SessionFlags::EndSessionRoles + i).isValid() == false);
+        item->setData(SessionFlags::EndSessionRoles + i, i);
+        QVERIFY(item->data(SessionFlags::EndSessionRoles + i) == i);
     }
 }
 


### PR DESCRIPTION
Dedicated QVariant property to handle value of 'double' in scientific way is removed.
* Now every double can be shown in scientific notation without breaking back compatibility
* To demonstrate this, right-mouse-button context menu is implemented for SampleView's property editor, where one can change scientific notation and number of decimals.

