### PR TITLE
Redmine issue 1917: std::vector<SimulationElement> replaced with templates

### DIFF
--- a/Core/Binning/SimulationElement.cpp
+++ b/Core/Binning/SimulationElement.cpp
@@ -147,14 +147,6 @@ double SimulationElement::getSolidAngle() const {
     return mP_pixel->getSolidAngle();
 }
 
-void addElementsWithWeight(std::vector<SimulationElement>::const_iterator first,
-                           std::vector<SimulationElement>::const_iterator last,
-                           std::vector<SimulationElement>::iterator result, double weight)
-{
-    for (std::vector<SimulationElement>::const_iterator it = first; it != last; ++it, ++result)
-        result->addIntensity(it->getIntensity() * weight);
-}
-
 SpecularData::SpecularData() : data_type_used(DATA_TYPE::Invalid) {}
 
 SpecularData::SpecularData(MatrixVector coefficients)

--- a/Core/Binning/SimulationElement.h
+++ b/Core/Binning/SimulationElement.h
@@ -106,13 +106,6 @@ private:
     std::unique_ptr<SpecularData> m_specular_data;
 };
 
-
-//! Add element vector to element vector with weight
-void addElementsWithWeight(std::vector<SimulationElement>::const_iterator first,
-                           std::vector<SimulationElement>::const_iterator last,
-                           std::vector<SimulationElement>::iterator result,
-                           double weight);
-
 //! Helper class for SimulationElement to carry specular information
 //! @ingroup simulation
 

--- a/Core/Computation/ConstantBackground.cpp
+++ b/Core/Computation/ConstantBackground.cpp
@@ -31,12 +31,9 @@ ConstantBackground* ConstantBackground::clone() const
     return new ConstantBackground(m_background_value);
 }
 
-void ConstantBackground::addBackGround(std::vector<SimulationElement>::iterator start,
-                                       std::vector<SimulationElement>::iterator end) const
+void ConstantBackground::addBackGroundToElement(SimulationElement& element) const
 {
-    for (auto it=start; it != end; it++) {
-        it->addIntensity(m_background_value);
-    }
+    element.addIntensity(m_background_value);
 }
 
 void ConstantBackground::init_parameters()

--- a/Core/Computation/ConstantBackground.h
+++ b/Core/Computation/ConstantBackground.h
@@ -32,9 +32,8 @@ public:
 
     void accept(INodeVisitor* visitor) const override { visitor->visit(this); }
 
-    void addBackGround(std::vector<SimulationElement>::iterator start,
-                       std::vector<SimulationElement>::iterator end) const override final;
 private:
+    virtual void addBackGroundToElement(SimulationElement& element) const override final;
     void init_parameters();
 
     double m_background_value;

--- a/Core/Computation/DWBAComputation.cpp
+++ b/Core/Computation/DWBAComputation.cpp
@@ -15,7 +15,6 @@
 #include "DWBAComputation.h"
 #include "ParticleLayoutComputation.h"
 #include "Layer.h"
-#include "IFresnelMap.h"
 #include "MatrixFresnelMap.h"
 #include "MultiLayer.h"
 #include "RoughMultiLayerComputation.h"
@@ -30,11 +29,7 @@ static_assert(std::is_copy_constructible<DWBAComputation>::value == false,
 static_assert(std::is_copy_assignable<DWBAComputation>::value == false,
     "DWBAComputation should not be copy assignable");
 
-DWBAComputation::DWBAComputation(const MultiLayer& multilayer, const SimulationOptions& options,
-                                 const std::shared_ptr<ProgressHandler>& progress,
-                                 const std::vector<SimulationElement>::iterator& begin_it,
-                                 const std::vector<SimulationElement>::iterator& end_it)
-    : IComputation(options, progress, begin_it, end_it, multilayer)
+void DWBAComputation::init()
 {
     mP_fresnel_map = createFresnelMap();
     bool polarized = mP_multi_layer->containsMagneticMaterial();
@@ -70,7 +65,7 @@ void DWBAComputation::runProtected()
     for (auto& comp: m_computation_terms) {
         if (!m_progress->alive())
             return;
-        comp->eval(m_begin_it, m_end_it );
+        m_iter_holder->eval(*comp);
     }
 }
 

--- a/Core/Computation/DWBAComputation.cpp
+++ b/Core/Computation/DWBAComputation.cpp
@@ -31,7 +31,7 @@ static_assert(std::is_copy_assignable<DWBAComputation>::value == false,
     "DWBAComputation should not be copy assignable");
 
 DWBAComputation::DWBAComputation(const MultiLayer& multilayer, const SimulationOptions& options,
-                                 ProgressHandler& progress,
+                                 const std::shared_ptr<ProgressHandler>& progress,
                                  const std::vector<SimulationElement>::iterator& begin_it,
                                  const std::vector<SimulationElement>::iterator& end_it)
     : IComputation(options, progress, begin_it, end_it, multilayer)
@@ -45,12 +45,12 @@ DWBAComputation::DWBAComputation(const MultiLayer& multilayer, const SimulationO
             m_computation_terms.emplace_back(
                         new ParticleLayoutComputation(
                             mP_multi_layer.get(), mP_fresnel_map.get(), p_layout, i,
-                            m_sim_options, polarized, *m_progress));
+                            m_sim_options, polarized, m_progress));
     }
     // scattering from rough surfaces in DWBA
     if (mP_multi_layer->hasRoughness())
         m_computation_terms.emplace_back(new RoughMultiLayerComputation(
-            mP_multi_layer.get(), mP_fresnel_map.get(), *m_progress));
+            mP_multi_layer.get(), mP_fresnel_map.get(), m_progress));
     if (m_sim_options.includeSpecular())
         m_computation_terms.emplace_back(new NormalizingSpecularComputationTerm(mP_multi_layer.get(),
                                                               mP_fresnel_map.get()));

--- a/Core/Computation/DWBAComputation.cpp
+++ b/Core/Computation/DWBAComputation.cpp
@@ -45,12 +45,12 @@ DWBAComputation::DWBAComputation(const MultiLayer& multilayer, const SimulationO
             m_computation_terms.emplace_back(
                         new ParticleLayoutComputation(
                             mP_multi_layer.get(), mP_fresnel_map.get(), p_layout, i,
-                            m_sim_options, polarized));
+                            m_sim_options, polarized, *m_progress));
     }
     // scattering from rough surfaces in DWBA
     if (mP_multi_layer->hasRoughness())
-        m_computation_terms.emplace_back(new RoughMultiLayerComputation(mP_multi_layer.get(),
-                                                                     mP_fresnel_map.get()));
+        m_computation_terms.emplace_back(new RoughMultiLayerComputation(
+            mP_multi_layer.get(), mP_fresnel_map.get(), *m_progress));
     if (m_sim_options.includeSpecular())
         m_computation_terms.emplace_back(new NormalizingSpecularComputationTerm(mP_multi_layer.get(),
                                                               mP_fresnel_map.get()));
@@ -70,7 +70,7 @@ void DWBAComputation::runProtected()
     for (auto& comp: m_computation_terms) {
         if (!m_progress->alive())
             return;
-        comp->eval(m_progress, m_begin_it, m_end_it );
+        comp->eval(m_begin_it, m_end_it );
     }
 }
 

--- a/Core/Computation/DWBAComputation.h
+++ b/Core/Computation/DWBAComputation.h
@@ -16,10 +16,10 @@
 #define MAINCOMPUTATION_H
 
 #include "IComputation.h"
+#include "IFresnelMap.h"
 #include "Complex.h"
 #include "SimulationOptions.h"
 
-class IFresnelMap;
 class MultiLayer;
 struct HomogeneousRegion;
 class IComputationTerm;
@@ -33,15 +33,21 @@ class IComputationTerm;
 class DWBAComputation : public IComputation
 {
 public:
-    DWBAComputation(
-        const MultiLayer& multilayer,
-        const SimulationOptions& options,
-        const std::shared_ptr<ProgressHandler>& progress,
-        const std::vector<SimulationElement>::iterator& begin_it,
-        const std::vector<SimulationElement>::iterator& end_it);
+    template <class Iter>
+    explicit DWBAComputation(const MultiLayer& multilayer,
+                             const SimulationOptions& options,
+                             const std::shared_ptr<ProgressHandler>& progress,
+                             Iter begin_it, Iter end_it)
+        : IComputation(options, progress, std::make_unique<IterHandler<Iter>>(begin_it, end_it),
+                       multilayer)
+    {
+        init();
+    }
+
     ~DWBAComputation();
 
 private:
+    void init();
     virtual void runProtected() override;
     std::unique_ptr<IFresnelMap> createFresnelMap();
     // creates a multilayer that contains averaged materials, for use in Fresnel calculations

--- a/Core/Computation/DWBAComputation.h
+++ b/Core/Computation/DWBAComputation.h
@@ -36,7 +36,7 @@ public:
     DWBAComputation(
         const MultiLayer& multilayer,
         const SimulationOptions& options,
-        ProgressHandler& progress,
+        const std::shared_ptr<ProgressHandler>& progress,
         const std::vector<SimulationElement>::iterator& begin_it,
         const std::vector<SimulationElement>::iterator& end_it);
     ~DWBAComputation();

--- a/Core/Computation/DWBAComputation.h
+++ b/Core/Computation/DWBAComputation.h
@@ -41,8 +41,6 @@ public:
         const std::vector<SimulationElement>::iterator& end_it);
     ~DWBAComputation();
 
-    void run();
-
 private:
     virtual void runProtected() override;
     std::unique_ptr<IFresnelMap> createFresnelMap();

--- a/Core/Computation/DelayedProgressCounter.cpp
+++ b/Core/Computation/DelayedProgressCounter.cpp
@@ -15,11 +15,11 @@
 #include "ProgressHandler.h"
 #include "DelayedProgressCounter.h"
 
-void DelayedProgressCounter::stepProgress(ProgressHandler* progress)
+void DelayedProgressCounter::stepProgress(ProgressHandler& progress)
 {
     ++m_count;
     if( m_count==m_interval ) {
-        progress->incrementDone(m_interval);
+        progress.incrementDone(m_interval);
         m_count = 0;
     }
 }

--- a/Core/Computation/DelayedProgressCounter.h
+++ b/Core/Computation/DelayedProgressCounter.h
@@ -28,7 +28,7 @@ public:
     ~DelayedProgressCounter() {}
 
     //! Increments inner counter; at regular intervals updates progress handler.
-    void stepProgress(ProgressHandler* progress);
+    void stepProgress(ProgressHandler& progress);
 private:
     const size_t m_interval;
     size_t m_count;

--- a/Core/Computation/IBackground.h
+++ b/Core/Computation/IBackground.h
@@ -31,8 +31,14 @@ public:
     virtual ~IBackground();
     virtual IBackground* clone() const =0;
 
-    virtual void addBackGround(std::vector<SimulationElement>::iterator start,
-                               std::vector<SimulationElement>::iterator end) const =0;
+    template <class Iter> void addBackGround(Iter start, Iter end) const
+    {
+        for (auto it = start; it != end; it++)
+            addBackGroundToElement(*it);
+    }
+
+protected:
+    virtual void addBackGroundToElement(SimulationElement& element) const = 0;
 };
 
 #endif // IBACKGROUND_H

--- a/Core/Computation/IComputation.cpp
+++ b/Core/Computation/IComputation.cpp
@@ -17,12 +17,13 @@
 #include "ProgressHandler.h"
 #include "SimulationElement.h"
 
-IComputation::IComputation(const SimulationOptions& options, ProgressHandler& progress,
+IComputation::IComputation(const SimulationOptions& options,
+                           const std::shared_ptr<ProgressHandler>& progress,
                            const std::vector<SimulationElement>::iterator& start,
                            const std::vector<SimulationElement>::iterator& end,
                            const MultiLayer& sample)
     : m_sim_options(options)
-    , m_progress(&progress)
+    , m_progress(progress)
     , m_begin_it(start)
     , m_end_it(end)
     , mP_multi_layer(sample.cloneSliced(options.useAvgMaterials()))

--- a/Core/Computation/IComputation.cpp
+++ b/Core/Computation/IComputation.cpp
@@ -15,17 +15,14 @@
 #include "IComputation.h"
 #include "MultiLayer.h"
 #include "ProgressHandler.h"
-#include "SimulationElement.h"
 
 IComputation::IComputation(const SimulationOptions& options,
                            const std::shared_ptr<ProgressHandler>& progress,
-                           const std::vector<SimulationElement>::iterator& start,
-                           const std::vector<SimulationElement>::iterator& end,
+                           std::unique_ptr<IIterHandler> iter_holder,
                            const MultiLayer& sample)
     : m_sim_options(options)
     , m_progress(progress)
-    , m_begin_it(start)
-    , m_end_it(end)
+    , m_iter_holder(std::move(iter_holder))
     , mP_multi_layer(sample.cloneSliced(options.useAvgMaterials()))
 {
     if (!mP_multi_layer)

--- a/Core/Computation/IComputation.h
+++ b/Core/Computation/IComputation.h
@@ -34,7 +34,8 @@ class SimulationElement;
 class IComputation
 {
 public:
-    IComputation(const SimulationOptions& options, ProgressHandler& progress,
+    IComputation(const SimulationOptions& options,
+                 const std::shared_ptr<ProgressHandler>& progress,
                  const std::vector<SimulationElement>::iterator& start,
                  const std::vector<SimulationElement>::iterator& end,
                  const MultiLayer& sample);
@@ -49,7 +50,7 @@ protected:
     virtual void runProtected() = 0;
 
     SimulationOptions m_sim_options;
-    ProgressHandler* m_progress;
+    std::shared_ptr<ProgressHandler> m_progress;
     std::vector<SimulationElement>::iterator m_begin_it, m_end_it; //!< these iterators define the span of detector bins this simulation will work on
     ComputationStatus m_status;
     std::unique_ptr<MultiLayer> mP_multi_layer;

--- a/Core/Computation/IComputationTerm.h
+++ b/Core/Computation/IComputationTerm.h
@@ -21,7 +21,6 @@
 
 class IFresnelMap;
 class MultiLayer;
-class ProgressHandler;
 class SimulationElement;
 class SimulationOptions;
 
@@ -36,16 +35,23 @@ public:
     IComputationTerm(const MultiLayer* p_multilayer, const IFresnelMap* p_fresnel_map);
     virtual ~IComputationTerm();
 
-    //! Calculate scattering intensity for each SimulationElement
-    //! returns false if nothing needed to be calculated
-    virtual void eval(ProgressHandler* progress,
-                      const std::vector<SimulationElement>::iterator& begin_it,
-                      const std::vector<SimulationElement>::iterator& end_it) const =0;
+    //! Calculates scattering intensity for a range of simulation elements.
+    template <class Iter>
+    void eval(Iter begin, Iter end) const
+    {
+        if (!checkComputation())
+            return;
+        for (auto it = begin; it != end; ++it)
+            evalSingle(*it);
+    }
 
     //! Merges its region map into the given one (notice non-const reference parameter)
     void mergeRegionMap(std::map<size_t, std::vector<HomogeneousRegion>>& region_map) const;
 
 protected:
+    //! Calculates scattering intensity for single simulation element.
+    virtual void evalSingle(SimulationElement& element) const = 0;
+    virtual bool checkComputation() const {return true;}
     const MultiLayer* mp_multilayer;
     const IFresnelMap* mp_fresnel_map;
     std::map<size_t, std::vector<HomogeneousRegion>> m_region_map;

--- a/Core/Computation/NormalizingSpecularComputationTerm.cpp
+++ b/Core/Computation/NormalizingSpecularComputationTerm.cpp
@@ -22,15 +22,17 @@ NormalizingSpecularComputationTerm::NormalizingSpecularComputationTerm(const Mul
     : SpecularComputationTerm(p_multi_layer, p_fresnel_map)
 {}
 
-void NormalizingSpecularComputationTerm::evalSingle(const std::vector<SimulationElement>::iterator& iter) const
+void NormalizingSpecularComputationTerm::evalSingle(SimulationElement& element) const
 {
-    complex_t R = mp_fresnel_map->getInCoefficients(*iter, 0)->getScalarR();
-    double sin_alpha_i = std::abs(std::sin(iter->getAlphaI()));
-    if (sin_alpha_i == 0.0)
-        sin_alpha_i = 1.0;
-    const double solid_angle = iter->getSolidAngle();
+    if (!element.specularData())
+        return;
+    const double solid_angle = element.getSolidAngle();
     if (solid_angle <= 0.0)
         return;
+    double sin_alpha_i = std::abs(std::sin(element.getAlphaI()));
+    if (sin_alpha_i == 0.0)
+        sin_alpha_i = 1.0;
+    const complex_t R = mp_fresnel_map->getInCoefficients(element, 0)->getScalarR();
     const double intensity = std::norm(R) * sin_alpha_i / solid_angle;
-    iter->setIntensity(intensity);
+    element.setIntensity(intensity);
 }

--- a/Core/Computation/NormalizingSpecularComputationTerm.h
+++ b/Core/Computation/NormalizingSpecularComputationTerm.h
@@ -28,7 +28,7 @@ public:
     NormalizingSpecularComputationTerm(const MultiLayer* p_multi_layer, const IFresnelMap* p_fresnel_map);
 
 private:
-    virtual void evalSingle(const std::vector<SimulationElement>::iterator& iter) const override;
+    virtual void evalSingle(SimulationElement& iter) const override;
 };
 
 #endif // NORMALIZINGSPECULARCOMPUTATIONTERM_H

--- a/Core/Computation/ParticleLayoutComputation.cpp
+++ b/Core/Computation/ParticleLayoutComputation.cpp
@@ -24,9 +24,10 @@
 #include "SimulationElement.h"
 
 const size_t element_interval = 100;
-ParticleLayoutComputation::ParticleLayoutComputation(
-        const MultiLayer* p_multilayer, const IFresnelMap* p_fresnel_map, const ILayout* p_layout,
-        size_t layer_index, const SimulationOptions& options, bool polarized, ProgressHandler& progress)
+ParticleLayoutComputation::ParticleLayoutComputation(const MultiLayer* p_multilayer, const IFresnelMap* p_fresnel_map,
+                                                     const ILayout* p_layout, size_t layer_index,
+                                                     const SimulationOptions& options, bool polarized,
+                                                     const std::shared_ptr<ProgressHandler>& progress)
     : IComputationTerm(p_multilayer, p_fresnel_map)
     , m_progress(progress)
     , m_progress_counter(element_interval)
@@ -40,7 +41,7 @@ ParticleLayoutComputation::ParticleLayoutComputation(
 
 void ParticleLayoutComputation::evalSingle(SimulationElement& element) const
 {
-    if (!m_progress.alive())
+    if (!m_progress->alive())
         return;
     const double alpha_f = element.getAlphaMean();
     const size_t n_layers = mp_multilayer->numberOfLayers();
@@ -48,5 +49,5 @@ void ParticleLayoutComputation::evalSingle(SimulationElement& element) const
         return; // zero for transmission with multilayers (n>1)
     else
         element.addIntensity(mP_strategy->evaluate(element) * m_surface_density);
-    m_progress_counter.stepProgress(m_progress);
+    m_progress_counter.stepProgress(*m_progress);
 }

--- a/Core/Computation/ParticleLayoutComputation.cpp
+++ b/Core/Computation/ParticleLayoutComputation.cpp
@@ -23,10 +23,13 @@
 #include "ProgressHandler.h"
 #include "SimulationElement.h"
 
+const size_t element_interval = 100;
 ParticleLayoutComputation::ParticleLayoutComputation(
         const MultiLayer* p_multilayer, const IFresnelMap* p_fresnel_map, const ILayout* p_layout,
-        size_t layer_index, const SimulationOptions& options, bool polarized)
+        size_t layer_index, const SimulationOptions& options, bool polarized, ProgressHandler& progress)
     : IComputationTerm(p_multilayer, p_fresnel_map)
+    , m_progress(progress)
+    , m_progress_counter(element_interval)
 {
     LayoutStrategyBuilder builder(mp_multilayer, p_layout, mp_fresnel_map,
                                   polarized, options, layer_index);
@@ -35,22 +38,15 @@ ParticleLayoutComputation::ParticleLayoutComputation(
     m_surface_density = p_layout->totalParticleSurfaceDensity();
 }
 
-//! Computes scattering intensity for given range of simulation elements.
-void ParticleLayoutComputation::eval(ProgressHandler* progress,
-    const std::vector<SimulationElement>::iterator& begin_it,
-    const std::vector<SimulationElement>::iterator& end_it) const
+void ParticleLayoutComputation::evalSingle(SimulationElement& element) const
 {
-    DelayedProgressCounter counter(100);
-    for (std::vector<SimulationElement>::iterator it = begin_it; it != end_it; ++it) {
-        if (!progress->alive())
-            return;
-        double alpha_f = it->getAlphaMean();
-        size_t n_layers = mp_multilayer->numberOfLayers();
-        if (n_layers > 1 && alpha_f < 0) {
-            continue; // zero for transmission with multilayers (n>1)
-        } else {
-            it->addIntensity(mP_strategy->evaluate(*it) * m_surface_density);
-        }
-        counter.stepProgress(progress);
-    }
+    if (!m_progress.alive())
+        return;
+    const double alpha_f = element.getAlphaMean();
+    const size_t n_layers = mp_multilayer->numberOfLayers();
+    if (n_layers > 1 && alpha_f < 0)
+        return; // zero for transmission with multilayers (n>1)
+    else
+        element.addIntensity(mP_strategy->evaluate(element) * m_surface_density);
+    m_progress_counter.stepProgress(m_progress);
 }

--- a/Core/Computation/ParticleLayoutComputation.h
+++ b/Core/Computation/ParticleLayoutComputation.h
@@ -15,6 +15,7 @@
 #ifndef PARTICLELAYOUTCOMPUTATION_H
 #define PARTICLELAYOUTCOMPUTATION_H
 
+#include "DelayedProgressCounter.h"
 #include "IComputationTerm.h"
 #include <memory>
 
@@ -22,6 +23,7 @@ using std::size_t;
 
 class ILayout;
 class IInterferenceFunctionStrategy;
+class ProgressHandler;
 
 //! Computes the scattering contribution from one particle layout.
 //! Used by DWBAComputation.
@@ -32,15 +34,14 @@ class ParticleLayoutComputation final : public IComputationTerm
 public:
     ParticleLayoutComputation(
         const MultiLayer* p_multilayer, const IFresnelMap* p_fresnel_map, const ILayout* p_layout,
-        size_t layer_index, const SimulationOptions& options, bool polarized);
-
-    void eval(ProgressHandler* progress,
-              const std::vector<SimulationElement>::iterator& begin_it,
-              const std::vector<SimulationElement>::iterator& end_it) const override;
+        size_t layer_index, const SimulationOptions& options, bool polarized, ProgressHandler& progress);
 
 private:
+    virtual void evalSingle(SimulationElement& element) const override;
     std::unique_ptr<const IInterferenceFunctionStrategy> mP_strategy;
     double m_surface_density;
+    ProgressHandler& m_progress;
+    mutable DelayedProgressCounter m_progress_counter;
 };
 
 #endif // PARTICLELAYOUTCOMPUTATION_H

--- a/Core/Computation/ParticleLayoutComputation.h
+++ b/Core/Computation/ParticleLayoutComputation.h
@@ -32,15 +32,16 @@ class ProgressHandler;
 class ParticleLayoutComputation final : public IComputationTerm
 {
 public:
-    ParticleLayoutComputation(
-        const MultiLayer* p_multilayer, const IFresnelMap* p_fresnel_map, const ILayout* p_layout,
-        size_t layer_index, const SimulationOptions& options, bool polarized, ProgressHandler& progress);
+    ParticleLayoutComputation(const MultiLayer* p_multilayer, const IFresnelMap* p_fresnel_map,
+                              const ILayout* p_layout, size_t layer_index,
+                              const SimulationOptions& options, bool polarized,
+                              const std::shared_ptr<ProgressHandler>& progress);
 
 private:
     virtual void evalSingle(SimulationElement& element) const override;
     std::unique_ptr<const IInterferenceFunctionStrategy> mP_strategy;
     double m_surface_density;
-    ProgressHandler& m_progress;
+    std::shared_ptr<ProgressHandler> m_progress;
     mutable DelayedProgressCounter m_progress_counter;
 };
 

--- a/Core/Computation/PoissonNoiseBackground.cpp
+++ b/Core/Computation/PoissonNoiseBackground.cpp
@@ -28,11 +28,8 @@ PoissonNoiseBackground*PoissonNoiseBackground::clone() const
     return new PoissonNoiseBackground;
 }
 
-void PoissonNoiseBackground::addBackGround(std::vector<SimulationElement>::iterator start,
-                                           std::vector<SimulationElement>::iterator end) const
+void PoissonNoiseBackground::addBackGroundToElement(SimulationElement& element) const
 {
-    for (auto it=start; it != end; it++) {
-        auto intensity = it->getIntensity();
-        it->setIntensity(MathFunctions::GeneratePoissonRandom(intensity));
-    }
+    auto intensity = element.getIntensity();
+    element.setIntensity(MathFunctions::GeneratePoissonRandom(intensity));
 }

--- a/Core/Computation/PoissonNoiseBackground.h
+++ b/Core/Computation/PoissonNoiseBackground.h
@@ -30,8 +30,8 @@ public:
 
     void accept(INodeVisitor* visitor) const override { visitor->visit(this); }
 
-    void addBackGround(std::vector<SimulationElement>::iterator start,
-                       std::vector<SimulationElement>::iterator end) const override final;
+private:
+    virtual void addBackGroundToElement(SimulationElement& element) const override final;
 };
 
 #endif // POISSONNOISEBACKGROUND_H

--- a/Core/Computation/RoughMultiLayerComputation.cpp
+++ b/Core/Computation/RoughMultiLayerComputation.cpp
@@ -42,7 +42,7 @@ namespace {
 const size_t element_interval = 100;
 RoughMultiLayerComputation::RoughMultiLayerComputation(const MultiLayer *p_multi_layer,
                                                        const IFresnelMap* p_fresnel_map,
-                                                       ProgressHandler& progress)
+                                                       const std::shared_ptr<ProgressHandler>& progress)
     : IComputationTerm(p_multi_layer, p_fresnel_map)
     , m_progress(progress)
     , m_progress_counter(element_interval)
@@ -53,7 +53,7 @@ RoughMultiLayerComputation::~RoughMultiLayerComputation()
 
 void RoughMultiLayerComputation::evalSingle(SimulationElement& element) const
 {
-    if (element.getAlphaMean() < 0.0 || !m_progress.alive())
+    if (element.getAlphaMean() < 0.0 || !m_progress->alive())
         return;
     const kvector_t q = element.getMeanQ();
     const double wavelength = element.getWavelength();
@@ -90,7 +90,7 @@ void RoughMultiLayerComputation::evalSingle(SimulationElement& element) const
     const double result = (autocorr + crosscorr.real()) * M_PI / 4. / wavelength / wavelength;
     element.addIntensity(result);
 
-    m_progress_counter.stepProgress(m_progress);
+    m_progress_counter.stepProgress(*m_progress);
 }
 
 bool RoughMultiLayerComputation::checkComputation() const

--- a/Core/Computation/RoughMultiLayerComputation.h
+++ b/Core/Computation/RoughMultiLayerComputation.h
@@ -16,6 +16,7 @@
 #define ROUGHMULTILAYERCOMPUTATION_H
 
 #include "Complex.h"
+#include "DelayedProgressCounter.h"
 #include "IComputationTerm.h"
 #include <vector>
 
@@ -30,17 +31,18 @@ class RoughMultiLayerComputation final : public IComputationTerm
 {
 public:
     RoughMultiLayerComputation(const MultiLayer* p_multi_layer,
-                               const IFresnelMap* p_fresnel_map);
+                               const IFresnelMap* p_fresnel_map,
+                               ProgressHandler& progress);
     ~RoughMultiLayerComputation();
 
-    void eval(ProgressHandler* progress,
-              const std::vector<SimulationElement>::iterator& begin_it,
-              const std::vector<SimulationElement>::iterator& end_it) const override;
-
 private:
-    double evaluate(const SimulationElement& sim_element) const;
+    virtual void evalSingle(SimulationElement& element) const override;
+    virtual bool checkComputation() const override;
     complex_t get_refractive_term(size_t ilayer, double wavelength) const;
     complex_t get_sum8terms(size_t ilayer, const SimulationElement& sim_element) const;
+
+    ProgressHandler& m_progress;
+    mutable DelayedProgressCounter m_progress_counter;
 };
 
 #endif // ROUGHMULTILAYERCOMPUTATION_H

--- a/Core/Computation/RoughMultiLayerComputation.h
+++ b/Core/Computation/RoughMultiLayerComputation.h
@@ -32,7 +32,7 @@ class RoughMultiLayerComputation final : public IComputationTerm
 public:
     RoughMultiLayerComputation(const MultiLayer* p_multi_layer,
                                const IFresnelMap* p_fresnel_map,
-                               ProgressHandler& progress);
+                               const std::shared_ptr<ProgressHandler>& progress);
     ~RoughMultiLayerComputation();
 
 private:
@@ -41,7 +41,7 @@ private:
     complex_t get_refractive_term(size_t ilayer, double wavelength) const;
     complex_t get_sum8terms(size_t ilayer, const SimulationElement& sim_element) const;
 
-    ProgressHandler& m_progress;
+    std::shared_ptr<ProgressHandler> m_progress;
     mutable DelayedProgressCounter m_progress_counter;
 };
 

--- a/Core/Computation/SpecularComputation.cpp
+++ b/Core/Computation/SpecularComputation.cpp
@@ -14,28 +14,22 @@
 
 #include "SpecularComputation.h"
 #include "Layer.h"
-#include "IFresnelMap.h"
 #include "MatrixFresnelMap.h"
 #include "MultiLayer.h"
 #include "ScalarFresnelMap.h"
 #include "ProgressHandler.h"
 #include "SimulationElement.h"
-#include "SpecularComputationTerm.h"
 
 static_assert(std::is_copy_constructible<SpecularComputation>::value == false,
               "SpecularComputation should not be copy constructible");
 static_assert(std::is_copy_assignable<SpecularComputation>::value == false,
               "SpecularComputation should not be copy assignable");
 
-SpecularComputation::SpecularComputation(const MultiLayer& multilayer,
-                                         const SimulationOptions& options,
-                                         const std::shared_ptr<ProgressHandler>& progress,
-                                         const std::vector<SimulationElement>::iterator& begin_it,
-                                         const std::vector<SimulationElement>::iterator& end_it)
-    : IComputation(options, progress, begin_it, end_it, multilayer)
+void SpecularComputation::init()
 {
     mP_fresnel_map = createFresnelMap();
-    m_computation_term.reset(new SpecularComputationTerm(mP_multi_layer.get(), mP_fresnel_map.get()));
+    m_computation_term.reset(
+        new SpecularComputationTerm(mP_multi_layer.get(), mP_fresnel_map.get()));
 }
 
 SpecularComputation::~SpecularComputation() = default;
@@ -44,7 +38,7 @@ void SpecularComputation::runProtected()
 {
     if (!m_progress->alive())
         return;
-    m_computation_term->eval(m_begin_it, m_end_it);
+    m_iter_holder->eval(*m_computation_term);
 }
 
 std::unique_ptr<IFresnelMap> SpecularComputation::createFresnelMap()

--- a/Core/Computation/SpecularComputation.cpp
+++ b/Core/Computation/SpecularComputation.cpp
@@ -29,7 +29,7 @@ static_assert(std::is_copy_assignable<SpecularComputation>::value == false,
 
 SpecularComputation::SpecularComputation(const MultiLayer& multilayer,
                                          const SimulationOptions& options,
-                                         ProgressHandler& progress,
+                                         const std::shared_ptr<ProgressHandler>& progress,
                                          const std::vector<SimulationElement>::iterator& begin_it,
                                          const std::vector<SimulationElement>::iterator& end_it)
     : IComputation(options, progress, begin_it, end_it, multilayer)

--- a/Core/Computation/SpecularComputation.cpp
+++ b/Core/Computation/SpecularComputation.cpp
@@ -44,7 +44,7 @@ void SpecularComputation::runProtected()
 {
     if (!m_progress->alive())
         return;
-    m_computation_term->eval(m_progress, m_begin_it, m_end_it);
+    m_computation_term->eval(m_begin_it, m_end_it);
 }
 
 std::unique_ptr<IFresnelMap> SpecularComputation::createFresnelMap()

--- a/Core/Computation/SpecularComputation.h
+++ b/Core/Computation/SpecularComputation.h
@@ -35,7 +35,7 @@ class SpecularComputation : public IComputation
 {
 public:
     SpecularComputation(const MultiLayer& multilayer, const SimulationOptions& options,
-                        ProgressHandler& progress,
+                        const std::shared_ptr<ProgressHandler>& progress,
                         const std::vector<SimulationElement>::iterator& begin_it,
                         const std::vector<SimulationElement>::iterator& end_it);
     virtual ~SpecularComputation();

--- a/Core/Computation/SpecularComputation.h
+++ b/Core/Computation/SpecularComputation.h
@@ -48,8 +48,6 @@ public:
 
     virtual ~SpecularComputation();
 
-    void run();
-
 private:
     void init();
     virtual void runProtected() override;

--- a/Core/Computation/SpecularComputation.h
+++ b/Core/Computation/SpecularComputation.h
@@ -16,10 +16,11 @@
 #define SPECULARCOMPUTATION_H_
 
 #include "IComputation.h"
+#include "IFresnelMap.h"
 #include "Complex.h"
 #include "SimulationOptions.h"
+#include "SpecularComputationTerm.h"
 
-class IFresnelMap;
 class MultiLayer;
 struct HomogeneousRegion;
 class IComputationTerm;
@@ -34,15 +35,23 @@ class SpecularComputationTerm;
 class SpecularComputation : public IComputation
 {
 public:
-    SpecularComputation(const MultiLayer& multilayer, const SimulationOptions& options,
-                        const std::shared_ptr<ProgressHandler>& progress,
-                        const std::vector<SimulationElement>::iterator& begin_it,
-                        const std::vector<SimulationElement>::iterator& end_it);
+    template <class Iter>
+    explicit SpecularComputation(const MultiLayer& multilayer,
+                                 const SimulationOptions& options,
+                                 const std::shared_ptr<ProgressHandler>& progress,
+                                 Iter begin_it, Iter end_it)
+        : IComputation(options, progress, std::make_unique<IterHandler<Iter>>(begin_it, end_it),
+                       multilayer)
+    {
+        init();
+    }
+
     virtual ~SpecularComputation();
 
     void run();
 
 private:
+    void init();
     virtual void runProtected() override;
     std::unique_ptr<IFresnelMap> createFresnelMap();
 

--- a/Core/Computation/SpecularComputationTerm.cpp
+++ b/Core/Computation/SpecularComputationTerm.cpp
@@ -9,21 +9,13 @@ SpecularComputationTerm::SpecularComputationTerm(const MultiLayer* p_multi_layer
     : IComputationTerm(p_multi_layer, p_fresnel_map)
 {}
 
-void SpecularComputationTerm::eval(ProgressHandler*,
-    const std::vector<SimulationElement>::iterator& begin_it,
-    const std::vector<SimulationElement>::iterator& end_it) const
+void SpecularComputationTerm::evalSingle(SimulationElement& element) const
 {
-    if (mp_multilayer->requiresMatrixRTCoefficients())
-        return;
-
-    for (auto it = begin_it; it != end_it; ++it)
-        if (it->specularData())
-            evalSingle(it);
+    mp_fresnel_map->fillSpecularData(element);
+    const ILayerRTCoefficients& layer_data = element.specularData()->operator [](0);
+    element.setIntensity(std::norm(layer_data.getScalarR()));
 }
 
-void SpecularComputationTerm::evalSingle(const std::vector<SimulationElement>::iterator& iter) const
-{
-    mp_fresnel_map->fillSpecularData(*iter);
-    const ILayerRTCoefficients& layer_data = (*iter->specularData())[0];
-    iter->setIntensity(std::norm(layer_data.getScalarR()));
+bool SpecularComputationTerm::checkComputation() const {
+    return !mp_multilayer->requiresMatrixRTCoefficients();
 }

--- a/Core/Computation/SpecularComputationTerm.h
+++ b/Core/Computation/SpecularComputationTerm.h
@@ -26,12 +26,9 @@ class SpecularComputationTerm : public IComputationTerm
 public:
     SpecularComputationTerm(const MultiLayer* p_multi_layer, const IFresnelMap* p_fresnel_map);
 
-    virtual void eval(ProgressHandler* progress,
-              const std::vector<SimulationElement>::iterator& begin_it,
-              const std::vector<SimulationElement>::iterator& end_it) const override;
-
 private:
-    virtual void evalSingle(const std::vector<SimulationElement>::iterator& iter) const;
+    virtual void evalSingle(SimulationElement& element) const override;
+    virtual bool checkComputation() const override;
 };
 
 #endif /* SPECULARCOMPUTATIONTERM_H_ */

--- a/Core/Instrument/IDetector.h
+++ b/Core/Instrument/IDetector.h
@@ -25,6 +25,7 @@ class Beam;
 class DetectorMask;
 class IDetectorResolution;
 class IResolutionFunction2D;
+class ISimulationElementsProvider;
 template<class T> class OutputData;
 class SimulationElement;
 class RegionOfInterest;
@@ -94,7 +95,7 @@ public:
     std::unique_ptr<OutputData<double>> createDetectorMap(const Beam& beam, AxesUnits units) const;
 
     //! Create a vector of SimulationElement objects according to the detector and its mask
-    virtual std::vector<SimulationElement> createSimulationElements(const Beam& beam) = 0;
+    virtual std::unique_ptr<ISimulationElementsProvider> createSimulationElements(const Beam& beam) = 0;
 #endif // SWIG
 
     //! Returns region of  interest if exists.

--- a/Core/Instrument/IDetector.h
+++ b/Core/Instrument/IDetector.h
@@ -19,15 +19,15 @@
 #include "ICloneable.h"
 #include "INode.h"
 #include "DetectionProperties.h"
+#include "OutputData.h"
 #include "SafePointerVector.h"
+#include "SimulationArea.h"
 
 class Beam;
 class DetectorMask;
 class IDetectorResolution;
 class IResolutionFunction2D;
 class ISimulationElementsProvider;
-template<class T> class OutputData;
-class SimulationElement;
 class RegionOfInterest;
 
 //! Wrapper for detector axes units, required for a better representation of
@@ -96,6 +96,31 @@ public:
 
     //! Create a vector of SimulationElement objects according to the detector and its mask
     virtual std::unique_ptr<ISimulationElementsProvider> createSimulationElements(const Beam& beam) = 0;
+
+    //! Returns new intensity map with detector resolution applied and axes in requested units
+    template <class SimElement>
+    std::unique_ptr<OutputData<double>>
+    createDetectorIntensity(const std::vector<SimElement>& elements, const Beam& beam,
+                            AxesUnits units_type = AxesUnits::DEFAULT) const
+    {
+        auto detectorMap = createDetectorMap(beam, units_type);
+
+        if (mP_detector_resolution) {
+            if (units_type != AxesUnits::DEFAULT) {
+                auto defaultMap = createDetectorMap(beam, AxesUnits::DEFAULT);
+                setDataToDetectorMap(*defaultMap, elements);
+                applyDetectorResolution(defaultMap.get());
+                detectorMap->setRawDataVector(defaultMap->getRawDataVector());
+            } else {
+                setDataToDetectorMap(*detectorMap, elements);
+                applyDetectorResolution(detectorMap.get());
+            }
+        } else {
+            setDataToDetectorMap(*detectorMap, elements);
+        }
+
+        return detectorMap;
+    }
 #endif // SWIG
 
     //! Returns region of  interest if exists.
@@ -109,11 +134,6 @@ public:
 
     //! Inits axes of OutputData to match the detector and sets values to zero.
     void initOutputData(OutputData<double>& data) const;
-
-    //! Returns new intensity map with detector resolution applied and axes in requested units
-    OutputData<double>* createDetectorIntensity(const std::vector<SimulationElement>& elements,
-                                                const Beam& beam,
-                                                AxesUnits units_type = AxesUnits::DEFAULT) const;
 
     //! Return default axes units
     virtual AxesUnits defaultAxesUnits() const {return AxesUnits::DEFAULT;}
@@ -148,8 +168,16 @@ private:
     //! Checks if given unit is valid for the detector. Throws exception if it is not the case.
     void checkAxesUnits(AxesUnits units) const;
 
+    template <class SimElement>
     void setDataToDetectorMap(OutputData<double>& detectorMap,
-                              const std::vector<SimulationElement>& elements) const;
+                              const std::vector<SimElement>& elements) const
+    {
+        if (elements.empty())
+            return;
+        SimulationArea area(this);
+        for (SimulationArea::iterator it = area.begin(); it != area.end(); ++it)
+            detectorMap[it.roiIndex()] = elements[it.elementIndex()].getIntensity();
+    }
 
     SafePointerVector<IAxis> m_axes;
     DetectionProperties m_detection_properties;

--- a/Core/Instrument/IDetector2D.cpp
+++ b/Core/Instrument/IDetector2D.cpp
@@ -117,7 +117,7 @@ std::unique_ptr<ISimulationElementsProvider> IDetector2D::createSimulationElemen
             sim_element.setSpecular();
     }
 
-    return agent;
+    return std::move(agent);
 }
 
 SimulationElement IDetector2D::getSimulationElement(size_t index, const Beam &beam) const

--- a/Core/Instrument/IDetector2D.cpp
+++ b/Core/Instrument/IDetector2D.cpp
@@ -15,8 +15,9 @@
 #include "IDetector2D.h"
 #include "Beam.h"
 #include "InfinitePlane.h"
-#include "SimulationElement.h"
 #include "SimulationArea.h"
+#include "SimulationElement.h"
+#include "SimulationElementsProvider.h"
 #include "BornAgainNamespace.h"
 #include "Units.h"
 #include "RegionOfInterest.h"
@@ -89,9 +90,10 @@ const DetectorMask* IDetector2D::detectorMask() const
     return &m_detector_mask;
 }
 
-std::vector<SimulationElement> IDetector2D::createSimulationElements(const Beam &beam)
+std::unique_ptr<ISimulationElementsProvider> IDetector2D::createSimulationElements(const Beam &beam)
 {
-    std::vector<SimulationElement> result;
+    auto agent = std::make_unique<SimulationElementsProvider<SimulationElement>>();
+    auto& elements = agent->getElementVector();
 
     const double wavelength = beam.getWavelength();
     const double alpha_i = - beam.getAlpha();  // Defined to be always positive in Beam
@@ -104,18 +106,18 @@ std::vector<SimulationElement> IDetector2D::createSimulationElements(const Beam 
     size_t spec_index = getIndexOfSpecular(beam);
 
     SimulationArea area(this);
-    result.reserve(area.totalSize());
+    elements.reserve(area.totalSize());
     for(SimulationArea::iterator it = area.begin(); it!=area.end(); ++it) {
-        result.emplace_back(wavelength, alpha_i, phi_i,
+        elements.emplace_back(wavelength, alpha_i, phi_i,
                             std::unique_ptr<IPixel>(createPixel(it.detectorIndex())));
-        auto& sim_element = result.back();
+        auto& sim_element = elements.back();
         sim_element.setPolarization(beam_polarization);
         sim_element.setAnalyzerOperator(analyzer_operator);
         if (it.index()==spec_index)
             sim_element.setSpecular();
     }
 
-    return result;
+    return agent;
 }
 
 SimulationElement IDetector2D::getSimulationElement(size_t index, const Beam &beam) const

--- a/Core/Instrument/IDetector2D.h
+++ b/Core/Instrument/IDetector2D.h
@@ -22,6 +22,7 @@
 class Beam;
 class IPixel;
 class IShape2D;
+class SimulationElement;
 
 //! Abstract 2D detector interface.
 //! @ingroup simulation

--- a/Core/Instrument/IDetector2D.h
+++ b/Core/Instrument/IDetector2D.h
@@ -60,7 +60,7 @@ public:
 
 #ifndef SWIG
     //! Create a vector of SimulationElement objects according to the detector and its mask
-    virtual std::vector<SimulationElement> createSimulationElements(const Beam& beam) override;
+    virtual std::unique_ptr<ISimulationElementsProvider> createSimulationElements(const Beam& beam) override;
 #endif
 
     //! Returns region of  interest if exists.

--- a/Core/Instrument/Instrument.cpp
+++ b/Core/Instrument/Instrument.cpp
@@ -77,12 +77,6 @@ std::vector<const INode*> Instrument::getChildren() const
     return result;
 }
 
-
-std::vector<SimulationElement> Instrument::createSimulationElements()
-{
-    return mP_detector->createSimulationElements(m_beam);
-}
-
 void Instrument::setDetectorResolutionFunction(const IResolutionFunction2D& p_resolution_function)
 {
     mP_detector->setResolutionFunction(p_resolution_function);

--- a/Core/Instrument/Instrument.cpp
+++ b/Core/Instrument/Instrument.cpp
@@ -27,7 +27,6 @@ Instrument::Instrument()
     setName(BornAgain::InstrumentType);
     registerChild(mP_detector.get());
     registerChild(&m_beam);
-    init_parameters();
 }
 
 Instrument::Instrument(const Instrument &other) : m_beam(other.m_beam)
@@ -36,7 +35,6 @@ Instrument::Instrument(const Instrument &other) : m_beam(other.m_beam)
         setDetector(*other.mP_detector);
     registerChild(&m_beam);
     setName(other.getName());
-    init_parameters();
 }
 
 Instrument::~Instrument() {}
@@ -48,7 +46,6 @@ Instrument &Instrument::operator=(const Instrument &other)
         registerChild(&m_beam);
         if(other.mP_detector)
             setDetector(*other.mP_detector);
-        init_parameters();
     }
     return *this;
 }
@@ -90,25 +87,6 @@ void Instrument::removeDetectorResolution()
 void Instrument::applyDetectorResolution(OutputData<double>* p_intensity_map) const
 {
     mP_detector->applyDetectorResolution(p_intensity_map);
-}
-
-OutputData<double> *Instrument::createDetectorIntensity(
-        const std::vector<SimulationElement> &elements, AxesUnits units) const
-{
-    return mP_detector->createDetectorIntensity(elements, m_beam, units);
-}
-
-Histogram2D* Instrument::createIntensityData(const std::vector<SimulationElement>& elements,
-                                         AxesUnits units_type) const
-{
-    const std::unique_ptr<OutputData<double>> data(createDetectorIntensity(elements, units_type));
-    std::unique_ptr<Histogram2D> result(new Histogram2D(*data));
-
-    if (units_type == AxesUnits::DEFAULT)
-        units_type = mP_detector->defaultAxesUnits();
-
-    result->setAxesUnits(DetectorFunctions::detectorUnitsName(units_type));
-    return result.release();
 }
 
 OutputData<double> *Instrument::createDetectorMap(AxesUnits units) const
@@ -177,4 +155,17 @@ void Instrument::setAnalyzerProperties(const kvector_t direction, double efficie
                                        double total_transmission)
 {
     mP_detector->setAnalyzerProperties(direction, efficiency, total_transmission);
+}
+
+std::unique_ptr<Histogram2D>
+Instrument::createUnitSpecificHistogram(std::unique_ptr<OutputData<double>> output_data,
+                                        AxesUnits units) const
+{
+    std::unique_ptr<Histogram2D> result = std::make_unique<Histogram2D>(*output_data);
+
+    if (units == AxesUnits::DEFAULT)
+        units = mP_detector->defaultAxesUnits();
+
+    result->setAxesUnits(DetectorFunctions::detectorUnitsName(units));
+    return result;
 }

--- a/Core/Instrument/Instrument.h
+++ b/Core/Instrument/Instrument.h
@@ -18,6 +18,7 @@
 #include "IDetector.h"
 #include "INode.h"
 #include "Beam.h"
+#include "SimulationElementsProvider.h"
 #include <memory>
 
 template<class T> class OutputData;
@@ -103,7 +104,15 @@ public:
 
 #ifndef SWIG
     //! Create a vector of SimulationElement objects according to the beam, detector and its mask
-    std::vector<SimulationElement> createSimulationElements();
+    template <class SimElement> std::vector<SimElement> createSimulationElements()
+    {
+        using ElementProvider = SimulationElementsProvider<SimElement>;
+        auto agent_base = mP_detector->createSimulationElements(m_beam);
+        auto agent = dynamic_cast<ElementProvider*>(agent_base.get());
+        if (!agent)
+            throw std::runtime_error("Error in Instrument::createSimulationElements: Incorrect detector or element type");
+        return agent->releaseSimElements();
+    }
 #endif
 
     //! init detector with beam settings

--- a/Core/Instrument/SimulationElementsProvider.h
+++ b/Core/Instrument/SimulationElementsProvider.h
@@ -1,0 +1,45 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Core/Computation/SimulationElementsProvider.h
+//! @brief     Implements class SimulationElementsProvider.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#ifndef SIMULATIONELEMENTSPROVIDER_H_
+#define SIMULATIONELEMENTSPROVIDER_H_
+
+#include <vector>
+
+//! Base for SimulationElementsProvider.
+class ISimulationElementsProvider
+{
+public:
+    virtual ~ISimulationElementsProvider() = default;
+};
+
+//! SimulationElementsProvider template, gives access to created simulation elements
+//! Intended to be used in detectors for access to simulation elements of different types
+template <class SimElement> class SimulationElementsProvider : public ISimulationElementsProvider
+{
+public:
+    std::vector<SimElement>& getElementVector()
+    {
+        return m_elements;
+    }
+    std::vector<SimElement> releaseSimElements()
+    {
+        return std::move(m_elements);
+    }
+
+private:
+    std::vector<SimElement> m_elements;
+};
+
+#endif /* SIMULATIONELEMENTSPROVIDER_H_ */

--- a/Core/Instrument/SpecularDetector1D.cpp
+++ b/Core/Instrument/SpecularDetector1D.cpp
@@ -101,7 +101,7 @@ std::unique_ptr<ISimulationElementsProvider> SpecularDetector1D::createSimulatio
         sim_element.setSpecular();
     }
 
-    return agent;
+    return std::move(agent);
 }
 
 std::string SpecularDetector1D::axisName(size_t index) const

--- a/Core/Instrument/SpecularDetector1D.h
+++ b/Core/Instrument/SpecularDetector1D.h
@@ -34,7 +34,7 @@ public:
 
 #ifndef SWIG
     //! Create a vector of SimulationElement objects according to the detector and its mask
-    virtual std::vector<SimulationElement> createSimulationElements(const Beam& beam) override;
+    virtual std::unique_ptr<ISimulationElementsProvider> createSimulationElements(const Beam& beam) override;
 #endif // SWIG
 
     //! Returns region of interest if exists.

--- a/Core/Simulation/GISASSimulation.cpp
+++ b/Core/Simulation/GISASSimulation.cpp
@@ -118,9 +118,9 @@ void GISASSimulation::setRegionOfInterest(double xlow, double ylow, double xup, 
     Detector2D(m_instrument)->setRegionOfInterest(xlow, ylow, xup, yup);
 }
 
-std::unique_ptr<IComputation> GISASSimulation::generateSingleThreadedComputation(
-        std::vector<SimulationElement>::iterator start,
-        std::vector<SimulationElement>::iterator end)
+std::unique_ptr<IComputation>
+GISASSimulation::generateSingleThreadedComputation(SimElementVector::iterator start,
+                                                   SimElementVector::iterator end)
 {
     return std::make_unique<DWBAComputation>(*sample(), m_options, m_progress, start, end);
 }

--- a/Core/Simulation/GISASSimulation.cpp
+++ b/Core/Simulation/GISASSimulation.cpp
@@ -18,7 +18,6 @@
 #include "Histogram2D.h"
 #include "IMultiLayerBuilder.h"
 #include "MultiLayer.h"
-#include "SimulationElement.h"
 
 namespace
 {
@@ -119,8 +118,7 @@ void GISASSimulation::setRegionOfInterest(double xlow, double ylow, double xup, 
 }
 
 std::unique_ptr<IComputation>
-GISASSimulation::generateSingleThreadedComputation(SimElementVector::iterator start,
-                                                   SimElementVector::iterator end)
+GISASSimulation::generateSingleThreadedComputation(SimIter start, SimIter end)
 {
     return std::make_unique<DWBAComputation>(*sample(), m_options, m_progress, start, end);
 }

--- a/Core/Simulation/GISASSimulation.cpp
+++ b/Core/Simulation/GISASSimulation.cpp
@@ -31,16 +31,24 @@ GISASSimulation::GISASSimulation()
 }
 
 GISASSimulation::GISASSimulation(const MultiLayer& p_sample)
-    : Simulation(p_sample)
+    : SimulationImpl(p_sample)
 {
     initialize();
 }
 
 GISASSimulation::GISASSimulation(const std::shared_ptr<IMultiLayerBuilder> p_sample_builder)
-    : Simulation(p_sample_builder)
+    : SimulationImpl(p_sample_builder)
 {
     initialize();
 }
+
+GISASSimulation::GISASSimulation(const GISASSimulation& other)
+    : SimulationImpl(other)
+{
+    initialize();
+}
+
+GISASSimulation::~GISASSimulation() = default;
 
 void GISASSimulation::prepareSimulation()
 {
@@ -115,12 +123,6 @@ std::unique_ptr<IComputation> GISASSimulation::generateSingleThreadedComputation
         std::vector<SimulationElement>::iterator end)
 {
     return std::make_unique<DWBAComputation>(*sample(), m_options, m_progress, start, end);
-}
-
-GISASSimulation::GISASSimulation(const GISASSimulation& other)
-    : Simulation(other)
-{
-    initialize();
 }
 
 void GISASSimulation::transferResultsToIntensityMap() {}

--- a/Core/Simulation/GISASSimulation.h
+++ b/Core/Simulation/GISASSimulation.h
@@ -15,7 +15,7 @@
 #ifndef GISASSIMULATION_H
 #define GISASSIMULATION_H
 
-#include "Simulation.h"
+#include "SimulationImpl.h"
 
 class MultiLayer;
 class IMultiLayerBuilder;
@@ -25,14 +25,14 @@ class Histogram2D;
 //! Main class to run a Grazing-Incidence Small-Angle Scattering simulation.
 //! @ingroup simulation
 
-class BA_CORE_API_ GISASSimulation : public Simulation
+class BA_CORE_API_ GISASSimulation : public SimulationImpl
 {
 public:
     GISASSimulation();
     GISASSimulation(const MultiLayer& p_sample);
     GISASSimulation(const std::shared_ptr<IMultiLayerBuilder> p_sample_builder);
 
-    ~GISASSimulation() final {}
+    virtual ~GISASSimulation();
 
     GISASSimulation* clone() const { return new GISASSimulation(*this); }
 

--- a/Core/Simulation/GISASSimulation.h
+++ b/Core/Simulation/GISASSimulation.h
@@ -84,9 +84,9 @@ public:
     void setRegionOfInterest(double xlow, double ylow, double xup, double yup);
 
 protected:
-    virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(
-            std::vector<SimulationElement>::iterator start,
-            std::vector<SimulationElement>::iterator end);
+    virtual std::unique_ptr<IComputation>
+    generateSingleThreadedComputation(SimElementVector::iterator start,
+                                      SimElementVector::iterator end);
 
 private:
     GISASSimulation(const GISASSimulation& other);

--- a/Core/Simulation/GISASSimulation.h
+++ b/Core/Simulation/GISASSimulation.h
@@ -16,6 +16,7 @@
 #define GISASSIMULATION_H
 
 #include "SimulationImpl.h"
+#include "SimulationElement.h"
 
 class MultiLayer;
 class IMultiLayerBuilder;
@@ -25,7 +26,7 @@ class Histogram2D;
 //! Main class to run a Grazing-Incidence Small-Angle Scattering simulation.
 //! @ingroup simulation
 
-class BA_CORE_API_ GISASSimulation : public SimulationImpl
+class BA_CORE_API_ GISASSimulation : public SimulationImpl<SimulationElement>
 {
 public:
     GISASSimulation();
@@ -85,8 +86,7 @@ public:
 
 protected:
     virtual std::unique_ptr<IComputation>
-    generateSingleThreadedComputation(SimElementVector::iterator start,
-                                      SimElementVector::iterator end);
+    generateSingleThreadedComputation(SimIter start, SimIter end);
 
 private:
     GISASSimulation(const GISASSimulation& other);

--- a/Core/Simulation/OffSpecSimulation.cpp
+++ b/Core/Simulation/OffSpecSimulation.cpp
@@ -18,7 +18,6 @@
 #include "Histogram2D.h"
 #include "IMultiLayerBuilder.h"
 #include "MultiLayer.h"
-#include "SimulationElement.h"
 
 OffSpecSimulation::OffSpecSimulation()
     : mp_alpha_i_axis(nullptr)
@@ -95,8 +94,7 @@ void OffSpecSimulation::setDetectorParameters(size_t n_x, double x_min, double x
 }
 
 std::unique_ptr<IComputation>
-OffSpecSimulation::generateSingleThreadedComputation(SimElementVector::iterator start,
-                                                     SimElementVector::iterator end)
+OffSpecSimulation::generateSingleThreadedComputation(SimIter start, SimIter end)
 {
     return std::make_unique<DWBAComputation>(*sample(), m_options, m_progress, start, end);
 }

--- a/Core/Simulation/OffSpecSimulation.cpp
+++ b/Core/Simulation/OffSpecSimulation.cpp
@@ -115,7 +115,7 @@ void OffSpecSimulation::initSimulationElementVector()
         beam.setCentralK(wavelength, alpha_i, phi_i);
         m_instrument.setBeam(beam);
         SimElementVector sim_elements_alpha_i =
-            m_instrument.createSimulationElements();
+            m_instrument.createSimulationElements<SimElementVector::value_type>();
         m_sim_elements.insert(m_sim_elements.end(), sim_elements_alpha_i.begin(),
                               sim_elements_alpha_i.end());
     }

--- a/Core/Simulation/OffSpecSimulation.cpp
+++ b/Core/Simulation/OffSpecSimulation.cpp
@@ -27,18 +27,30 @@ OffSpecSimulation::OffSpecSimulation()
 }
 
 OffSpecSimulation::OffSpecSimulation(const MultiLayer& p_sample)
-    : Simulation(p_sample)
+    : SimulationImpl(p_sample)
     , mp_alpha_i_axis(nullptr)
 {
     initialize();
 }
 
 OffSpecSimulation::OffSpecSimulation(const std::shared_ptr<IMultiLayerBuilder> p_sample_builder)
-    : Simulation(p_sample_builder)
+    : SimulationImpl(p_sample_builder)
     , mp_alpha_i_axis(nullptr)
 {
     initialize();
 }
+
+OffSpecSimulation::OffSpecSimulation(const OffSpecSimulation& other)
+    : SimulationImpl(other)
+    , mp_alpha_i_axis(nullptr)
+{
+    if(other.mp_alpha_i_axis)
+        mp_alpha_i_axis = other.mp_alpha_i_axis->clone();
+    m_intensity_map.copyFrom(other.m_intensity_map);
+    initialize();
+}
+
+OffSpecSimulation::~OffSpecSimulation() = default;
 
 void OffSpecSimulation::prepareSimulation()
 {
@@ -87,16 +99,6 @@ std::unique_ptr<IComputation> OffSpecSimulation::generateSingleThreadedComputati
         std::vector<SimulationElement>::iterator end)
 {
     return std::make_unique<DWBAComputation>(*sample(), m_options, m_progress, start, end);
-}
-
-OffSpecSimulation::OffSpecSimulation(const OffSpecSimulation& other)
-    : Simulation(other)
-    , mp_alpha_i_axis(nullptr)
-{
-    if(other.mp_alpha_i_axis)
-        mp_alpha_i_axis = other.mp_alpha_i_axis->clone();
-    m_intensity_map.copyFrom(other.m_intensity_map);
-    initialize();
 }
 
 void OffSpecSimulation::initSimulationElementVector()

--- a/Core/Simulation/OffSpecSimulation.cpp
+++ b/Core/Simulation/OffSpecSimulation.cpp
@@ -94,9 +94,9 @@ void OffSpecSimulation::setDetectorParameters(size_t n_x, double x_min, double x
     updateIntensityMap();
 }
 
-std::unique_ptr<IComputation> OffSpecSimulation::generateSingleThreadedComputation(
-        std::vector<SimulationElement>::iterator start,
-        std::vector<SimulationElement>::iterator end)
+std::unique_ptr<IComputation>
+OffSpecSimulation::generateSingleThreadedComputation(SimElementVector::iterator start,
+                                                     SimElementVector::iterator end)
 {
     return std::make_unique<DWBAComputation>(*sample(), m_options, m_progress, start, end);
 }
@@ -114,7 +114,7 @@ void OffSpecSimulation::initSimulationElementVector()
         double alpha_i = mp_alpha_i_axis->getBin(iAlpha).getMidPoint();
         beam.setCentralK(wavelength, alpha_i, phi_i);
         m_instrument.setBeam(beam);
-        std::vector<SimulationElement> sim_elements_alpha_i =
+        SimElementVector sim_elements_alpha_i =
             m_instrument.createSimulationElements();
         m_sim_elements.insert(m_sim_elements.end(), sim_elements_alpha_i.begin(),
                               sim_elements_alpha_i.end());

--- a/Core/Simulation/OffSpecSimulation.h
+++ b/Core/Simulation/OffSpecSimulation.h
@@ -16,13 +16,14 @@
 #define OFFSPECSIMULATION_H
 
 #include "SimulationImpl.h"
+#include "SimulationElement.h"
 
 class Histogram2D;
 
 //! Main class to run an off-specular simulation.
 //! @ingroup simulation
 
-class BA_CORE_API_ OffSpecSimulation : public SimulationImpl
+class BA_CORE_API_ OffSpecSimulation : public SimulationImpl<SimulationElement>
 {
 public:
     OffSpecSimulation();
@@ -57,8 +58,7 @@ public:
 
 protected:
     virtual std::unique_ptr<IComputation>
-    generateSingleThreadedComputation(SimElementVector::iterator start,
-                                      SimElementVector::iterator end);
+    generateSingleThreadedComputation(SimIter start, SimIter end);
 
 private:
     OffSpecSimulation(const OffSpecSimulation& other);

--- a/Core/Simulation/OffSpecSimulation.h
+++ b/Core/Simulation/OffSpecSimulation.h
@@ -56,9 +56,9 @@ public:
                                size_t n_y, double y_min, double y_max);
 
 protected:
-    virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(
-            std::vector<SimulationElement>::iterator start,
-            std::vector<SimulationElement>::iterator end);
+    virtual std::unique_ptr<IComputation>
+    generateSingleThreadedComputation(SimElementVector::iterator start,
+                                      SimElementVector::iterator end);
 
 private:
     OffSpecSimulation(const OffSpecSimulation& other);

--- a/Core/Simulation/OffSpecSimulation.h
+++ b/Core/Simulation/OffSpecSimulation.h
@@ -15,20 +15,20 @@
 #ifndef OFFSPECSIMULATION_H
 #define OFFSPECSIMULATION_H
 
-#include "Simulation.h"
+#include "SimulationImpl.h"
 
 class Histogram2D;
 
 //! Main class to run an off-specular simulation.
 //! @ingroup simulation
 
-class BA_CORE_API_ OffSpecSimulation : public Simulation
+class BA_CORE_API_ OffSpecSimulation : public SimulationImpl
 {
 public:
     OffSpecSimulation();
     OffSpecSimulation(const MultiLayer& p_sample);
     OffSpecSimulation(const std::shared_ptr<class IMultiLayerBuilder> p_sample_builder);
-    ~OffSpecSimulation() final {}
+    virtual ~OffSpecSimulation();
 
     OffSpecSimulation* clone() const { return new OffSpecSimulation(*this); }
 

--- a/Core/Simulation/Simulation.cpp
+++ b/Core/Simulation/Simulation.cpp
@@ -21,19 +21,20 @@
 #include <iostream>
 
 Simulation::Simulation()
+    : m_progress(std::make_shared<ProgressHandler>())
 {
     initialize();
 }
 
 Simulation::Simulation(const MultiLayer& p_sample)
+    : Simulation()
 {
-    initialize();
     m_sample_provider.setSample(p_sample);
 }
 
 Simulation::Simulation(const std::shared_ptr<IMultiLayerBuilder> p_sample_builder)
+    : Simulation()
 {
-    initialize();
     m_sample_provider.setSampleBuilder(p_sample_builder);
 }
 
@@ -55,7 +56,7 @@ Simulation::~Simulation() {}
 //! Initializes a progress monitor that prints to stdout.
 void Simulation::setTerminalProgressMonitor()
 {
-    m_progress.subscribe( [] (size_t percentage_done) -> bool {
+    m_progress->subscribe( [] (size_t percentage_done) -> bool {
             if (percentage_done<100)
                 std::cout << std::setprecision(2)
                           << "\r... " << percentage_done << "%" << std::flush;

--- a/Core/Simulation/Simulation.cpp
+++ b/Core/Simulation/Simulation.cpp
@@ -142,10 +142,9 @@ void Simulation::runSimulation()
     for (size_t index = 0; index < param_combinations; ++index) {
         double weight = m_distribution_handler.setParameterValues(P_param_pool.get(), index);
         runSingleSimulation();
-        addElementsWithWeight(m_sim_elements.begin(), m_sim_elements.end(), total_intensity.begin(),
-                              weight);
+        addElementsWithWeight(total_intensity.begin(), weight);
     }
-    m_sim_elements = total_intensity;
+    m_sim_elements = std::move(total_intensity);
     transferResultsToIntensityMap();
 }
 
@@ -332,6 +331,12 @@ Simulation::SimElementVector::iterator Simulation::getBatchEnd(int n_batches, in
     if (end_index >= total_size)
         return m_sim_elements.end();
     return m_sim_elements.begin() + end_index;
+}
+
+void Simulation::addElementsWithWeight(SimElementVector::iterator result, double weight) const
+{
+    for (auto it = m_sim_elements.cbegin(); it != m_sim_elements.cend(); ++it, ++result)
+        result->addIntensity(it->getIntensity() * weight);
 }
 
 void Simulation::initialize()

--- a/Core/Simulation/Simulation.cpp
+++ b/Core/Simulation/Simulation.cpp
@@ -16,12 +16,6 @@
 #include "IBackground.h"
 #include "IMultiLayerBuilder.h"
 #include "MultiLayer.h"
-#include "IComputation.h"
-#include "ParameterPool.h"
-#include "ParameterSample.h"
-#include "SimulationElement.h"
-#include "StringUtils.h"
-#include <thread>
 #include <gsl/gsl_errno.h>
 #include <iomanip>
 #include <iostream>
@@ -49,7 +43,6 @@ Simulation::Simulation(const Simulation& other)
     , m_options(other.m_options)
     , m_distribution_handler(other.m_distribution_handler)
     , m_progress(other.m_progress)
-    , m_sim_elements(other.m_sim_elements)
     , m_instrument(other.m_instrument)
 {
     if (other.mP_background)
@@ -114,40 +107,6 @@ void Simulation::prepareSimulation()
     gsl_set_error_handler_off();
 }
 
-//! Run simulation with possible averaging over parameter distributions
-void Simulation::runSimulation()
-{
-    prepareSimulation();
-
-    size_t param_combinations = m_distribution_handler.getTotalNumberOfSamples();
-
-    m_progress.reset();
-    size_t prefactor = ( sample()->totalNofLayouts()>0 ? 1 : 0 )
-        + ( sample()->hasRoughness() ? 1 : 0 );
-    m_progress.setExpectedNTicks(prefactor*param_combinations*numberOfSimulationElements());
-
-    // no averaging needed:
-    if (param_combinations == 1) {
-        std::unique_ptr<ParameterPool> P_param_pool(createParameterTree());
-        m_distribution_handler.setParameterValues(P_param_pool.get(), 0);
-        runSingleSimulation();
-        transferResultsToIntensityMap();
-        return;
-    }
-
-    // average over parameter distributions:
-    initSimulationElementVector();
-    SimElementVector total_intensity = m_sim_elements;
-    std::unique_ptr<ParameterPool> P_param_pool(createParameterTree());
-    for (size_t index = 0; index < param_combinations; ++index) {
-        double weight = m_distribution_handler.setParameterValues(P_param_pool.get(), index);
-        runSingleSimulation();
-        addElementsWithWeight(total_intensity.begin(), weight);
-    }
-    m_sim_elements = std::move(total_intensity);
-    transferResultsToIntensityMap();
-}
-
 /* currently unused
 void Simulation::runOMPISimulation()
 {
@@ -207,152 +166,13 @@ void Simulation::addParameterDistribution(const ParameterDistribution& par_distr
     m_distribution_handler.addParameterDistribution(par_distr);
 }
 
-void Simulation::initSimulationElementVector()
-{
-    m_sim_elements = m_instrument.createSimulationElements();
-}
-
 void Simulation::updateSample()
 {
     m_sample_provider.updateSample();
-}
-
-//! Runs a single simulation with fixed parameter values.
-//! If desired, the simulation is run in several threads.
-void Simulation::runSingleSimulation()
-{
-    prepareSimulation();
-    initSimulationElementVector();
-
-    // restrict calculation to current batch
-    auto batch_start = getBatchStart(m_options.getNumberOfBatches(), m_options.getCurrentBatch());
-
-    auto batch_end = getBatchEnd(m_options.getNumberOfBatches(), m_options.getCurrentBatch());
-
-    if (m_options.getNumberOfThreads() == 1) {
-        // Single thread.
-        auto P_computation = generateSingleThreadedComputation(batch_start, batch_end);
-        P_computation->run(); // the work is done here
-        if (!P_computation->isCompleted()) {
-            std::string message = P_computation->errorMessage();
-            throw Exceptions::RuntimeErrorException("Simulation::runSimulation() -> Simulation has "
-                                                    "terminated unexpectedly with following error "
-                                                    "message.\n" + message);
-        }
-    } else {
-        // Multithreading.
-        std::vector<std::unique_ptr<std::thread>> threads;
-        std::vector<std::unique_ptr<IComputation>> computations;
-
-        // Initialize n computations.
-        auto total_batch_elements = batch_end - batch_start;
-        auto element_thread_step = total_batch_elements / m_options.getNumberOfThreads();
-        if (total_batch_elements % m_options.getNumberOfThreads()) // there is a remainder
-            ++element_thread_step;
-
-        for (int i_thread = 0; i_thread < m_options.getNumberOfThreads(); ++i_thread) {
-            if (i_thread*element_thread_step >= total_batch_elements)
-                break;
-            auto begin_it = batch_start + i_thread * element_thread_step;
-            auto end_thread_index = (i_thread + 1) * element_thread_step;
-            auto end_it = end_thread_index >= total_batch_elements ? batch_end
-                                                                   : batch_start + end_thread_index;
-            computations.push_back(generateSingleThreadedComputation(begin_it, end_it));
-        }
-
-        // Run simulations in n threads.
-        for (auto& comp: computations)
-            threads.emplace_back(new std::thread([&comp]() {comp->run();}));
-
-        // Wait for threads to complete.
-        for (auto& thread: threads) {
-            thread->join();
-        }
-
-        // Check successful completion.
-        std::vector<std::string> failure_messages;
-        for (auto& comp: computations) {
-            if (!comp->isCompleted())
-                failure_messages.push_back(comp->errorMessage());
-        }
-        if (failure_messages.size())
-            throw Exceptions::RuntimeErrorException(
-                "Simulation::runSingleSimulation() -> "
-                "At least one simulation thread has terminated unexpectedly.\n"
-                "Messages: " + StringUtils::join(failure_messages, " --- "));
-    }
-    normalize(batch_start, batch_end);
-    addBackGroundIntensity(batch_start, batch_end);
-}
-
-//! Normalize the detector counts to beam intensity, to solid angle, and to exposure angle.
-void Simulation::normalize(SimElementVector::iterator begin_it,
-                           SimElementVector::iterator end_it) const
-{
-    double beam_intensity = getBeamIntensity();
-    if (beam_intensity==0.0)
-        return; // no normalization when beam intensity is zero
-    for(auto it=begin_it; it!=end_it; ++it) {
-        double sin_alpha_i = std::abs(std::sin(it->getAlphaI()));
-        if (sin_alpha_i==0.0) sin_alpha_i = 1.0;
-        double solid_angle = it->getSolidAngle();
-        it->setIntensity(it->getIntensity()*beam_intensity*solid_angle/sin_alpha_i);
-    }
-}
-
-void Simulation::addBackGroundIntensity(SimElementVector::iterator begin_it,
-                                        SimElementVector::iterator end_it) const
-{
-    if (mP_background) {
-        mP_background->addBackGround(begin_it, end_it);
-    }
-}
-
-Simulation::SimElementVector::iterator Simulation::getBatchStart(int n_batches, int current_batch)
-{
-    imposeConsistencyOfBatchNumbers(n_batches, current_batch);
-    int total_size = static_cast<int>(m_sim_elements.size());
-    int size_per_batch = total_size/n_batches;
-    if (total_size%n_batches)
-        ++size_per_batch;
-    if (current_batch*size_per_batch >= total_size)
-        return m_sim_elements.end();
-    return m_sim_elements.begin() + current_batch*size_per_batch;
-}
-
-Simulation::SimElementVector::iterator Simulation::getBatchEnd(int n_batches, int current_batch)
-{
-    imposeConsistencyOfBatchNumbers(n_batches, current_batch);
-    int total_size = static_cast<int>(m_sim_elements.size());
-    int size_per_batch = total_size/n_batches;
-    if (total_size%n_batches)
-        ++size_per_batch;
-    int end_index = (current_batch + 1)*size_per_batch;
-    if (end_index >= total_size)
-        return m_sim_elements.end();
-    return m_sim_elements.begin() + end_index;
-}
-
-void Simulation::addElementsWithWeight(SimElementVector::iterator result, double weight) const
-{
-    for (auto it = m_sim_elements.cbegin(); it != m_sim_elements.cend(); ++it, ++result)
-        result->addIntensity(it->getIntensity() * weight);
 }
 
 void Simulation::initialize()
 {
     registerChild(&m_instrument);
     registerChild(&m_sample_provider);
-}
-
-void Simulation::imposeConsistencyOfBatchNumbers(int& n_batches, int& current_batch)
-{
-    if (n_batches < 2) {
-        n_batches = 1;
-        current_batch = 0;
-    }
-    if (current_batch >= n_batches)
-        throw Exceptions::ClassInitializationException(
-            "Simulation::imposeConsistencyOfBatchNumbers(): Batch number must be smaller than "
-            "number of batches.");
 }

--- a/Core/Simulation/Simulation.h
+++ b/Core/Simulation/Simulation.h
@@ -140,6 +140,8 @@ protected:
     std::unique_ptr<IBackground> mP_background;
 
 private:
+    //! Add element vector to element vector with weight
+    void addElementsWithWeight(SimElementVector::iterator result, double weight) const;
     void initialize();
     void imposeConsistencyOfBatchNumbers(int& n_batches, int& current_batch);
 };

--- a/Core/Simulation/Simulation.h
+++ b/Core/Simulation/Simulation.h
@@ -94,7 +94,10 @@ public:
 
     std::vector<const INode*> getChildren() const;
 
+    typedef std::vector<SimulationElement> SimElementVector;
+
 protected:
+
     Simulation(const Simulation& other);
 
     //! Initializes the vector of Simulation elements
@@ -109,30 +112,30 @@ protected:
 
     //! Generate a single threaded computation for a given range of SimulationElement's
     virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(
-            std::vector<SimulationElement>::iterator start,
-            std::vector<SimulationElement>::iterator end) = 0;
+            SimElementVector::iterator start,
+            SimElementVector::iterator end) = 0;
 
     void runSingleSimulation();
 
     virtual void updateIntensityMap() =0;
 
-    virtual void normalize(std::vector<SimulationElement>::iterator begin_it,
-                   std::vector<SimulationElement>::iterator end_it) const;
+    virtual void normalize(SimElementVector::iterator begin_it,
+                           SimElementVector::iterator end_it) const;
 
-    void addBackGroundIntensity(std::vector<SimulationElement>::iterator begin_it,
-                                std::vector<SimulationElement>::iterator end_it) const;
+    void addBackGroundIntensity(SimElementVector::iterator begin_it,
+                                SimElementVector::iterator end_it) const;
 
     //! Returns the start iterator of simulation elements for the current batch
-    std::vector<SimulationElement>::iterator getBatchStart(int n_batches, int current_batch);
+    SimElementVector::iterator getBatchStart(int n_batches, int current_batch);
 
     //! Returns the end iterator of simulation elements for the current batch
-    std::vector<SimulationElement>::iterator getBatchEnd(int n_batches, int current_batch);
+    SimElementVector::iterator getBatchEnd(int n_batches, int current_batch);
 
     SampleProvider m_sample_provider;
     SimulationOptions m_options;
     DistributionHandler m_distribution_handler;
     ProgressHandler m_progress;
-    std::vector<SimulationElement> m_sim_elements;
+    SimElementVector m_sim_elements;
     Instrument m_instrument;
     std::unique_ptr<IBackground> mP_background;
 

--- a/Core/Simulation/Simulation.h
+++ b/Core/Simulation/Simulation.h
@@ -25,11 +25,10 @@
 
 template<class T> class OutputData;
 class IBackground;
-class IComputation;
 class IMultiLayerBuilder;
 class MultiLayer;
 
-//! Pure virtual base class of OffSpecularSimulation, GISASSimulation and SpecularSimulation.
+//! Abstract base class for simulation implementations.
 //! Holds the common infrastructure to run a simulation: multithreading, batch processing,
 //! weighting over parameter distributions, ...
 //! @ingroup simulation
@@ -44,11 +43,8 @@ public:
 
     virtual Simulation* clone() const =0;
 
-    //! Put into a clean state for running a simulation
-    virtual void prepareSimulation();
-
     //! Run a simulation, possibly averaged over parameter distributions
-    void runSimulation();
+    virtual void runSimulation() = 0;
 
     void setInstrument(const Instrument& instrument);
     const Instrument& getInstrument() const { return m_instrument; }
@@ -94,56 +90,26 @@ public:
 
     std::vector<const INode*> getChildren() const;
 
-    typedef std::vector<SimulationElement> SimElementVector;
-
 protected:
-
     Simulation(const Simulation& other);
 
-    //! Initializes the vector of Simulation elements
-    virtual void initSimulationElementVector();
-
-    //! Creates the appropriate data structure (e.g. 2D intensity map) from the calculated
-    //! SimulationElement objects
-    virtual void transferResultsToIntensityMap() =0;
+    //! Put into a clean state for running a simulation
+    virtual void prepareSimulation();
 
     //! Update the sample by calling the sample builder, if present
     void updateSample();
 
-    //! Generate a single threaded computation for a given range of SimulationElement's
-    virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(
-            SimElementVector::iterator start,
-            SimElementVector::iterator end) = 0;
-
-    void runSingleSimulation();
-
     virtual void updateIntensityMap() =0;
-
-    virtual void normalize(SimElementVector::iterator begin_it,
-                           SimElementVector::iterator end_it) const;
-
-    void addBackGroundIntensity(SimElementVector::iterator begin_it,
-                                SimElementVector::iterator end_it) const;
-
-    //! Returns the start iterator of simulation elements for the current batch
-    SimElementVector::iterator getBatchStart(int n_batches, int current_batch);
-
-    //! Returns the end iterator of simulation elements for the current batch
-    SimElementVector::iterator getBatchEnd(int n_batches, int current_batch);
 
     SampleProvider m_sample_provider;
     SimulationOptions m_options;
     DistributionHandler m_distribution_handler;
     ProgressHandler m_progress;
-    SimElementVector m_sim_elements;
     Instrument m_instrument;
     std::unique_ptr<IBackground> mP_background;
 
 private:
-    //! Add element vector to element vector with weight
-    void addElementsWithWeight(SimElementVector::iterator result, double weight) const;
     void initialize();
-    void imposeConsistencyOfBatchNumbers(int& n_batches, int& current_batch);
 };
 
 #endif // SIMULATION_H

--- a/Core/Simulation/Simulation.h
+++ b/Core/Simulation/Simulation.h
@@ -85,7 +85,7 @@ public:
     const SimulationOptions& getOptions() const { return m_options; }
     SimulationOptions& getOptions() { return m_options; }
 
-    void subscribe(ProgressHandler::Callback_t inform) { m_progress.subscribe(inform); }
+    void subscribe(ProgressHandler::Callback_t inform) { m_progress->subscribe(inform); }
     void setTerminalProgressMonitor();
 
     std::vector<const INode*> getChildren() const;
@@ -104,7 +104,7 @@ protected:
     SampleProvider m_sample_provider;
     SimulationOptions m_options;
     DistributionHandler m_distribution_handler;
-    ProgressHandler m_progress;
+    std::shared_ptr<ProgressHandler> m_progress;
     Instrument m_instrument;
     std::unique_ptr<IBackground> mP_background;
 

--- a/Core/Simulation/SimulationImpl.cpp
+++ b/Core/Simulation/SimulationImpl.cpp
@@ -1,0 +1,183 @@
+#include "IBackground.h"
+#include "IComputation.h"
+#include "MultiLayer.h"
+#include "ParameterPool.h"
+#include "SimulationImpl.h"
+#include "StringUtils.h"
+#include <thread>
+
+SimulationImpl::SimulationImpl() = default;
+SimulationImpl::SimulationImpl(const SimulationImpl& other)
+    : Simulation(other)
+    , m_sim_elements(other.m_sim_elements)
+{}
+SimulationImpl::~SimulationImpl() = default;
+
+void SimulationImpl::runSimulation()
+{
+    prepareSimulation();
+
+    size_t param_combinations = m_distribution_handler.getTotalNumberOfSamples();
+
+    m_progress.reset();
+    size_t prefactor = ( sample()->totalNofLayouts() > 0 ? 1 : 0 )
+        + ( sample()->hasRoughness() ? 1 : 0 );
+    m_progress.setExpectedNTicks(prefactor*param_combinations*numberOfSimulationElements());
+
+    // no averaging needed:
+    if (param_combinations == 1) {
+        std::unique_ptr<ParameterPool> P_param_pool(createParameterTree());
+        m_distribution_handler.setParameterValues(P_param_pool.get(), 0);
+        runSingleSimulation();
+        transferResultsToIntensityMap();
+        return;
+    }
+
+    // average over parameter distributions:
+    initSimulationElementVector();
+    SimElementVector total_intensity = m_sim_elements;
+    std::unique_ptr<ParameterPool> P_param_pool(createParameterTree());
+    for (size_t index = 0; index < param_combinations; ++index) {
+        double weight = m_distribution_handler.setParameterValues(P_param_pool.get(), index);
+        runSingleSimulation();
+        addElementsWithWeight(total_intensity.begin(), weight);
+    }
+    m_sim_elements = std::move(total_intensity);
+    transferResultsToIntensityMap();
+}
+
+void SimulationImpl::initSimulationElementVector()
+{
+    m_sim_elements = m_instrument.createSimulationElements();
+}
+
+void SimulationImpl::runSingleSimulation()
+{
+    prepareSimulation();
+    initSimulationElementVector();
+
+    // restrict calculation to current batch
+    auto batch_start = getBatchStart(m_options.getNumberOfBatches(), m_options.getCurrentBatch());
+
+    auto batch_end = getBatchEnd(m_options.getNumberOfBatches(), m_options.getCurrentBatch());
+
+    if (m_options.getNumberOfThreads() == 1) {
+        // Single thread.
+        auto P_computation = generateSingleThreadedComputation(batch_start, batch_end);
+        P_computation->run(); // the work is done here
+        if (!P_computation->isCompleted()) {
+            std::string message = P_computation->errorMessage();
+            throw Exceptions::RuntimeErrorException("SimulationImpl::runSimulation() -> Simulation has "
+                                                    "terminated unexpectedly with following error "
+                                                    "message.\n" + message);
+        }
+    } else {
+        // Multithreading.
+        std::vector<std::unique_ptr<std::thread>> threads;
+        std::vector<std::unique_ptr<IComputation>> computations;
+
+        // Initialize n computations.
+        auto total_batch_elements = batch_end - batch_start;
+        auto element_thread_step = total_batch_elements / m_options.getNumberOfThreads();
+        if (total_batch_elements % m_options.getNumberOfThreads()) // there is a remainder
+            ++element_thread_step;
+
+        for (int i_thread = 0; i_thread < m_options.getNumberOfThreads(); ++i_thread) {
+            if (i_thread*element_thread_step >= total_batch_elements)
+                break;
+            auto begin_it = batch_start + i_thread * element_thread_step;
+            auto end_thread_index = (i_thread + 1) * element_thread_step;
+            auto end_it = end_thread_index >= total_batch_elements ? batch_end
+                                                                   : batch_start + end_thread_index;
+            computations.push_back(generateSingleThreadedComputation(begin_it, end_it));
+        }
+
+        // Run simulations in n threads.
+        for (auto& comp: computations)
+            threads.emplace_back(new std::thread([&comp]() {comp->run();}));
+
+        // Wait for threads to complete.
+        for (auto& thread: threads) {
+            thread->join();
+        }
+
+        // Check successful completion.
+        std::vector<std::string> failure_messages;
+        for (auto& comp: computations) {
+            if (!comp->isCompleted())
+                failure_messages.push_back(comp->errorMessage());
+        }
+        if (failure_messages.size())
+            throw Exceptions::RuntimeErrorException(
+                "Simulation::runSingleSimulation() -> "
+                "At least one simulation thread has terminated unexpectedly.\n"
+                "Messages: " + StringUtils::join(failure_messages, " --- "));
+    }
+    normalize(batch_start, batch_end);
+    addBackGroundIntensity(batch_start, batch_end);
+}
+
+void SimulationImpl::normalize(SimElementVector::iterator begin_it,
+                               SimElementVector::iterator end_it) const
+{
+    double beam_intensity = getBeamIntensity();
+    if (beam_intensity==0.0)
+        return; // no normalization when beam intensity is zero
+    for(auto it=begin_it; it!=end_it; ++it) {
+        double sin_alpha_i = std::abs(std::sin(it->getAlphaI()));
+        if (sin_alpha_i==0.0) sin_alpha_i = 1.0;
+        double solid_angle = it->getSolidAngle();
+        it->setIntensity(it->getIntensity()*beam_intensity*solid_angle/sin_alpha_i);
+    }
+}
+
+void SimulationImpl::addBackGroundIntensity(SimElementVector::iterator begin_it,
+                                            SimElementVector::iterator end_it) const
+{
+    if (mP_background)
+        mP_background->addBackGround(begin_it, end_it);
+}
+
+SimulationImpl::SimElementVector::iterator SimulationImpl::getBatchStart(int n_batches, int current_batch)
+{
+    imposeConsistencyOfBatchNumbers(n_batches, current_batch);
+    int total_size = static_cast<int>(m_sim_elements.size());
+    int size_per_batch = total_size/n_batches;
+    if (total_size%n_batches)
+        ++size_per_batch;
+    if (current_batch*size_per_batch >= total_size)
+        return m_sim_elements.end();
+    return m_sim_elements.begin() + current_batch*size_per_batch;
+}
+
+SimulationImpl::SimElementVector::iterator SimulationImpl::getBatchEnd(int n_batches, int current_batch)
+{
+    imposeConsistencyOfBatchNumbers(n_batches, current_batch);
+    int total_size = static_cast<int>(m_sim_elements.size());
+    int size_per_batch = total_size/n_batches;
+    if (total_size%n_batches)
+        ++size_per_batch;
+    int end_index = (current_batch + 1)*size_per_batch;
+    if (end_index >= total_size)
+        return m_sim_elements.end();
+    return m_sim_elements.begin() + end_index;
+}
+
+void SimulationImpl::addElementsWithWeight(SimElementVector::iterator result, double weight) const
+{
+    for (auto it = m_sim_elements.cbegin(); it != m_sim_elements.cend(); ++it, ++result)
+        result->addIntensity(it->getIntensity() * weight);
+}
+
+void SimulationImpl::imposeConsistencyOfBatchNumbers(int& n_batches, int& current_batch)
+{
+    if (n_batches < 2) {
+        n_batches = 1;
+        current_batch = 0;
+    }
+    if (current_batch >= n_batches)
+        throw Exceptions::ClassInitializationException(
+            "SimulationImpl::imposeConsistencyOfBatchNumbers(): Batch number must be smaller than "
+            "number of batches.");
+}
+

--- a/Core/Simulation/SimulationImpl.cpp
+++ b/Core/Simulation/SimulationImpl.cpp
@@ -48,7 +48,7 @@ void SimulationImpl::runSimulation()
 
 void SimulationImpl::initSimulationElementVector()
 {
-    m_sim_elements = m_instrument.createSimulationElements();
+    m_sim_elements = m_instrument.createSimulationElements<SimElementVector::value_type>();
 }
 
 void SimulationImpl::runSingleSimulation()

--- a/Core/Simulation/SimulationImpl.cpp
+++ b/Core/Simulation/SimulationImpl.cpp
@@ -19,10 +19,10 @@ void SimulationImpl::runSimulation()
 
     size_t param_combinations = m_distribution_handler.getTotalNumberOfSamples();
 
-    m_progress.reset();
+    m_progress->reset();
     size_t prefactor = ( sample()->totalNofLayouts() > 0 ? 1 : 0 )
         + ( sample()->hasRoughness() ? 1 : 0 );
-    m_progress.setExpectedNTicks(prefactor*param_combinations*numberOfSimulationElements());
+    m_progress->setExpectedNTicks(prefactor*param_combinations*numberOfSimulationElements());
 
     // no averaging needed:
     if (param_combinations == 1) {

--- a/Core/Simulation/SimulationImpl.h
+++ b/Core/Simulation/SimulationImpl.h
@@ -51,10 +51,6 @@ protected:
     generateSingleThreadedComputation(SimElementVector::iterator start,
                                       SimElementVector::iterator end) = 0;
 
-    //! Runs a single simulation with fixed parameter values.
-    //! If desired, the simulation is run in several threads.
-    void runSingleSimulation();
-
     //! Normalize the detector counts to beam intensity, to solid angle, and to exposure angle.
     virtual void normalize(SimElementVector::iterator begin_it,
                            SimElementVector::iterator end_it) const;
@@ -62,15 +58,19 @@ protected:
     void addBackGroundIntensity(SimElementVector::iterator begin_it,
                                 SimElementVector::iterator end_it) const;
 
+    SimElementVector m_sim_elements;
+
+private:
+    //! Runs a single simulation with fixed parameter values.
+    //! If desired, the simulation is run in several threads.
+    void runSingleSimulation();
+
     //! Returns the start iterator of simulation elements for the current batch
     SimElementVector::iterator getBatchStart(int n_batches, int current_batch);
 
     //! Returns the end iterator of simulation elements for the current batch
     SimElementVector::iterator getBatchEnd(int n_batches, int current_batch);
 
-    SimElementVector m_sim_elements;
-
-private:
     //! Add element vector to element vector with weight
     void addElementsWithWeight(SimElementVector::iterator result, double weight) const;
     void imposeConsistencyOfBatchNumbers(int& n_batches, int& current_batch);

--- a/Core/Simulation/SimulationImpl.h
+++ b/Core/Simulation/SimulationImpl.h
@@ -15,17 +15,19 @@
 #define SIMULATIONIMPL_H_
 
 #include "Simulation.h"
-#include "SimulationElement.h"
 
 class IComputation;
 
-//! Abstract Simulation implementation,
-//! base class for OffSpecularSimulation, GISASSimulation and SpecularSimulation.
+//! Template base class for OffSpecularSimulation, GISASSimulation and SpecularSimulation.
 //! Operates on the vector of simulation elements
 //! @ingroup simulation
 
+template<class SimElement>
 class BA_CORE_API_ SimulationImpl : public Simulation
 {
+protected:
+    typedef std::vector<SimElement> SimElementVector;
+
 public:
     using Simulation::Simulation;
     SimulationImpl(); // required until C++17
@@ -34,7 +36,7 @@ public:
     //! Run a simulation, possibly averaged over parameter distributions
     virtual void runSimulation() override final;
 
-    typedef std::vector<SimulationElement> SimElementVector;
+    typedef typename std::vector<SimElement>::iterator SimIter;
 
 protected:
     SimulationImpl(const SimulationImpl& other);
@@ -48,15 +50,12 @@ protected:
 
     //! Generate a single threaded computation for a given range of SimulationElement's
     virtual std::unique_ptr<IComputation>
-    generateSingleThreadedComputation(SimElementVector::iterator start,
-                                      SimElementVector::iterator end) = 0;
+    generateSingleThreadedComputation(SimIter start, SimIter end) = 0;
 
     //! Normalize the detector counts to beam intensity, to solid angle, and to exposure angle.
-    virtual void normalize(SimElementVector::iterator begin_it,
-                           SimElementVector::iterator end_it) const;
+    virtual void normalize(SimIter begin_it, SimIter end_it) const;
 
-    void addBackGroundIntensity(SimElementVector::iterator begin_it,
-                                SimElementVector::iterator end_it) const;
+    void addBackGroundIntensity(SimIter begin_it, SimIter end_it) const;
 
     SimElementVector m_sim_elements;
 
@@ -66,13 +65,13 @@ private:
     void runSingleSimulation();
 
     //! Returns the start iterator of simulation elements for the current batch
-    SimElementVector::iterator getBatchStart(int n_batches, int current_batch);
+    SimIter getBatchStart(int n_batches, int current_batch);
 
     //! Returns the end iterator of simulation elements for the current batch
-    SimElementVector::iterator getBatchEnd(int n_batches, int current_batch);
+    SimIter getBatchEnd(int n_batches, int current_batch);
 
     //! Add element vector to element vector with weight
-    void addElementsWithWeight(SimElementVector::iterator result, double weight) const;
+    void addElementsWithWeight(SimIter result, double weight) const;
     void imposeConsistencyOfBatchNumbers(int& n_batches, int& current_batch);
 };
 

--- a/Core/Simulation/SimulationImpl.h
+++ b/Core/Simulation/SimulationImpl.h
@@ -1,0 +1,79 @@
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Core/Simulation/SimulationImpl.h
+//! @brief     Defines class SimulationImpl.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#ifndef SIMULATIONIMPL_H_
+#define SIMULATIONIMPL_H_
+
+#include "Simulation.h"
+#include "SimulationElement.h"
+
+class IComputation;
+
+//! Abstract Simulation implementation,
+//! base class for OffSpecularSimulation, GISASSimulation and SpecularSimulation.
+//! Operates on the vector of simulation elements
+//! @ingroup simulation
+
+class BA_CORE_API_ SimulationImpl : public Simulation
+{
+public:
+    using Simulation::Simulation;
+    SimulationImpl(); // required until C++17
+    virtual ~SimulationImpl();
+
+    //! Run a simulation, possibly averaged over parameter distributions
+    virtual void runSimulation() override final;
+
+    typedef std::vector<SimulationElement> SimElementVector;
+
+protected:
+    SimulationImpl(const SimulationImpl& other);
+
+    //! Initializes the vector of Simulation elements
+    virtual void initSimulationElementVector();
+
+    //! Creates the appropriate data structure (e.g. 2D intensity map) from the calculated
+    //! SimulationElement objects
+    virtual void transferResultsToIntensityMap() = 0;
+
+    //! Generate a single threaded computation for a given range of SimulationElement's
+    virtual std::unique_ptr<IComputation>
+    generateSingleThreadedComputation(SimElementVector::iterator start,
+                                      SimElementVector::iterator end) = 0;
+
+    //! Runs a single simulation with fixed parameter values.
+    //! If desired, the simulation is run in several threads.
+    void runSingleSimulation();
+
+    //! Normalize the detector counts to beam intensity, to solid angle, and to exposure angle.
+    virtual void normalize(SimElementVector::iterator begin_it,
+                           SimElementVector::iterator end_it) const;
+
+    void addBackGroundIntensity(SimElementVector::iterator begin_it,
+                                SimElementVector::iterator end_it) const;
+
+    //! Returns the start iterator of simulation elements for the current batch
+    SimElementVector::iterator getBatchStart(int n_batches, int current_batch);
+
+    //! Returns the end iterator of simulation elements for the current batch
+    SimElementVector::iterator getBatchEnd(int n_batches, int current_batch);
+
+    SimElementVector m_sim_elements;
+
+private:
+    //! Add element vector to element vector with weight
+    void addElementsWithWeight(SimElementVector::iterator result, double weight) const;
+    void imposeConsistencyOfBatchNumbers(int& n_batches, int& current_batch);
+};
+
+#endif /* SIMULATIONIMPL_H_ */

--- a/Core/Simulation/SpecularSimulation.cpp
+++ b/Core/Simulation/SpecularSimulation.cpp
@@ -110,8 +110,9 @@ SpecularSimulation::getDataByAbsValue(size_t i_layer, DataGetter fn_ptr) const
     return output_ptr;
 }
 
-std::unique_ptr<IComputation> SpecularSimulation::generateSingleThreadedComputation(
-    std::vector<SimulationElement>::iterator start, std::vector<SimulationElement>::iterator end)
+std::unique_ptr<IComputation>
+SpecularSimulation::generateSingleThreadedComputation(SimElementVector::iterator start,
+                                                      SimElementVector::iterator end)
 {
     return std::make_unique<SpecularComputation>(*sample(), m_options, m_progress, start, end);
 }
@@ -150,8 +151,8 @@ std::vector<complex_t> SpecularSimulation::getScalarKz(size_t i_layer) const
     return getData(i_layer, &ILayerRTCoefficients::getScalarKz);
 }
 
-void SpecularSimulation::normalize(std::vector<SimulationElement>::iterator begin_it,
-                           std::vector<SimulationElement>::iterator end_it) const
+void SpecularSimulation::normalize(SimElementVector::iterator begin_it,
+                                   SimElementVector::iterator end_it) const
 {
     double beam_intensity = getBeamIntensity();
     if (beam_intensity==0.0)

--- a/Core/Simulation/SpecularSimulation.cpp
+++ b/Core/Simulation/SpecularSimulation.cpp
@@ -121,7 +121,7 @@ OutputData<double>* SpecularSimulation::getDetectorIntensity(AxesUnits units_typ
 {
     const size_t i_layer = 0; // detector intensity is proportional to reflectivity from the zeroth layer
     validityCheck(i_layer);
-    return m_instrument.createDetectorIntensity(m_sim_elements, units_type);
+    return m_instrument.createDetectorIntensity(m_sim_elements, units_type).release();
 }
 
 Histogram1D* SpecularSimulation::reflectivity() const

--- a/Core/Simulation/SpecularSimulation.cpp
+++ b/Core/Simulation/SpecularSimulation.cpp
@@ -18,7 +18,7 @@
 #include "SpecularMatrix.h"
 #include "MaterialUtils.h"
 #include "Histogram1D.h"
-#include "SimulationElement.h"
+#include "OutputData.h"
 #include "SpecularComputation.h"
 #include "SpecularDetector1D.h"
 
@@ -111,8 +111,7 @@ SpecularSimulation::getDataByAbsValue(size_t i_layer, DataGetter fn_ptr) const
 }
 
 std::unique_ptr<IComputation>
-SpecularSimulation::generateSingleThreadedComputation(SimElementVector::iterator start,
-                                                      SimElementVector::iterator end)
+SpecularSimulation::generateSingleThreadedComputation(SimIter start, SimIter end)
 {
     return std::make_unique<SpecularComputation>(*sample(), m_options, m_progress, start, end);
 }
@@ -151,8 +150,7 @@ std::vector<complex_t> SpecularSimulation::getScalarKz(size_t i_layer) const
     return getData(i_layer, &ILayerRTCoefficients::getScalarKz);
 }
 
-void SpecularSimulation::normalize(SimElementVector::iterator begin_it,
-                                   SimElementVector::iterator end_it) const
+void SpecularSimulation::normalize(SimIter begin_it, SimIter end_it) const
 {
     double beam_intensity = getBeamIntensity();
     if (beam_intensity==0.0)

--- a/Core/Simulation/SpecularSimulation.cpp
+++ b/Core/Simulation/SpecularSimulation.cpp
@@ -22,24 +22,25 @@
 #include "SpecularComputation.h"
 #include "SpecularDetector1D.h"
 
-SpecularSimulation::SpecularSimulation() : Simulation()
+SpecularSimulation::SpecularSimulation()
 {
     initialize();
 }
 
-SpecularSimulation::SpecularSimulation(const MultiLayer& sample) : Simulation(sample)
+SpecularSimulation::SpecularSimulation(const MultiLayer& sample)
+    : SimulationImpl(sample)
 {
     initialize();
 }
 
 SpecularSimulation::SpecularSimulation(const std::shared_ptr<IMultiLayerBuilder> sample_builder)
-    : Simulation(sample_builder)
+    : SimulationImpl(sample_builder)
 {
     initialize();
 }
 
 SpecularSimulation::SpecularSimulation(const SpecularSimulation& other)
-    : Simulation(other)
+    : SimulationImpl(other)
 {
     initialize();
 }

--- a/Core/Simulation/SpecularSimulation.h
+++ b/Core/Simulation/SpecularSimulation.h
@@ -15,21 +15,19 @@
 #ifndef SPECULARSIMULATION_H
 #define SPECULARSIMULATION_H
 
-#include "Simulation.h"
+#include "SimulationImpl.h"
 #include "ILayerRTCoefficients.h"
 #include "OutputData.h"
 
 class IAxis;
 class IComputation;
 class ISample;
-class IMultiLayerBuilder;
-class MultiLayer;
 class Histogram1D;
 
 //! Main class to run a specular simulation.
 //! @ingroup simulation
 
-class BA_CORE_API_ SpecularSimulation : public Simulation
+class BA_CORE_API_ SpecularSimulation : public SimulationImpl
 {
 public:
     SpecularSimulation();

--- a/Core/Simulation/SpecularSimulation.h
+++ b/Core/Simulation/SpecularSimulation.h
@@ -89,12 +89,12 @@ private:
 
     //! Generate a single threaded computation for a given range of SimulationElement's
     virtual std::unique_ptr<IComputation>
-    generateSingleThreadedComputation(std::vector<SimulationElement>::iterator start,
-                                      std::vector<SimulationElement>::iterator end) override;
+    generateSingleThreadedComputation(SimElementVector::iterator start,
+                                      SimElementVector::iterator end) override;
 
     //! Normalize the detector counts to beam intensity, to solid angle, and to exposure angle.
-    virtual void normalize(std::vector<SimulationElement>::iterator begin_it,
-                           std::vector<SimulationElement>::iterator end_it) const override;
+    virtual void normalize(SimElementVector::iterator begin_it,
+                           SimElementVector::iterator end_it) const override;
 
     //! Checks if simulation data is ready for retrieval
     void validityCheck(size_t i_layer) const;

--- a/Core/Simulation/SpecularSimulation.h
+++ b/Core/Simulation/SpecularSimulation.h
@@ -15,19 +15,20 @@
 #ifndef SPECULARSIMULATION_H
 #define SPECULARSIMULATION_H
 
-#include "SimulationImpl.h"
 #include "ILayerRTCoefficients.h"
-#include "OutputData.h"
+#include "SimulationImpl.h"
+#include "SimulationElement.h"
 
 class IAxis;
 class IComputation;
 class ISample;
 class Histogram1D;
+template <class T> class OutputData;
 
 //! Main class to run a specular simulation.
 //! @ingroup simulation
 
-class BA_CORE_API_ SpecularSimulation : public SimulationImpl
+class BA_CORE_API_ SpecularSimulation : public SimulationImpl<SimulationElement>
 {
 public:
     SpecularSimulation();
@@ -89,12 +90,10 @@ private:
 
     //! Generate a single threaded computation for a given range of SimulationElement's
     virtual std::unique_ptr<IComputation>
-    generateSingleThreadedComputation(SimElementVector::iterator start,
-                                      SimElementVector::iterator end) override;
+    generateSingleThreadedComputation(SimIter start, SimIter end) override;
 
     //! Normalize the detector counts to beam intensity, to solid angle, and to exposure angle.
-    virtual void normalize(SimElementVector::iterator begin_it,
-                           SimElementVector::iterator end_it) const override;
+    virtual void normalize(SimIter begin_it, SimIter end_it) const override;
 
     //! Checks if simulation data is ready for retrieval
     void validityCheck(size_t i_layer) const;

--- a/Tests/Functional/Core/CoreSpecial/DetectorTest.cpp
+++ b/Tests/Functional/Core/CoreSpecial/DetectorTest.cpp
@@ -118,7 +118,7 @@ void test_sim_elements(const IDetector& detector)
 {
     auto instr = createInstrument(detector);
     instr->initDetector();
-    instr->createSimulationElements();
+    instr->createSimulationElements<SimulationElement>();
 }
 
 void test_run_simulation(const IDetector& detector)

--- a/Tests/UnitTests/Core/Detector/RectangularDetectorTest.h
+++ b/Tests/UnitTests/Core/Detector/RectangularDetectorTest.h
@@ -2,6 +2,7 @@
 #include "Numeric.h"
 #include "RectangularDetector.h"
 #include "SimulationElement.h"
+#include "SimulationElementsProvider.h"
 #include "Units.h"
 #include "google_test.h"
 #include <iostream>
@@ -29,6 +30,17 @@ protected:
             std::cout << "lhs:" << lhs << " rhs:" << rhs << " diff:" << (lhs - rhs) << std::endl;
         }
         return is_equal;
+    }
+
+    std::vector<SimulationElement>
+    extractSimulationElements(std::unique_ptr<ISimulationElementsProvider> agent_base)
+    {
+        auto agent
+            = dynamic_cast<SimulationElementsProvider<SimulationElement>*>(agent_base.get());
+        std::vector<SimulationElement> result;
+        if (agent)
+            result = agent->releaseSimElements();
+        return result;
     }
 };
 
@@ -94,8 +106,8 @@ TEST_F(RectangularDetectorTest, PerpToSample)
     EXPECT_TRUE(kvector_t(distance, 0, 0) == det.getNormalVector());
     EXPECT_TRUE(kvector_t(0.0, -1.0, 0.0) == det.getDirectionVector());
 
-    std::vector<SimulationElement> elements
-        = det.createSimulationElements(simulation.getInstrument().getBeam());
+    std::vector<SimulationElement> elements = extractSimulationElements(
+        det.createSimulationElements(simulation.getInstrument().getBeam()));
     EXPECT_EQ(elements.size(), nbinsx * nbinsy);
 
     // lower left bin
@@ -151,8 +163,8 @@ TEST_F(RectangularDetectorTest, PerpToDirectBeam)
     EXPECT_TRUE(isEqual(normal, det.getNormalVector()));
     EXPECT_TRUE(kvector_t(0.0, -1.0, 0.0) == det.getDirectionVector());
 
-    std::vector<SimulationElement> elements
-        = det.createSimulationElements(simulation.getInstrument().getBeam());
+    std::vector<SimulationElement> elements = extractSimulationElements(
+        det.createSimulationElements(simulation.getInstrument().getBeam()));
     EXPECT_EQ(elements.size(), nbinsx * nbinsy);
 
     // lower left bin
@@ -195,8 +207,8 @@ TEST_F(RectangularDetectorTest, PerpToReflectedBeam)
     EXPECT_TRUE(kvector_t(0.0, -1.0, 0.0) == det.getDirectionVector());
 
     // checking detector elements
-    std::vector<SimulationElement> elements
-        = det.createSimulationElements(simulation.getInstrument().getBeam());
+    std::vector<SimulationElement> elements = extractSimulationElements(
+        det.createSimulationElements(simulation.getInstrument().getBeam()));
     EXPECT_EQ(elements.size(), nbinsx * nbinsy);
 
     double ds = v0 - dy / 2.;
@@ -253,8 +265,8 @@ TEST_F(RectangularDetectorTest, PerpToReflectedBeamDpos)
     EXPECT_EQ(v0, det.getV0());
 
     // checking detector elements
-    std::vector<SimulationElement> elements
-        = det.createSimulationElements(simulation.getInstrument().getBeam());
+    std::vector<SimulationElement> elements = extractSimulationElements(
+        det.createSimulationElements(simulation.getInstrument().getBeam()));
     EXPECT_EQ(elements.size(), nbinsx * nbinsy);
 
     double ds = v0 - dy / 2.;

--- a/Tests/UnitTests/Core/Detector/SpecularDetector1DTest.h
+++ b/Tests/UnitTests/Core/Detector/SpecularDetector1DTest.h
@@ -2,8 +2,9 @@
 #include "BornAgainNamespace.h"
 #include "FixedBinAxis.h"
 #include "OutputData.h"
-#include "SimulationElement.h"
 #include "SimulationArea.h"
+#include "SimulationElement.h"
+#include "SimulationElementsProvider.h"
 #include "SpecularDetector1D.h"
 #include "Units.h"
 #include "google_test.h"
@@ -13,6 +14,17 @@ class SpecularDetectorTest : public ::testing::Test
 {
 protected:
     ~SpecularDetectorTest();
+
+    std::vector<SimulationElement>
+    extractSimulationElements(std::unique_ptr<ISimulationElementsProvider> agent_base)
+    {
+        auto agent
+            = dynamic_cast<SimulationElementsProvider<SimulationElement>*>(agent_base.get());
+        std::vector<SimulationElement> result;
+        if (agent)
+            result = agent->releaseSimElements();
+        return result;
+    }
 };
 
 SpecularDetectorTest::~SpecularDetectorTest() = default;
@@ -111,7 +123,7 @@ TEST_F(SpecularDetectorTest, SimulationElements)
     Beam beam;
     beam.setCentralK(1.0 * Units::angstrom, 0.4 * Units::deg, 0.0);
 
-    auto sim_elements = detector.createSimulationElements(beam);
+    auto sim_elements = extractSimulationElements(detector.createSimulationElements(beam));
 
     EXPECT_EQ(5u, sim_elements.size());
 

--- a/Wrap/swig/libBornAgainCore.i
+++ b/Wrap/swig/libBornAgainCore.i
@@ -204,7 +204,6 @@
 #include "Rotations.h"
 #include "Rotations.h"
 #include "SampleBuilderFactory.h"
-#include "Simulation.h"
 #include "SimulationFactory.h"
 #include "SimulationOptions.h"
 #include "SlicedParticle.h"
@@ -357,6 +356,7 @@
 %include "FormFactorWeighted.h"
 
 %include "Simulation.h"
+%include "SimulationImpl.h"
 %include "SimulationOptions.h"
 %include "GISASSimulation.h"
 %include "IHistogram.h"

--- a/Wrap/swig/libBornAgainCore.i
+++ b/Wrap/swig/libBornAgainCore.i
@@ -357,6 +357,7 @@
 
 %include "Simulation.h"
 %include "SimulationImpl.h"
+%template(SimulationElementSimulationImpl) SimulationImpl<SimulationElement>;
 %include "SimulationOptions.h"
 %include "GISASSimulation.h"
 %include "IHistogram.h"

--- a/auto/Wrap/doxygen_core.i
+++ b/auto/Wrap/doxygen_core.i
@@ -13553,18 +13553,18 @@ C++ includes: SimulationFactory.h
 // File: classSimulationImpl.xml
 %feature("docstring") SimulationImpl "
 
-Abstract  Simulation implementation, base class for OffSpecularSimulation,  GISASSimulation and  SpecularSimulation. Operates on the vector of simulation elements
+Template base class for OffSpecularSimulation,  GISASSimulation and  SpecularSimulation. Operates on the vector of simulation elements
 
 C++ includes: SimulationImpl.h
 ";
 
-%feature("docstring")  SimulationImpl::SimulationImpl "SimulationImpl::SimulationImpl()
+%feature("docstring")  SimulationImpl::SimulationImpl "SimulationImpl< SimElement >::SimulationImpl()
 ";
 
-%feature("docstring")  SimulationImpl::~SimulationImpl "SimulationImpl::~SimulationImpl()
+%feature("docstring")  SimulationImpl::~SimulationImpl "SimulationImpl< SimElement >::~SimulationImpl()
 ";
 
-%feature("docstring")  SimulationImpl::runSimulation "void SimulationImpl::runSimulation() override final
+%feature("docstring")  SimulationImpl::runSimulation "void SimulationImpl< SimElement >::runSimulation() override final
 
 Run a simulation, possibly averaged over parameter distributions. 
 ";
@@ -13776,9 +13776,6 @@ C++ includes: SpecularComputation.h
 ";
 
 %feature("docstring")  SpecularComputation::~SpecularComputation "SpecularComputation::~SpecularComputation()
-";
-
-%feature("docstring")  SpecularComputation::run "void SpecularComputation::run()
 ";
 
 

--- a/auto/Wrap/doxygen_core.i
+++ b/auto/Wrap/doxygen_core.i
@@ -193,7 +193,7 @@ Calls the  INodeVisitor's visit method.
 // File: classBasicVector3D.xml
 %feature("docstring") BasicVector3D "
 
-Three-dimensional vector template, for use with integer, double, or complex components.
+Forked from CLHEP/Geometry by E. Chernyaev Evgueni.Tcherniaev@cern.ch, then reworked beyond recongnition. Removed split of point and vector semantics. Transforms are relegated to a separate class  Transform3D. Three-dimensional vector template, for use with integer, double, or complex components.
 
 C++ includes: BasicVector3D.h
 ";
@@ -610,21 +610,21 @@ C++ includes: BoxCompositionBuilder.h
 ";
 
 
-// File: structIntegratorReal_1_1CallBackHolder.xml
-%feature("docstring") IntegratorReal::CallBackHolder "
-
-structure holding the object and possible extra parameters
-
-C++ includes: IntegratorReal.h
-";
-
-
 // File: structIntegratorMCMiser_1_1CallBackHolder.xml
 %feature("docstring") IntegratorMCMiser::CallBackHolder "
 
 structure holding the object and possible extra parameters
 
 C++ includes: IntegratorMCMiser.h
+";
+
+
+// File: structIntegratorReal_1_1CallBackHolder.xml
+%feature("docstring") IntegratorReal::CallBackHolder "
+
+structure holding the object and possible extra parameters
+
+C++ includes: IntegratorReal.h
 ";
 
 
@@ -744,9 +744,6 @@ C++ includes: ConstantBackground.h
 %feature("docstring")  ConstantBackground::accept "void ConstantBackground::accept(INodeVisitor *visitor) const override
 
 Calls the  INodeVisitor's visit method. 
-";
-
-%feature("docstring")  ConstantBackground::addBackGround "void ConstantBackground::addBackGround(std::vector< SimulationElement >::iterator start, std::vector< SimulationElement >::iterator end) const override final
 ";
 
 
@@ -1170,7 +1167,7 @@ C++ includes: DelayedProgressCounter.h
 %feature("docstring")  DelayedProgressCounter::~DelayedProgressCounter "DelayedProgressCounter::~DelayedProgressCounter()
 ";
 
-%feature("docstring")  DelayedProgressCounter::stepProgress "void DelayedProgressCounter::stepProgress(ProgressHandler *progress)
+%feature("docstring")  DelayedProgressCounter::stepProgress "void DelayedProgressCounter::stepProgress(ProgressHandler &progress)
 
 Increments inner counter; at regular intervals updates progress handler. 
 ";
@@ -1683,18 +1680,15 @@ Calls the  INodeVisitor's visit method.
 
 Performs a single-threaded DWBA computation with given sample and simulation parameters.
 
-Controlled by the multi-threading machinery in  Simulation::runSingleSimulation().
+Controlled by the multi-threading machinery in Simulation::runSingleSimulation().
 
 C++ includes: DWBAComputation.h
 ";
 
-%feature("docstring")  DWBAComputation::DWBAComputation "DWBAComputation::DWBAComputation(const MultiLayer &multilayer, const SimulationOptions &options, ProgressHandler &progress, const std::vector< SimulationElement >::iterator &begin_it, const std::vector< SimulationElement >::iterator &end_it)
+%feature("docstring")  DWBAComputation::DWBAComputation "DWBAComputation::DWBAComputation(const MultiLayer &multilayer, const SimulationOptions &options, const std::shared_ptr< ProgressHandler > &progress, Iter begin_it, Iter end_it)
 ";
 
 %feature("docstring")  DWBAComputation::~DWBAComputation "DWBAComputation::~DWBAComputation()
-";
-
-%feature("docstring")  DWBAComputation::run "void DWBAComputation::run()
 ";
 
 
@@ -5567,7 +5561,7 @@ C++ includes: GISASSimulation.h
 %feature("docstring")  GISASSimulation::GISASSimulation "GISASSimulation::GISASSimulation(const std::shared_ptr< IMultiLayerBuilder > p_sample_builder)
 ";
 
-%feature("docstring")  GISASSimulation::~GISASSimulation "GISASSimulation::~GISASSimulation() final
+%feature("docstring")  GISASSimulation::~GISASSimulation "GISASSimulation::~GISASSimulation()
 ";
 
 %feature("docstring")  GISASSimulation::clone "GISASSimulation* GISASSimulation::clone() const
@@ -6177,7 +6171,7 @@ C++ includes: IBackground.h
 %feature("docstring")  IBackground::clone "virtual IBackground* IBackground::clone() const =0
 ";
 
-%feature("docstring")  IBackground::addBackGround "virtual void IBackground::addBackGround(std::vector< SimulationElement >::iterator start, std::vector< SimulationElement >::iterator end) const =0
+%feature("docstring")  IBackground::addBackGround "void IBackground::addBackGround(Iter start, Iter end) const
 ";
 
 
@@ -6306,12 +6300,12 @@ Creates region information with volumetric densities instead of absolute volume 
 
 Interface for a single-threaded computation with given range of SimulationElements and  ProgressHandler.
 
-Controlled by the multi-threading machinery in  Simulation::runSingleSimulation().
+Controlled by the multi-threading machinery in Simulation::runSingleSimulation().
 
 C++ includes: IComputation.h
 ";
 
-%feature("docstring")  IComputation::IComputation "IComputation::IComputation(const SimulationOptions &options, ProgressHandler &progress, const std::vector< SimulationElement >::iterator &start, const std::vector< SimulationElement >::iterator &end, const MultiLayer &sample)
+%feature("docstring")  IComputation::IComputation "IComputation::IComputation(const SimulationOptions &options, const std::shared_ptr< ProgressHandler > &progress, std::unique_ptr< IIterHandler > iter_holder, const MultiLayer &sample)
 ";
 
 %feature("docstring")  IComputation::~IComputation "IComputation::~IComputation()
@@ -6341,9 +6335,9 @@ C++ includes: IComputationTerm.h
 %feature("docstring")  IComputationTerm::~IComputationTerm "IComputationTerm::~IComputationTerm()
 ";
 
-%feature("docstring")  IComputationTerm::eval "virtual void IComputationTerm::eval(ProgressHandler *progress, const std::vector< SimulationElement >::iterator &begin_it, const std::vector< SimulationElement >::iterator &end_it) const =0
+%feature("docstring")  IComputationTerm::eval "void IComputationTerm::eval(Iter begin, Iter end) const
 
-Calculate scattering intensity for each  SimulationElement returns false if nothing needed to be calculated 
+Calculates scattering intensity for a range of simulation elements. 
 ";
 
 %feature("docstring")  IComputationTerm::mergeRegionMap "void IComputationTerm::mergeRegionMap(std::map< size_t, std::vector< HomogeneousRegion >> &region_map) const
@@ -6446,9 +6440,14 @@ Returns a pointer to detector resolution object.
 Returns empty detector map in given axes units. 
 ";
 
-%feature("docstring")  IDetector::createSimulationElements "virtual std::vector<SimulationElement> IDetector::createSimulationElements(const Beam &beam)=0
+%feature("docstring")  IDetector::createSimulationElements "virtual std::unique_ptr<ISimulationElementsProvider> IDetector::createSimulationElements(const Beam &beam)=0
 
 Create a vector of  SimulationElement objects according to the detector and its mask. 
+";
+
+%feature("docstring")  IDetector::createDetectorIntensity "std::unique_ptr<OutputData<double> > IDetector::createDetectorIntensity(const std::vector< SimElement > &elements, const Beam &beam, AxesUnits units_type=AxesUnits::DEFAULT) const
+
+Returns new intensity map with detector resolution applied and axes in requested units. 
 ";
 
 %feature("docstring")  IDetector::regionOfInterest "virtual const RegionOfInterest* IDetector::regionOfInterest() const =0
@@ -6469,11 +6468,6 @@ Returns detection properties.
 %feature("docstring")  IDetector::initOutputData "void IDetector::initOutputData(OutputData< double > &data) const
 
 Inits axes of  OutputData to match the detector and sets values to zero. 
-";
-
-%feature("docstring")  IDetector::createDetectorIntensity "OutputData< double > * IDetector::createDetectorIntensity(const std::vector< SimulationElement > &elements, const Beam &beam, AxesUnits units_type=AxesUnits::DEFAULT) const
-
-Returns new intensity map with detector resolution applied and axes in requested units. 
 ";
 
 %feature("docstring")  IDetector::defaultAxesUnits "virtual AxesUnits IDetector::defaultAxesUnits() const
@@ -6553,7 +6547,7 @@ The value of mask
 Put the mask for all detector channels (i.e. exclude whole detector from the analysis) 
 ";
 
-%feature("docstring")  IDetector2D::createSimulationElements "std::vector< SimulationElement > IDetector2D::createSimulationElements(const Beam &beam) override
+%feature("docstring")  IDetector2D::createSimulationElements "std::unique_ptr< ISimulationElementsProvider > IDetector2D::createSimulationElements(const Beam &beam) override
 
 Create a vector of  SimulationElement objects according to the detector and its mask. 
 ";
@@ -7556,6 +7550,9 @@ Calculates the intensity for scalar particles/interactions.
 ";
 
 
+// File: structIComputation_1_1IIterHandler.xml
+
+
 // File: classILayerRTCoefficients.xml
 %feature("docstring") ILayerRTCoefficients "
 
@@ -8259,24 +8256,24 @@ Sets the polarization analyzer characteristics of the detector.
 apply the detector resolution to the given intensity map 
 ";
 
-%feature("docstring")  Instrument::createDetectorIntensity "OutputData< double > * Instrument::createDetectorIntensity(const std::vector< SimulationElement > &elements, AxesUnits units=AxesUnits::DEFAULT) const
+%feature("docstring")  Instrument::createDetectorIntensity "std::unique_ptr<OutputData<double> > Instrument::createDetectorIntensity(const std::vector< SimElement > &elements, AxesUnits units=AxesUnits::DEFAULT) const
 
 Returns new intensity map with detector resolution applied and axes in requested units. 
 ";
 
-%feature("docstring")  Instrument::createIntensityData "Histogram2D * Instrument::createIntensityData(const std::vector< SimulationElement > &elements, AxesUnits units_type=AxesUnits::DEFAULT) const
+%feature("docstring")  Instrument::createIntensityData "Histogram2D* Instrument::createIntensityData(const std::vector< SimElement > &elements, AxesUnits units_type=AxesUnits::DEFAULT) const
 
 Returns histogram representing intensity map in requested axes units. 
+";
+
+%feature("docstring")  Instrument::createSimulationElements "std::vector<SimElement> Instrument::createSimulationElements()
+
+Create a vector of  SimulationElement objects according to the beam, detector and its mask. 
 ";
 
 %feature("docstring")  Instrument::createDetectorMap "OutputData< double > * Instrument::createDetectorMap(AxesUnits units=AxesUnits::DEFAULT) const
 
 Returns empty detector map in given axes units. 
-";
-
-%feature("docstring")  Instrument::createSimulationElements "std::vector< SimulationElement > Instrument::createSimulationElements()
-
-Create a vector of  SimulationElement objects according to the beam, detector and its mask. 
 ";
 
 %feature("docstring")  Instrument::initDetector "void Instrument::initDetector()
@@ -9354,6 +9351,18 @@ Returns true if area defined by two bins is inside or on border of polygon (more
 ";
 
 
+// File: classISimulationElementsProvider.xml
+%feature("docstring") ISimulationElementsProvider "
+
+Base for  SimulationElementsProvider.
+
+C++ includes: SimulationElementsProvider.h
+";
+
+%feature("docstring")  ISimulationElementsProvider::~ISimulationElementsProvider "virtual ISimulationElementsProvider::~ISimulationElementsProvider()=default
+";
+
+
 // File: classISingleton.xml
 %feature("docstring") ISingleton "
 
@@ -9473,6 +9482,9 @@ C++ includes: NodeIterator.h
 
 %feature("docstring")  IteratorState::next "void IteratorState::next()
 ";
+
+
+// File: structIComputation_1_1IterHandler.xml
 
 
 // File: classLabelMap.xml
@@ -10712,7 +10724,7 @@ C++ includes: OffSpecSimulation.h
 %feature("docstring")  OffSpecSimulation::OffSpecSimulation "OffSpecSimulation::OffSpecSimulation(const std::shared_ptr< class IMultiLayerBuilder > p_sample_builder)
 ";
 
-%feature("docstring")  OffSpecSimulation::~OffSpecSimulation "OffSpecSimulation::~OffSpecSimulation() final
+%feature("docstring")  OffSpecSimulation::~OffSpecSimulation "OffSpecSimulation::~OffSpecSimulation()
 ";
 
 %feature("docstring")  OffSpecSimulation::clone "OffSpecSimulation* OffSpecSimulation::clone() const
@@ -11838,12 +11850,7 @@ Computes the scattering contribution from one particle layout. Used by  DWBAComp
 C++ includes: ParticleLayoutComputation.h
 ";
 
-%feature("docstring")  ParticleLayoutComputation::ParticleLayoutComputation "ParticleLayoutComputation::ParticleLayoutComputation(const MultiLayer *p_multilayer, const IFresnelMap *p_fresnel_map, const ILayout *p_layout, size_t layer_index, const SimulationOptions &options, bool polarized)
-";
-
-%feature("docstring")  ParticleLayoutComputation::eval "void ParticleLayoutComputation::eval(ProgressHandler *progress, const std::vector< SimulationElement >::iterator &begin_it, const std::vector< SimulationElement >::iterator &end_it) const override
-
-Computes scattering intensity for given range of simulation elements. 
+%feature("docstring")  ParticleLayoutComputation::ParticleLayoutComputation "ParticleLayoutComputation::ParticleLayoutComputation(const MultiLayer *p_multilayer, const IFresnelMap *p_fresnel_map, const ILayout *p_layout, size_t layer_index, const SimulationOptions &options, bool polarized, const std::shared_ptr< ProgressHandler > &progress)
 ";
 
 
@@ -11871,9 +11878,6 @@ C++ includes: PoissonNoiseBackground.h
 %feature("docstring")  PoissonNoiseBackground::accept "void PoissonNoiseBackground::accept(INodeVisitor *visitor) const override
 
 Calls the  INodeVisitor's visit method. 
-";
-
-%feature("docstring")  PoissonNoiseBackground::addBackGround "void PoissonNoiseBackground::addBackGround(std::vector< SimulationElement >::iterator start, std::vector< SimulationElement >::iterator end) const override final
 ";
 
 
@@ -12807,15 +12811,10 @@ Computes the diffuse reflection from the rough interfaces of a multilayer. Used 
 C++ includes: RoughMultiLayerComputation.h
 ";
 
-%feature("docstring")  RoughMultiLayerComputation::RoughMultiLayerComputation "RoughMultiLayerComputation::RoughMultiLayerComputation(const MultiLayer *p_multi_layer, const IFresnelMap *p_fresnel_map)
+%feature("docstring")  RoughMultiLayerComputation::RoughMultiLayerComputation "RoughMultiLayerComputation::RoughMultiLayerComputation(const MultiLayer *p_multi_layer, const IFresnelMap *p_fresnel_map, const std::shared_ptr< ProgressHandler > &progress)
 ";
 
 %feature("docstring")  RoughMultiLayerComputation::~RoughMultiLayerComputation "RoughMultiLayerComputation::~RoughMultiLayerComputation()
-";
-
-%feature("docstring")  RoughMultiLayerComputation::eval "void RoughMultiLayerComputation::eval(ProgressHandler *progress, const std::vector< SimulationElement >::iterator &begin_it, const std::vector< SimulationElement >::iterator &end_it) const override
-
-Calculate scattering intensity for each  SimulationElement returns false if nothing needed to be calculated 
 ";
 
 
@@ -13239,7 +13238,7 @@ C++ includes: ISelectionRule.h
 // File: classSimulation.xml
 %feature("docstring") Simulation "
 
-Pure virtual base class of OffSpecularSimulation,  GISASSimulation and  SpecularSimulation. Holds the common infrastructure to run a simulation: multithreading, batch processing, weighting over parameter distributions, ...
+Abstract base class for simulation implementations. Holds the common infrastructure to run a simulation: multithreading, batch processing, weighting over parameter distributions, ...
 
 C++ includes: Simulation.h
 ";
@@ -13259,16 +13258,9 @@ C++ includes: Simulation.h
 %feature("docstring")  Simulation::clone "virtual Simulation* Simulation::clone() const =0
 ";
 
-%feature("docstring")  Simulation::prepareSimulation "void Simulation::prepareSimulation()
+%feature("docstring")  Simulation::runSimulation "virtual void Simulation::runSimulation()=0
 
-Put into a clean state for running a simulation. 
-";
-
-%feature("docstring")  Simulation::runSimulation "void Simulation::runSimulation()
-
-Run a simulation, possibly averaged over parameter distributions.
-
-Run simulation with possible averaging over parameter distributions. 
+Run a simulation, possibly averaged over parameter distributions. 
 ";
 
 %feature("docstring")  Simulation::setInstrument "void Simulation::setInstrument(const Instrument &instrument)
@@ -13531,6 +13523,21 @@ Turn on specular data.
 ";
 
 
+// File: classSimulationElementsProvider.xml
+%feature("docstring") SimulationElementsProvider "
+
+SimulationElementsProvider template, gives access to created simulation elements Intended to be used in detectors for access to simulation elements of different types
+
+C++ includes: SimulationElementsProvider.h
+";
+
+%feature("docstring")  SimulationElementsProvider::getElementVector "std::vector<SimElement>& SimulationElementsProvider< SimElement >::getElementVector()
+";
+
+%feature("docstring")  SimulationElementsProvider::releaseSimElements "std::vector<SimElement> SimulationElementsProvider< SimElement >::releaseSimElements()
+";
+
+
 // File: classSimulationFactory.xml
 %feature("docstring") SimulationFactory "
 
@@ -13540,6 +13547,26 @@ C++ includes: SimulationFactory.h
 ";
 
 %feature("docstring")  SimulationFactory::SimulationFactory "SimulationFactory::SimulationFactory()
+";
+
+
+// File: classSimulationImpl.xml
+%feature("docstring") SimulationImpl "
+
+Abstract  Simulation implementation, base class for OffSpecularSimulation,  GISASSimulation and  SpecularSimulation. Operates on the vector of simulation elements
+
+C++ includes: SimulationImpl.h
+";
+
+%feature("docstring")  SimulationImpl::SimulationImpl "SimulationImpl::SimulationImpl()
+";
+
+%feature("docstring")  SimulationImpl::~SimulationImpl "SimulationImpl::~SimulationImpl()
+";
+
+%feature("docstring")  SimulationImpl::runSimulation "void SimulationImpl::runSimulation() override final
+
+Run a simulation, possibly averaged over parameter distributions. 
 ";
 
 
@@ -13740,12 +13767,12 @@ C++ includes: IFormFactorBorn.h
 
 Performs a single-threaded specular computation with given sample.
 
-Controlled by the multi-threading machinery in  Simulation::runSingleSimulation().
+Controlled by the multi-threading machinery in Simulation::runSingleSimulation().
 
 C++ includes: SpecularComputation.h
 ";
 
-%feature("docstring")  SpecularComputation::SpecularComputation "SpecularComputation::SpecularComputation(const MultiLayer &multilayer, const SimulationOptions &options, ProgressHandler &progress, const std::vector< SimulationElement >::iterator &begin_it, const std::vector< SimulationElement >::iterator &end_it)
+%feature("docstring")  SpecularComputation::SpecularComputation "SpecularComputation::SpecularComputation(const MultiLayer &multilayer, const SimulationOptions &options, const std::shared_ptr< ProgressHandler > &progress, Iter begin_it, Iter end_it)
 ";
 
 %feature("docstring")  SpecularComputation::~SpecularComputation "SpecularComputation::~SpecularComputation()
@@ -13764,11 +13791,6 @@ C++ includes: SpecularComputationTerm.h
 ";
 
 %feature("docstring")  SpecularComputationTerm::SpecularComputationTerm "SpecularComputationTerm::SpecularComputationTerm(const MultiLayer *p_multi_layer, const IFresnelMap *p_fresnel_map)
-";
-
-%feature("docstring")  SpecularComputationTerm::eval "void SpecularComputationTerm::eval(ProgressHandler *progress, const std::vector< SimulationElement >::iterator &begin_it, const std::vector< SimulationElement >::iterator &end_it) const override
-
-Calculate scattering intensity for each  SimulationElement returns false if nothing needed to be calculated 
 ";
 
 
@@ -13820,7 +13842,7 @@ Calls the  INodeVisitor's visit method.
 Returns detector masks container. 
 ";
 
-%feature("docstring")  SpecularDetector1D::createSimulationElements "std::vector< SimulationElement > SpecularDetector1D::createSimulationElements(const Beam &beam) override
+%feature("docstring")  SpecularDetector1D::createSimulationElements "std::unique_ptr< ISimulationElementsProvider > SpecularDetector1D::createSimulationElements(const Beam &beam) override
 
 Create a vector of  SimulationElement objects according to the detector and its mask. 
 ";
@@ -14694,58 +14716,58 @@ C++ includes: ZLimits.h
 // File: namespace_0D263.xml
 
 
-// File: namespace_0D271.xml
+// File: namespace_0D272.xml
 
 
-// File: namespace_0D292.xml
+// File: namespace_0D293.xml
 
 
-// File: namespace_0D296.xml
+// File: namespace_0D297.xml
 
 
-// File: namespace_0D298.xml
+// File: namespace_0D299.xml
 
 
-// File: namespace_0D300.xml
+// File: namespace_0D301.xml
 
 
-// File: namespace_0D308.xml
+// File: namespace_0D309.xml
 
 
-// File: namespace_0D323.xml
+// File: namespace_0D324.xml
 
 
-// File: namespace_0D331.xml
+// File: namespace_0D332.xml
 
 
-// File: namespace_0D337.xml
+// File: namespace_0D338.xml
 
 
-// File: namespace_0D340.xml
+// File: namespace_0D341.xml
 
 
-// File: namespace_0D342.xml
+// File: namespace_0D343.xml
 
 
-// File: namespace_0D363.xml
+// File: namespace_0D364.xml
 
 
-// File: namespace_0D372.xml
+// File: namespace_0D373.xml
 
 
-// File: namespace_0D405.xml
+// File: namespace_0D406.xml
 
 
-// File: namespace_0D412.xml
+// File: namespace_0D413.xml
 
 
-// File: namespace_0D450.xml
+// File: namespace_0D451.xml
 
 
-// File: namespace_0D522.xml
+// File: namespace_0D525.xml
 
 
-// File: namespace_0D544.xml
+// File: namespace_0D547.xml
 
 
 // File: namespace_0D73.xml
@@ -15654,17 +15676,9 @@ global helper function for comparison of axes
 
 
 // File: SimulationElement_8cpp.xml
-%feature("docstring")  addElementsWithWeight "void addElementsWithWeight(std::vector< SimulationElement >::const_iterator first, std::vector< SimulationElement >::const_iterator last, std::vector< SimulationElement >::iterator result, double weight)
-
-Add element vector to element vector with weight. 
-";
 
 
 // File: SimulationElement_8h.xml
-%feature("docstring")  addElementsWithWeight "void addElementsWithWeight(std::vector< SimulationElement >::const_iterator first, std::vector< SimulationElement >::const_iterator last, std::vector< SimulationElement >::iterator result, double weight)
-
-Add element vector to element vector with weight. 
-";
 
 
 // File: VariableBinAxis_8cpp.xml
@@ -16334,6 +16348,9 @@ make Swappable
 
 
 // File: SimulationAreaIterator_8h.xml
+
+
+// File: SimulationElementsProvider_8h.xml
 
 
 // File: SpecularDetector1D_8cpp.xml
@@ -17111,6 +17128,12 @@ Generate vertices of centered ellipse with given semi-axes at height z.
 
 
 // File: Simulation_8h.xml
+
+
+// File: SimulationImpl_8cpp.xml
+
+
+// File: SimulationImpl_8h.xml
 
 
 // File: SpecularSimulation_8cpp.xml

--- a/auto/Wrap/libBornAgainCore.py
+++ b/auto/Wrap/libBornAgainCore.py
@@ -2626,7 +2626,7 @@ class kvector_t(_object):
     """
 
 
-    Three-dimensional vector template, for use with integer, double, or complex components.
+    Forked from CLHEP/Geometry by E. Chernyaev Evgueni.Tcherniaev@cern.ch, then reworked beyond recongnition. Removed split of point and vector semantics. Transforms are relegated to a separate class  Transform3D. Three-dimensional vector template, for use with integer, double, or complex components.
 
     C++ includes: BasicVector3D.h
 
@@ -3138,7 +3138,7 @@ class cvector_t(_object):
     """
 
 
-    Three-dimensional vector template, for use with integer, double, or complex components.
+    Forked from CLHEP/Geometry by E. Chernyaev Evgueni.Tcherniaev@cern.ch, then reworked beyond recongnition. Removed split of point and vector semantics. Transforms are relegated to a separate class  Transform3D. Three-dimensional vector template, for use with integer, double, or complex components.
 
     C++ includes: BasicVector3D.h
 
@@ -16179,7 +16179,7 @@ class Simulation(ICloneable, INode):
     """
 
 
-    Pure virtual base class of OffSpecularSimulation,  GISASSimulation and  SpecularSimulation. Holds the common infrastructure to run a simulation: multithreading, batch processing, weighting over parameter distributions, ...
+    Abstract base class for simulation implementations. Holds the common infrastructure to run a simulation: multithreading, batch processing, weighting over parameter distributions, ...
 
     C++ includes: Simulation.h
 
@@ -16210,27 +16210,13 @@ class Simulation(ICloneable, INode):
         return _libBornAgainCore.Simulation_clone(self)
 
 
-    def prepareSimulation(self):
-        """
-        prepareSimulation(Simulation self)
-
-        void Simulation::prepareSimulation()
-
-        Put into a clean state for running a simulation. 
-
-        """
-        return _libBornAgainCore.Simulation_prepareSimulation(self)
-
-
     def runSimulation(self):
         """
         runSimulation(Simulation self)
 
-        void Simulation::runSimulation()
+        virtual void Simulation::runSimulation()=0
 
-        Run a simulation, possibly averaged over parameter distributions.
-
-        Run simulation with possible averaging over parameter distributions. 
+        Run a simulation, possibly averaged over parameter distributions. 
 
         """
         return _libBornAgainCore.Simulation_runSimulation(self)
@@ -16481,6 +16467,45 @@ class Simulation(ICloneable, INode):
 Simulation_swigregister = _libBornAgainCore.Simulation_swigregister
 Simulation_swigregister(Simulation)
 
+class SimulationImpl(Simulation):
+    """
+
+
+    Abstract  Simulation implementation, base class for OffSpecularSimulation,  GISASSimulation and  SpecularSimulation. Operates on the vector of simulation elements
+
+    C++ includes: SimulationImpl.h
+
+    """
+
+    __swig_setmethods__ = {}
+    for _s in [Simulation]:
+        __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
+    __setattr__ = lambda self, name, value: _swig_setattr(self, SimulationImpl, name, value)
+    __swig_getmethods__ = {}
+    for _s in [Simulation]:
+        __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
+    __getattr__ = lambda self, name: _swig_getattr(self, SimulationImpl, name)
+
+    def __init__(self, *args, **kwargs):
+        raise AttributeError("No constructor defined - class is abstract")
+    __repr__ = _swig_repr
+    __swig_destroy__ = _libBornAgainCore.delete_SimulationImpl
+    __del__ = lambda self: None
+
+    def runSimulation(self):
+        """
+        runSimulation(SimulationImpl self)
+
+        void SimulationImpl::runSimulation() override final
+
+        Run a simulation, possibly averaged over parameter distributions. 
+
+        """
+        return _libBornAgainCore.SimulationImpl_runSimulation(self)
+
+SimulationImpl_swigregister = _libBornAgainCore.SimulationImpl_swigregister
+SimulationImpl_swigregister(SimulationImpl)
+
 class SimulationOptions(_object):
     """
 
@@ -16675,7 +16700,7 @@ class SimulationOptions(_object):
 SimulationOptions_swigregister = _libBornAgainCore.SimulationOptions_swigregister
 SimulationOptions_swigregister(SimulationOptions)
 
-class GISASSimulation(Simulation):
+class GISASSimulation(SimulationImpl):
     """
 
 
@@ -16686,11 +16711,11 @@ class GISASSimulation(Simulation):
     """
 
     __swig_setmethods__ = {}
-    for _s in [Simulation]:
+    for _s in [SimulationImpl]:
         __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
     __setattr__ = lambda self, name, value: _swig_setattr(self, GISASSimulation, name, value)
     __swig_getmethods__ = {}
-    for _s in [Simulation]:
+    for _s in [SimulationImpl]:
         __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
     __getattr__ = lambda self, name: _swig_getattr(self, GISASSimulation, name)
     __repr__ = _swig_repr
@@ -17853,16 +17878,6 @@ class IBackground(ICloneable, INode):
         """
         return _libBornAgainCore.IBackground_clone(self)
 
-
-    def addBackGround(self, start, end):
-        """
-        addBackGround(IBackground self, std::vector< SimulationElement,std::allocator< SimulationElement > >::iterator start, std::vector< SimulationElement,std::allocator< SimulationElement > >::iterator end)
-
-        virtual void IBackground::addBackGround(std::vector< SimulationElement >::iterator start, std::vector< SimulationElement >::iterator end) const =0
-
-        """
-        return _libBornAgainCore.IBackground_addBackGround(self, start, end)
-
 IBackground_swigregister = _libBornAgainCore.IBackground_swigregister
 IBackground_swigregister(IBackground)
 
@@ -17931,16 +17946,6 @@ class ConstantBackground(IBackground):
 
         """
         return _libBornAgainCore.ConstantBackground_accept(self, visitor)
-
-
-    def addBackGround(self, start, end):
-        """
-        addBackGround(ConstantBackground self, std::vector< SimulationElement,std::allocator< SimulationElement > >::iterator start, std::vector< SimulationElement,std::allocator< SimulationElement > >::iterator end)
-
-        void ConstantBackground::addBackGround(std::vector< SimulationElement >::iterator start, std::vector< SimulationElement >::iterator end) const override final
-
-        """
-        return _libBornAgainCore.ConstantBackground_addBackGround(self, start, end)
 
 ConstantBackground_swigregister = _libBornAgainCore.ConstantBackground_swigregister
 ConstantBackground_swigregister(ConstantBackground)
@@ -18215,19 +18220,6 @@ class IDetector(ICloneable, INode):
 
         """
         return _libBornAgainCore.IDetector_initOutputData(self, data)
-
-
-    def createDetectorIntensity(self, *args):
-        """
-        createDetectorIntensity(IDetector self, std::vector< SimulationElement,std::allocator< SimulationElement > > const & elements, Beam beam, AxesUnits units_type) -> IntensityData
-        createDetectorIntensity(IDetector self, std::vector< SimulationElement,std::allocator< SimulationElement > > const & elements, Beam beam) -> IntensityData
-
-        OutputData< double > * IDetector::createDetectorIntensity(const std::vector< SimulationElement > &elements, const Beam &beam, AxesUnits units_type=AxesUnits::DEFAULT) const
-
-        Returns new intensity map with detector resolution applied and axes in requested units. 
-
-        """
-        return _libBornAgainCore.IDetector_createDetectorIntensity(self, *args)
 
 
     def defaultAxesUnits(self):
@@ -20073,45 +20065,6 @@ class Instrument(INode):
 
         """
         return _libBornAgainCore.Instrument_applyDetectorResolution(self, p_intensity_map)
-
-
-    def createDetectorIntensity(self, *args):
-        """
-        createDetectorIntensity(Instrument self, std::vector< SimulationElement,std::allocator< SimulationElement > > const & elements, AxesUnits units) -> IntensityData
-        createDetectorIntensity(Instrument self, std::vector< SimulationElement,std::allocator< SimulationElement > > const & elements) -> IntensityData
-
-        OutputData< double > * Instrument::createDetectorIntensity(const std::vector< SimulationElement > &elements, AxesUnits units=AxesUnits::DEFAULT) const
-
-        Returns new intensity map with detector resolution applied and axes in requested units. 
-
-        """
-        return _libBornAgainCore.Instrument_createDetectorIntensity(self, *args)
-
-
-    def createIntensityData(self, *args):
-        """
-        createIntensityData(Instrument self, std::vector< SimulationElement,std::allocator< SimulationElement > > const & elements, AxesUnits units_type) -> Histogram2D
-        createIntensityData(Instrument self, std::vector< SimulationElement,std::allocator< SimulationElement > > const & elements) -> Histogram2D
-
-        Histogram2D * Instrument::createIntensityData(const std::vector< SimulationElement > &elements, AxesUnits units_type=AxesUnits::DEFAULT) const
-
-        Returns histogram representing intensity map in requested axes units. 
-
-        """
-        return _libBornAgainCore.Instrument_createIntensityData(self, *args)
-
-
-    def createDetectorMap(self, *args):
-        """
-        createDetectorMap(Instrument self, AxesUnits units) -> IntensityData
-        createDetectorMap(Instrument self) -> IntensityData
-
-        OutputData< double > * Instrument::createDetectorMap(AxesUnits units=AxesUnits::DEFAULT) const
-
-        Returns empty detector map in given axes units. 
-
-        """
-        return _libBornAgainCore.Instrument_createDetectorMap(self, *args)
 
 
     def initDetector(self):
@@ -23514,7 +23467,7 @@ class MultiLayer(ISample):
 MultiLayer_swigregister = _libBornAgainCore.MultiLayer_swigregister
 MultiLayer_swigregister(MultiLayer)
 
-class OffSpecSimulation(Simulation):
+class OffSpecSimulation(SimulationImpl):
     """
 
 
@@ -23525,11 +23478,11 @@ class OffSpecSimulation(Simulation):
     """
 
     __swig_setmethods__ = {}
-    for _s in [Simulation]:
+    for _s in [SimulationImpl]:
         __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
     __setattr__ = lambda self, name, value: _swig_setattr(self, OffSpecSimulation, name, value)
     __swig_getmethods__ = {}
-    for _s in [Simulation]:
+    for _s in [SimulationImpl]:
         __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
     __getattr__ = lambda self, name: _swig_getattr(self, OffSpecSimulation, name)
     __repr__ = _swig_repr
@@ -25470,16 +25423,6 @@ class PoissonNoiseBackground(IBackground):
         """
         return _libBornAgainCore.PoissonNoiseBackground_accept(self, visitor)
 
-
-    def addBackGround(self, start, end):
-        """
-        addBackGround(PoissonNoiseBackground self, std::vector< SimulationElement,std::allocator< SimulationElement > >::iterator start, std::vector< SimulationElement,std::allocator< SimulationElement > >::iterator end)
-
-        void PoissonNoiseBackground::addBackGround(std::vector< SimulationElement >::iterator start, std::vector< SimulationElement >::iterator end) const override final
-
-        """
-        return _libBornAgainCore.PoissonNoiseBackground_addBackGround(self, start, end)
-
 PoissonNoiseBackground_swigregister = _libBornAgainCore.PoissonNoiseBackground_swigregister
 PoissonNoiseBackground_swigregister(PoissonNoiseBackground)
 
@@ -26279,7 +26222,7 @@ class ResolutionFunction2DGaussian(IResolutionFunction2D):
 ResolutionFunction2DGaussian_swigregister = _libBornAgainCore.ResolutionFunction2DGaussian_swigregister
 ResolutionFunction2DGaussian_swigregister(ResolutionFunction2DGaussian)
 
-class SpecularSimulation(Simulation):
+class SpecularSimulation(SimulationImpl):
     """
 
 
@@ -26290,11 +26233,11 @@ class SpecularSimulation(Simulation):
     """
 
     __swig_setmethods__ = {}
-    for _s in [Simulation]:
+    for _s in [SimulationImpl]:
         __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
     __setattr__ = lambda self, name, value: _swig_setattr(self, SpecularSimulation, name, value)
     __swig_getmethods__ = {}
-    for _s in [Simulation]:
+    for _s in [SimulationImpl]:
         __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
     __getattr__ = lambda self, name: _swig_getattr(self, SpecularSimulation, name)
     __repr__ = _swig_repr

--- a/auto/Wrap/libBornAgainCore.py
+++ b/auto/Wrap/libBornAgainCore.py
@@ -16467,11 +16467,11 @@ class Simulation(ICloneable, INode):
 Simulation_swigregister = _libBornAgainCore.Simulation_swigregister
 Simulation_swigregister(Simulation)
 
-class SimulationImpl(Simulation):
+class SimulationElementSimulationImpl(Simulation):
     """
 
 
-    Abstract  Simulation implementation, base class for OffSpecularSimulation,  GISASSimulation and  SpecularSimulation. Operates on the vector of simulation elements
+    Template base class for OffSpecularSimulation,  GISASSimulation and  SpecularSimulation. Operates on the vector of simulation elements
 
     C++ includes: SimulationImpl.h
 
@@ -16480,31 +16480,31 @@ class SimulationImpl(Simulation):
     __swig_setmethods__ = {}
     for _s in [Simulation]:
         __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
-    __setattr__ = lambda self, name, value: _swig_setattr(self, SimulationImpl, name, value)
+    __setattr__ = lambda self, name, value: _swig_setattr(self, SimulationElementSimulationImpl, name, value)
     __swig_getmethods__ = {}
     for _s in [Simulation]:
         __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
-    __getattr__ = lambda self, name: _swig_getattr(self, SimulationImpl, name)
+    __getattr__ = lambda self, name: _swig_getattr(self, SimulationElementSimulationImpl, name)
 
     def __init__(self, *args, **kwargs):
         raise AttributeError("No constructor defined - class is abstract")
     __repr__ = _swig_repr
-    __swig_destroy__ = _libBornAgainCore.delete_SimulationImpl
+    __swig_destroy__ = _libBornAgainCore.delete_SimulationElementSimulationImpl
     __del__ = lambda self: None
 
     def runSimulation(self):
         """
-        runSimulation(SimulationImpl self)
+        runSimulation(SimulationElementSimulationImpl self)
 
-        void SimulationImpl::runSimulation() override final
+        void SimulationImpl< SimElement >::runSimulation() override final
 
         Run a simulation, possibly averaged over parameter distributions. 
 
         """
-        return _libBornAgainCore.SimulationImpl_runSimulation(self)
+        return _libBornAgainCore.SimulationElementSimulationImpl_runSimulation(self)
 
-SimulationImpl_swigregister = _libBornAgainCore.SimulationImpl_swigregister
-SimulationImpl_swigregister(SimulationImpl)
+SimulationElementSimulationImpl_swigregister = _libBornAgainCore.SimulationElementSimulationImpl_swigregister
+SimulationElementSimulationImpl_swigregister(SimulationElementSimulationImpl)
 
 class SimulationOptions(_object):
     """
@@ -16700,7 +16700,7 @@ class SimulationOptions(_object):
 SimulationOptions_swigregister = _libBornAgainCore.SimulationOptions_swigregister
 SimulationOptions_swigregister(SimulationOptions)
 
-class GISASSimulation(SimulationImpl):
+class GISASSimulation(SimulationElementSimulationImpl):
     """
 
 
@@ -16711,11 +16711,11 @@ class GISASSimulation(SimulationImpl):
     """
 
     __swig_setmethods__ = {}
-    for _s in [SimulationImpl]:
+    for _s in [SimulationElementSimulationImpl]:
         __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
     __setattr__ = lambda self, name, value: _swig_setattr(self, GISASSimulation, name, value)
     __swig_getmethods__ = {}
-    for _s in [SimulationImpl]:
+    for _s in [SimulationElementSimulationImpl]:
         __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
     __getattr__ = lambda self, name: _swig_getattr(self, GISASSimulation, name)
     __repr__ = _swig_repr
@@ -23467,7 +23467,7 @@ class MultiLayer(ISample):
 MultiLayer_swigregister = _libBornAgainCore.MultiLayer_swigregister
 MultiLayer_swigregister(MultiLayer)
 
-class OffSpecSimulation(SimulationImpl):
+class OffSpecSimulation(SimulationElementSimulationImpl):
     """
 
 
@@ -23478,11 +23478,11 @@ class OffSpecSimulation(SimulationImpl):
     """
 
     __swig_setmethods__ = {}
-    for _s in [SimulationImpl]:
+    for _s in [SimulationElementSimulationImpl]:
         __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
     __setattr__ = lambda self, name, value: _swig_setattr(self, OffSpecSimulation, name, value)
     __swig_getmethods__ = {}
-    for _s in [SimulationImpl]:
+    for _s in [SimulationElementSimulationImpl]:
         __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
     __getattr__ = lambda self, name: _swig_getattr(self, OffSpecSimulation, name)
     __repr__ = _swig_repr
@@ -26222,7 +26222,7 @@ class ResolutionFunction2DGaussian(IResolutionFunction2D):
 ResolutionFunction2DGaussian_swigregister = _libBornAgainCore.ResolutionFunction2DGaussian_swigregister
 ResolutionFunction2DGaussian_swigregister(ResolutionFunction2DGaussian)
 
-class SpecularSimulation(SimulationImpl):
+class SpecularSimulation(SimulationElementSimulationImpl):
     """
 
 
@@ -26233,11 +26233,11 @@ class SpecularSimulation(SimulationImpl):
     """
 
     __swig_setmethods__ = {}
-    for _s in [SimulationImpl]:
+    for _s in [SimulationElementSimulationImpl]:
         __swig_setmethods__.update(getattr(_s, '__swig_setmethods__', {}))
     __setattr__ = lambda self, name, value: _swig_setattr(self, SpecularSimulation, name, value)
     __swig_getmethods__ = {}
-    for _s in [SimulationImpl]:
+    for _s in [SimulationElementSimulationImpl]:
         __swig_getmethods__.update(getattr(_s, '__swig_getmethods__', {}))
     __getattr__ = lambda self, name: _swig_getattr(self, SpecularSimulation, name)
     __repr__ = _swig_repr


### PR DESCRIPTION
In the future it will help to use several different types of simulation elements without performance decrease