### PR TITLE
Redmine issue 1917: removed simulation elements from Simulation class

### DIFF
--- a/Core/Binning/SimulationElement.cpp
+++ b/Core/Binning/SimulationElement.cpp
@@ -147,14 +147,6 @@ double SimulationElement::getSolidAngle() const {
     return mP_pixel->getSolidAngle();
 }
 
-void addElementsWithWeight(std::vector<SimulationElement>::const_iterator first,
-                           std::vector<SimulationElement>::const_iterator last,
-                           std::vector<SimulationElement>::iterator result, double weight)
-{
-    for (std::vector<SimulationElement>::const_iterator it = first; it != last; ++it, ++result)
-        result->addIntensity(it->getIntensity() * weight);
-}
-
 SpecularData::SpecularData() : data_type_used(DATA_TYPE::Invalid) {}
 
 SpecularData::SpecularData(MatrixVector coefficients)

--- a/Core/Binning/SimulationElement.h
+++ b/Core/Binning/SimulationElement.h
@@ -106,13 +106,6 @@ private:
     std::unique_ptr<SpecularData> m_specular_data;
 };
 
-
-//! Add element vector to element vector with weight
-void addElementsWithWeight(std::vector<SimulationElement>::const_iterator first,
-                           std::vector<SimulationElement>::const_iterator last,
-                           std::vector<SimulationElement>::iterator result,
-                           double weight);
-
 //! Helper class for SimulationElement to carry specular information
 //! @ingroup simulation
 

--- a/Core/Computation/ConstantBackground.cpp
+++ b/Core/Computation/ConstantBackground.cpp
@@ -31,12 +31,9 @@ ConstantBackground* ConstantBackground::clone() const
     return new ConstantBackground(m_background_value);
 }
 
-void ConstantBackground::addBackGround(std::vector<SimulationElement>::iterator start,
-                                       std::vector<SimulationElement>::iterator end) const
+void ConstantBackground::addBackGround(SimulationElement& element) const
 {
-    for (auto it=start; it != end; it++) {
-        it->addIntensity(m_background_value);
-    }
+    element.addIntensity(m_background_value);
 }
 
 void ConstantBackground::init_parameters()

--- a/Core/Computation/ConstantBackground.h
+++ b/Core/Computation/ConstantBackground.h
@@ -32,8 +32,7 @@ public:
 
     void accept(INodeVisitor* visitor) const override { visitor->visit(this); }
 
-    void addBackGround(std::vector<SimulationElement>::iterator start,
-                       std::vector<SimulationElement>::iterator end) const override final;
+    virtual void addBackGround(SimulationElement& element) const override final;
 private:
     void init_parameters();
 

--- a/Core/Computation/DWBAComputation.cpp
+++ b/Core/Computation/DWBAComputation.cpp
@@ -32,8 +32,8 @@ static_assert(std::is_copy_assignable<DWBAComputation>::value == false,
 
 DWBAComputation::DWBAComputation(const MultiLayer& multilayer, const SimulationOptions& options,
                                  ProgressHandler& progress,
-                                 const std::vector<SimulationElement>::iterator& begin_it,
-                                 const std::vector<SimulationElement>::iterator& end_it)
+                                 std::vector<SimulationElement>::iterator begin_it,
+                                 std::vector<SimulationElement>::iterator end_it)
     : IComputation(options, progress, begin_it, end_it, multilayer)
 {
     mP_fresnel_map = createFresnelMap();

--- a/Core/Computation/DWBAComputation.h
+++ b/Core/Computation/DWBAComputation.h
@@ -33,12 +33,10 @@ class IComputationTerm;
 class DWBAComputation : public IComputation
 {
 public:
-    DWBAComputation(
-        const MultiLayer& multilayer,
-        const SimulationOptions& options,
-        ProgressHandler& progress,
-        const std::vector<SimulationElement>::iterator& begin_it,
-        const std::vector<SimulationElement>::iterator& end_it);
+    DWBAComputation(const MultiLayer& multilayer, const SimulationOptions& options,
+                    ProgressHandler& progress,
+                    std::vector<SimulationElement>::iterator begin_it,
+                    std::vector<SimulationElement>::iterator end_it);
     ~DWBAComputation();
 
     void run();

--- a/Core/Computation/IBackground.cpp
+++ b/Core/Computation/IBackground.cpp
@@ -13,5 +13,13 @@
 // ************************************************************************** //
 
 #include "IBackground.h"
+#include "SimulationElement.h"
 
 IBackground::~IBackground() {}
+
+void IBackground::addBackGround(std::vector<SimulationElement>::iterator start,
+                       std::vector<SimulationElement>::iterator end) const
+{
+    for (auto it = start; it != end; it++)
+        addBackGround(*it);
+}

--- a/Core/Computation/IBackground.h
+++ b/Core/Computation/IBackground.h
@@ -31,8 +31,10 @@ public:
     virtual ~IBackground();
     virtual IBackground* clone() const =0;
 
-    virtual void addBackGround(std::vector<SimulationElement>::iterator start,
-                               std::vector<SimulationElement>::iterator end) const =0;
+    void addBackGround(std::vector<SimulationElement>::iterator start,
+                       std::vector<SimulationElement>::iterator end) const;
+
+    virtual void addBackGround(SimulationElement& element) const = 0;
 };
 
 #endif // IBACKGROUND_H

--- a/Core/Computation/IComputation.cpp
+++ b/Core/Computation/IComputation.cpp
@@ -18,13 +18,11 @@
 #include "SimulationElement.h"
 
 IComputation::IComputation(const SimulationOptions& options, ProgressHandler& progress,
-                           const std::vector<SimulationElement>::iterator& start,
-                           const std::vector<SimulationElement>::iterator& end,
-                           const MultiLayer& sample)
+                           std::vector<SimulationElement>::iterator start,
+                           std::vector<SimulationElement>::iterator end, const MultiLayer& sample)
     : m_sim_options(options)
     , m_progress(&progress)
-    , m_begin_it(start)
-    , m_end_it(end)
+    , m_begin_it(start), m_end_it(end)
     , mP_multi_layer(sample.cloneSliced(options.useAvgMaterials()))
 {
     if (!mP_multi_layer)

--- a/Core/Computation/IComputation.h
+++ b/Core/Computation/IComputation.h
@@ -35,8 +35,8 @@ class IComputation
 {
 public:
     IComputation(const SimulationOptions& options, ProgressHandler& progress,
-                 const std::vector<SimulationElement>::iterator& start,
-                 const std::vector<SimulationElement>::iterator& end,
+                 std::vector<SimulationElement>::iterator start,
+                 std::vector<SimulationElement>::iterator end,
                  const MultiLayer& sample);
     virtual ~IComputation();
 

--- a/Core/Computation/PoissonNoiseBackground.cpp
+++ b/Core/Computation/PoissonNoiseBackground.cpp
@@ -28,11 +28,8 @@ PoissonNoiseBackground*PoissonNoiseBackground::clone() const
     return new PoissonNoiseBackground;
 }
 
-void PoissonNoiseBackground::addBackGround(std::vector<SimulationElement>::iterator start,
-                                           std::vector<SimulationElement>::iterator end) const
+void PoissonNoiseBackground::addBackGround(SimulationElement& element) const
 {
-    for (auto it=start; it != end; it++) {
-        auto intensity = it->getIntensity();
-        it->setIntensity(MathFunctions::GeneratePoissonRandom(intensity));
-    }
+    const double intensity = element.getIntensity();
+    element.setIntensity(MathFunctions::GeneratePoissonRandom(intensity));
 }

--- a/Core/Computation/PoissonNoiseBackground.h
+++ b/Core/Computation/PoissonNoiseBackground.h
@@ -30,8 +30,7 @@ public:
 
     void accept(INodeVisitor* visitor) const override { visitor->visit(this); }
 
-    void addBackGround(std::vector<SimulationElement>::iterator start,
-                       std::vector<SimulationElement>::iterator end) const override final;
+    virtual void addBackGround(SimulationElement& element) const override final;
 };
 
 #endif // POISSONNOISEBACKGROUND_H

--- a/Core/Computation/SpecularComputation.cpp
+++ b/Core/Computation/SpecularComputation.cpp
@@ -30,8 +30,8 @@ static_assert(std::is_copy_assignable<SpecularComputation>::value == false,
 SpecularComputation::SpecularComputation(const MultiLayer& multilayer,
                                          const SimulationOptions& options,
                                          ProgressHandler& progress,
-                                         const std::vector<SimulationElement>::iterator& begin_it,
-                                         const std::vector<SimulationElement>::iterator& end_it)
+                                         std::vector<SimulationElement>::iterator begin_it,
+                                         std::vector<SimulationElement>::iterator end_it)
     : IComputation(options, progress, begin_it, end_it, multilayer)
 {
     mP_fresnel_map = createFresnelMap();

--- a/Core/Computation/SpecularComputation.h
+++ b/Core/Computation/SpecularComputation.h
@@ -36,8 +36,8 @@ class SpecularComputation : public IComputation
 public:
     SpecularComputation(const MultiLayer& multilayer, const SimulationOptions& options,
                         ProgressHandler& progress,
-                        const std::vector<SimulationElement>::iterator& begin_it,
-                        const std::vector<SimulationElement>::iterator& end_it);
+                        std::vector<SimulationElement>::iterator begin_it,
+                        std::vector<SimulationElement>::iterator end_it);
     virtual ~SpecularComputation();
 
     void run();

--- a/Core/Parametrization/SimulationOptions.cpp
+++ b/Core/Parametrization/SimulationOptions.cpp
@@ -13,6 +13,7 @@
 // ************************************************************************** //
 
 #include "SimulationOptions.h"
+#include <stdexcept>
 #include <thread>
 
 SimulationOptions::SimulationOptions()
@@ -37,9 +38,9 @@ void SimulationOptions::setMonteCarloIntegration(bool flag, size_t mc_points)
 
 void SimulationOptions::setNumberOfThreads(int nthreads)
 {
-    if(nthreads == 0)
-        m_thread_info.n_threads = (int)std::thread::hardware_concurrency();
-    else if(nthreads > 0)
+    if (nthreads == 0)
+        m_thread_info.n_threads = getHardwareConcurrency();
+    else if (nthreads > 0)
         m_thread_info.n_threads = nthreads;
     else
         m_thread_info.n_threads = 1;
@@ -47,21 +48,33 @@ void SimulationOptions::setNumberOfThreads(int nthreads)
 
 int SimulationOptions::getNumberOfThreads() const
 {
+    if (m_thread_info.n_threads < 1)
+        throw std::runtime_error("Error in SimulationOptions::getNumberOfThreads: Number of "
+                                 "threads must be positive");
     return m_thread_info.n_threads;
 }
 
 void SimulationOptions::setNumberOfBatches(int nbatches)
 {
+    if (nbatches < 1)
+        throw std::runtime_error("Error in SimulationOptions::setNumberOfBatches: Number of "
+                                 "batches must be positive");
     m_thread_info.n_batches = nbatches;
 }
 
 int SimulationOptions::getNumberOfBatches() const
 {
+    if (m_thread_info.n_batches < 1)
+        throw std::runtime_error("Error in SimulationOptions::getNumberOfBatches: Number of "
+                                 "batches must be positive");
     return m_thread_info.n_batches;
 }
 
 int SimulationOptions::getCurrentBatch() const
 {
+    if (m_thread_info.current_batch >= getNumberOfBatches())
+        throw std::runtime_error(
+            "Error in SimulationOptions::getCurrentBatch: current batch is out of range");
     return m_thread_info.current_batch;
 }
 

--- a/Core/Parametrization/SimulationOptions.cpp
+++ b/Core/Parametrization/SimulationOptions.cpp
@@ -46,7 +46,7 @@ void SimulationOptions::setNumberOfThreads(int nthreads)
         m_thread_info.n_threads = 1;
 }
 
-int SimulationOptions::getNumberOfThreads() const
+unsigned SimulationOptions::getNumberOfThreads() const
 {
     if (m_thread_info.n_threads < 1)
         throw std::runtime_error("Error in SimulationOptions::getNumberOfThreads: Number of "
@@ -62,7 +62,7 @@ void SimulationOptions::setNumberOfBatches(int nbatches)
     m_thread_info.n_batches = nbatches;
 }
 
-int SimulationOptions::getNumberOfBatches() const
+unsigned SimulationOptions::getNumberOfBatches() const
 {
     if (m_thread_info.n_batches < 1)
         throw std::runtime_error("Error in SimulationOptions::getNumberOfBatches: Number of "
@@ -70,7 +70,7 @@ int SimulationOptions::getNumberOfBatches() const
     return m_thread_info.n_batches;
 }
 
-int SimulationOptions::getCurrentBatch() const
+unsigned SimulationOptions::getCurrentBatch() const
 {
     if (m_thread_info.current_batch >= getNumberOfBatches())
         throw std::runtime_error(
@@ -78,7 +78,7 @@ int SimulationOptions::getCurrentBatch() const
     return m_thread_info.current_batch;
 }
 
-int SimulationOptions::getHardwareConcurrency() const
+unsigned SimulationOptions::getHardwareConcurrency() const
 {
-    return (int)std::thread::hardware_concurrency();
+    return std::thread::hardware_concurrency();
 }

--- a/Core/Parametrization/SimulationOptions.h
+++ b/Core/Parametrization/SimulationOptions.h
@@ -41,19 +41,19 @@ public:
     //! the hardware)
     void setNumberOfThreads(int nthreads);
 
-    int getNumberOfThreads() const;
+    unsigned getNumberOfThreads() const;
 
     //! @brief Sets number of batches to split
     void setNumberOfBatches(int nbatches);
 
-    int getNumberOfBatches() const;
+    unsigned getNumberOfBatches() const;
 
-    int getCurrentBatch() const;
+    unsigned getCurrentBatch() const;
 
     //! @brief Sets the batch and thread information to be used
     void setThreadInfo(const ThreadInfo& thread_info) { m_thread_info = thread_info; }
 
-    int getHardwareConcurrency() const;
+    unsigned getHardwareConcurrency() const;
 
     void setIncludeSpecular(bool include_specular) { m_include_specular = include_specular; }
 

--- a/Core/Parametrization/ThreadInfo.h
+++ b/Core/Parametrization/ThreadInfo.h
@@ -23,9 +23,9 @@
 struct BA_CORE_API_ ThreadInfo
 {
     ThreadInfo();
-    int n_threads;
-    int n_batches;
-    int current_batch;
+    unsigned n_threads;
+    unsigned n_batches;
+    unsigned current_batch;
 };
 
 inline ThreadInfo::ThreadInfo()

--- a/Core/Parametrization/ThreadInfo.h
+++ b/Core/Parametrization/ThreadInfo.h
@@ -24,14 +24,12 @@ struct BA_CORE_API_ ThreadInfo
 {
     ThreadInfo();
     int n_threads;
-    int current_thread;
     int n_batches;
     int current_batch;
 };
 
 inline ThreadInfo::ThreadInfo()
     : n_threads(0)
-    , current_thread(0)
     , n_batches(1)
     , current_batch(0)
 {

--- a/Core/Simulation/GISASSimulation.cpp
+++ b/Core/Simulation/GISASSimulation.cpp
@@ -112,12 +112,12 @@ void GISASSimulation::setRegionOfInterest(double xlow, double ylow, double xup, 
 }
 
 std::unique_ptr<IComputation> GISASSimulation::generateSingleThreadedComputation(size_t start,
-                                                                                 size_t end)
+                                                                                 size_t n_elements)
 {
-    assert(start < end && end <= m_sim_elements.size());
-    const auto& begin = m_sim_elements.begin();
-    return std::make_unique<DWBAComputation>(*sample(), m_options, m_progress,
-                                             begin + start, begin + end);
+    assert(start < m_sim_elements.size() && start + n_elements <= m_sim_elements.size());
+    const auto& begin = m_sim_elements.begin() + start;
+    return std::make_unique<DWBAComputation>(*sample(), m_options, m_progress, begin,
+                                             begin + n_elements);
 }
 
 void GISASSimulation::normalizeIntensity(size_t index, double beam_intensity)
@@ -130,11 +130,11 @@ void GISASSimulation::normalizeIntensity(size_t index, double beam_intensity)
     element.setIntensity(element.getIntensity() * beam_intensity * solid_angle / sin_alpha_i);
 }
 
-void GISASSimulation::addBackGroundIntensity(size_t begin_ind, size_t end_ind)
+void GISASSimulation::addBackGroundIntensity(size_t start_ind, size_t n_elements)
 {
     if (!mP_background)
         return;
-    for (size_t i = begin_ind; i < end_ind; ++i) {
+    for (size_t i = start_ind, stop_point = start_ind + n_elements; i < stop_point; ++i) {
         SimulationElement& element = m_sim_elements[i];
         mP_background->addBackGround(element);
     }

--- a/Core/Simulation/GISASSimulation.cpp
+++ b/Core/Simulation/GISASSimulation.cpp
@@ -44,6 +44,14 @@ GISASSimulation::GISASSimulation(const std::shared_ptr<IMultiLayerBuilder> p_sam
     initialize();
 }
 
+GISASSimulation::GISASSimulation(const GISASSimulation& other)
+    : Simulation(other)
+    , m_sim_elements(other.m_sim_elements)
+    , m_storage(other.m_storage)
+{
+    initialize();
+}
+
 void GISASSimulation::prepareSimulation()
 {
     if (m_instrument.getDetectorDimension() != 2)
@@ -151,13 +159,6 @@ void GISASSimulation::moveDataFromStorage()
     assert(!m_storage.empty());
     if (!m_storage.empty())
         m_sim_elements = std::move(m_storage);
-}
-
-GISASSimulation::GISASSimulation(const GISASSimulation& other)
-    : Simulation(other)
-    , m_storage(other.m_storage)
-{
-    initialize();
 }
 
 void GISASSimulation::initSimulationElementVector(bool init_storage)

--- a/Core/Simulation/GISASSimulation.cpp
+++ b/Core/Simulation/GISASSimulation.cpp
@@ -137,10 +137,6 @@ void GISASSimulation::initSimulationElementVector()
     m_sim_elements = m_instrument.createSimulationElements();
 }
 
-void GISASSimulation::transferResultsToIntensityMap() {}
-
-void GISASSimulation::updateIntensityMap() {}
-
 void GISASSimulation::initialize()
 {
     setName(BornAgain::GISASSimulationType);

--- a/Core/Simulation/GISASSimulation.cpp
+++ b/Core/Simulation/GISASSimulation.cpp
@@ -19,6 +19,7 @@
 #include "Histogram2D.h"
 #include "IMultiLayerBuilder.h"
 #include "MultiLayer.h"
+#include "SimElementUtils.h"
 #include "SimulationElement.h"
 
 namespace
@@ -140,6 +141,18 @@ void GISASSimulation::addBackGroundIntensity(size_t start_ind, size_t n_elements
     }
 }
 
+void GISASSimulation::addDataToStorage(double weight)
+{
+    SimElementUtils::addElementsWithWeight(m_sim_elements, m_storage, weight);
+}
+
+void GISASSimulation::moveDataFromStorage()
+{
+    assert(!m_storage.empty());
+    if (!m_storage.empty())
+        m_sim_elements = std::move(m_storage);
+}
+
 GISASSimulation::GISASSimulation(const GISASSimulation& other)
     : Simulation(other)
     , m_storage(other.m_storage)
@@ -147,9 +160,11 @@ GISASSimulation::GISASSimulation(const GISASSimulation& other)
     initialize();
 }
 
-void GISASSimulation::initSimulationElementVector()
+void GISASSimulation::initSimulationElementVector(bool init_storage)
 {
     m_sim_elements = m_instrument.createSimulationElements();
+    if (init_storage)
+        m_storage = m_sim_elements;
 }
 
 void GISASSimulation::initialize()

--- a/Core/Simulation/GISASSimulation.cpp
+++ b/Core/Simulation/GISASSimulation.cpp
@@ -111,13 +111,6 @@ void GISASSimulation::setRegionOfInterest(double xlow, double ylow, double xup, 
     Detector2D(m_instrument)->setRegionOfInterest(xlow, ylow, xup, yup);
 }
 
-std::unique_ptr<IComputation> GISASSimulation::generateSingleThreadedComputation(
-        std::vector<SimulationElement>::iterator start,
-        std::vector<SimulationElement>::iterator end)
-{
-    return std::make_unique<DWBAComputation>(*sample(), m_options, m_progress, start, end);
-}
-
 std::unique_ptr<IComputation> GISASSimulation::generateSingleThreadedComputation(size_t start,
                                                                                  size_t end)
 {

--- a/Core/Simulation/GISASSimulation.cpp
+++ b/Core/Simulation/GISASSimulation.cpp
@@ -126,6 +126,16 @@ std::unique_ptr<IComputation> GISASSimulation::generateSingleThreadedComputation
                                              begin + start, begin + end);
 }
 
+void GISASSimulation::normalizeIntensity(size_t index, double beam_intensity)
+{
+    SimulationElement& element = m_sim_elements[index];
+    double sin_alpha_i = std::abs(std::sin(element.getAlphaI()));
+    if (sin_alpha_i == 0.0)
+        sin_alpha_i = 1.0;
+    const double solid_angle = element.getSolidAngle();
+    element.setIntensity(element.getIntensity() * beam_intensity * solid_angle / sin_alpha_i);
+}
+
 GISASSimulation::GISASSimulation(const GISASSimulation& other)
     : Simulation(other)
 {

--- a/Core/Simulation/GISASSimulation.cpp
+++ b/Core/Simulation/GISASSimulation.cpp
@@ -12,6 +12,7 @@
 //
 // ************************************************************************** //
 
+#include "IBackground.h"
 #include "GISASSimulation.h"
 #include "BornAgainNamespace.h"
 #include "DWBAComputation.h"
@@ -134,6 +135,16 @@ void GISASSimulation::normalizeIntensity(size_t index, double beam_intensity)
         sin_alpha_i = 1.0;
     const double solid_angle = element.getSolidAngle();
     element.setIntensity(element.getIntensity() * beam_intensity * solid_angle / sin_alpha_i);
+}
+
+void GISASSimulation::addBackGroundIntensity(size_t begin_ind, size_t end_ind)
+{
+    if (!mP_background)
+        return;
+    for (size_t i = begin_ind; i < end_ind; ++i) {
+        SimulationElement& element = m_sim_elements[i];
+        mP_background->addBackGround(element);
+    }
 }
 
 GISASSimulation::GISASSimulation(const GISASSimulation& other)

--- a/Core/Simulation/GISASSimulation.cpp
+++ b/Core/Simulation/GISASSimulation.cpp
@@ -117,6 +117,15 @@ std::unique_ptr<IComputation> GISASSimulation::generateSingleThreadedComputation
     return std::make_unique<DWBAComputation>(*sample(), m_options, m_progress, start, end);
 }
 
+std::unique_ptr<IComputation> GISASSimulation::generateSingleThreadedComputation(size_t start,
+                                                                                 size_t end)
+{
+    assert(start < end && end <= m_sim_elements.size());
+    const auto& begin = m_sim_elements.begin();
+    return std::make_unique<DWBAComputation>(*sample(), m_options, m_progress,
+                                             begin + start, begin + end);
+}
+
 GISASSimulation::GISASSimulation(const GISASSimulation& other)
     : Simulation(other)
 {

--- a/Core/Simulation/GISASSimulation.cpp
+++ b/Core/Simulation/GISASSimulation.cpp
@@ -123,6 +123,11 @@ GISASSimulation::GISASSimulation(const GISASSimulation& other)
     initialize();
 }
 
+void GISASSimulation::initSimulationElementVector()
+{
+    m_sim_elements = m_instrument.createSimulationElements();
+}
+
 void GISASSimulation::transferResultsToIntensityMap() {}
 
 void GISASSimulation::updateIntensityMap() {}

--- a/Core/Simulation/GISASSimulation.cpp
+++ b/Core/Simulation/GISASSimulation.cpp
@@ -142,6 +142,7 @@ void GISASSimulation::addBackGroundIntensity(size_t start_ind, size_t n_elements
 
 GISASSimulation::GISASSimulation(const GISASSimulation& other)
     : Simulation(other)
+    , m_storage(other.m_storage)
 {
     initialize();
 }

--- a/Core/Simulation/GISASSimulation.h
+++ b/Core/Simulation/GISASSimulation.h
@@ -88,7 +88,8 @@ private:
     GISASSimulation(const GISASSimulation& other);
 
     //! Initializes the vector of Simulation elements
-    virtual void initSimulationElementVector() override;
+    //! @param init_storage Initialize storage for accumulating results
+    virtual void initSimulationElementVector(bool init_storage) override;
 
     void initialize();
 
@@ -101,6 +102,12 @@ private:
     virtual void normalizeIntensity(size_t index, double beam_intensity) override;
 
     virtual void addBackGroundIntensity(size_t start_ind, size_t n_elements) override;
+
+    virtual bool isStorageInited() const override {return !m_storage.empty();}
+
+    virtual void addDataToStorage(double weight) override;
+
+    virtual void moveDataFromStorage() override;
 
     std::vector<SimulationElement> m_storage;
 };

--- a/Core/Simulation/GISASSimulation.h
+++ b/Core/Simulation/GISASSimulation.h
@@ -102,6 +102,12 @@ private:
     void updateIntensityMap() final;
 
     void initialize();
+
+    //! Generate a single threaded computation for a given range of simulation elements
+    //! @param start Index of the first element to include into computation
+    //! @param end Index of the element after the last one to include into computation
+    virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(size_t start,
+                                                                            size_t end) override;
 };
 
 #endif // GISASSIMULATION_H

--- a/Core/Simulation/GISASSimulation.h
+++ b/Core/Simulation/GISASSimulation.h
@@ -103,6 +103,8 @@ private:
                                                                             size_t end) override;
 
     virtual void normalizeIntensity(size_t index, double beam_intensity) override;
+
+    virtual void addBackGroundIntensity(size_t begin_ind, size_t end_ind) override;
 };
 
 #endif // GISASSIMULATION_H

--- a/Core/Simulation/GISASSimulation.h
+++ b/Core/Simulation/GISASSimulation.h
@@ -35,7 +35,7 @@ public:
 
     ~GISASSimulation() final {}
 
-    GISASSimulation* clone() const { return new GISASSimulation(*this); }
+    GISASSimulation* clone() const override { return new GISASSimulation(*this); }
 
     void accept(INodeVisitor* visitor) const final { visitor->visit(this); }
 
@@ -46,8 +46,8 @@ public:
     size_t numberOfSimulationElements() const final;
 
     //! Returns clone of the detector intensity map with detector resolution applied
-    OutputData<double>* getDetectorIntensity(
-            AxesUnits units_type = AxesUnits::DEFAULT) const;
+    virtual OutputData<double>* getDetectorIntensity(AxesUnits units_type
+                                                     = AxesUnits::DEFAULT) const override;
 
     //! Returns histogram representing intensity map in requested axes units
     Histogram2D* getIntensityData(AxesUnits units_type = AxesUnits::DEFAULT) const;

--- a/Core/Simulation/GISASSimulation.h
+++ b/Core/Simulation/GISASSimulation.h
@@ -93,13 +93,13 @@ private:
 
     //! Generate a single threaded computation for a given range of simulation elements
     //! @param start Index of the first element to include into computation
-    //! @param end Index of the element after the last one to include into computation
-    virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(size_t start,
-                                                                            size_t end) override;
+    //! @param n_elements Number of elements to process
+    virtual std::unique_ptr<IComputation>
+    generateSingleThreadedComputation(size_t start, size_t n_elements) override;
 
     virtual void normalizeIntensity(size_t index, double beam_intensity) override;
 
-    virtual void addBackGroundIntensity(size_t begin_ind, size_t end_ind) override;
+    virtual void addBackGroundIntensity(size_t start_ind, size_t n_elements) override;
 };
 
 #endif // GISASSIMULATION_H

--- a/Core/Simulation/GISASSimulation.h
+++ b/Core/Simulation/GISASSimulation.h
@@ -16,6 +16,7 @@
 #define GISASSIMULATION_H
 
 #include "Simulation.h"
+#include "SimulationElement.h"
 
 class MultiLayer;
 class IMultiLayerBuilder;
@@ -100,6 +101,8 @@ private:
     virtual void normalizeIntensity(size_t index, double beam_intensity) override;
 
     virtual void addBackGroundIntensity(size_t start_ind, size_t n_elements) override;
+
+    std::vector<SimulationElement> m_storage;
 };
 
 #endif // GISASSIMULATION_H

--- a/Core/Simulation/GISASSimulation.h
+++ b/Core/Simulation/GISASSimulation.h
@@ -101,6 +101,8 @@ private:
     //! @param end Index of the element after the last one to include into computation
     virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(size_t start,
                                                                             size_t end) override;
+
+    virtual void normalizeIntensity(size_t index, double beam_intensity) override;
 };
 
 #endif // GISASSIMULATION_H

--- a/Core/Simulation/GISASSimulation.h
+++ b/Core/Simulation/GISASSimulation.h
@@ -109,6 +109,7 @@ private:
 
     virtual void moveDataFromStorage() override;
 
+    std::vector<SimulationElement> m_sim_elements;
     std::vector<SimulationElement> m_storage;
 };
 

--- a/Core/Simulation/GISASSimulation.h
+++ b/Core/Simulation/GISASSimulation.h
@@ -83,11 +83,6 @@ public:
     //! Sets rectangular region of interest with lower left and upper right corners defined.
     void setRegionOfInterest(double xlow, double ylow, double xup, double yup);
 
-protected:
-    virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(
-            std::vector<SimulationElement>::iterator start,
-            std::vector<SimulationElement>::iterator end);
-
 private:
     GISASSimulation(const GISASSimulation& other);
 

--- a/Core/Simulation/GISASSimulation.h
+++ b/Core/Simulation/GISASSimulation.h
@@ -94,13 +94,6 @@ private:
     //! Initializes the vector of Simulation elements
     virtual void initSimulationElementVector() override;
 
-    //! Creates the appropriate data structure (e.g. 2D intensity map) from the calculated
-    //! SimulationElement objects
-    void transferResultsToIntensityMap() final;
-
-    //! Default implementation only adds the detector axes
-    void updateIntensityMap() final;
-
     void initialize();
 
     //! Generate a single threaded computation for a given range of simulation elements

--- a/Core/Simulation/GISASSimulation.h
+++ b/Core/Simulation/GISASSimulation.h
@@ -91,6 +91,9 @@ protected:
 private:
     GISASSimulation(const GISASSimulation& other);
 
+    //! Initializes the vector of Simulation elements
+    virtual void initSimulationElementVector() override;
+
     //! Creates the appropriate data structure (e.g. 2D intensity map) from the calculated
     //! SimulationElement objects
     void transferResultsToIntensityMap() final;

--- a/Core/Simulation/OffSpecSimulation.cpp
+++ b/Core/Simulation/OffSpecSimulation.cpp
@@ -19,6 +19,7 @@
 #include "Histogram2D.h"
 #include "IMultiLayerBuilder.h"
 #include "MultiLayer.h"
+#include "SimElementUtils.h"
 #include "SimulationElement.h"
 
 OffSpecSimulation::OffSpecSimulation()
@@ -113,7 +114,7 @@ OffSpecSimulation::OffSpecSimulation(const OffSpecSimulation& other)
     initialize();
 }
 
-void OffSpecSimulation::initSimulationElementVector()
+void OffSpecSimulation::initSimulationElementVector(bool init_storage)
 {
     m_sim_elements.clear();
     Beam beam = m_instrument.getBeam();
@@ -131,6 +132,8 @@ void OffSpecSimulation::initSimulationElementVector()
         m_sim_elements.insert(m_sim_elements.end(), sim_elements_alpha_i.begin(),
                               sim_elements_alpha_i.end());
     }
+    if (init_storage)
+        m_storage = m_sim_elements;
 }
 
 void OffSpecSimulation::addBackGroundIntensity(size_t start_ind, size_t n_elements)
@@ -141,6 +144,18 @@ void OffSpecSimulation::addBackGroundIntensity(size_t start_ind, size_t n_elemen
         SimulationElement& element = m_sim_elements[i];
         mP_background->addBackGround(element);
     }
+}
+
+void OffSpecSimulation::addDataToStorage(double weight)
+{
+    SimElementUtils::addElementsWithWeight(m_sim_elements, m_storage, weight);
+}
+
+void OffSpecSimulation::moveDataFromStorage()
+{
+    assert(!m_storage.empty());
+    if (!m_storage.empty())
+        m_sim_elements = std::move(m_storage);
 }
 
 void OffSpecSimulation::transferResultsToIntensityMap()

--- a/Core/Simulation/OffSpecSimulation.cpp
+++ b/Core/Simulation/OffSpecSimulation.cpp
@@ -83,13 +83,13 @@ void OffSpecSimulation::setDetectorParameters(size_t n_x, double x_min, double x
     updateIntensityMap();
 }
 
-std::unique_ptr<IComputation> OffSpecSimulation::generateSingleThreadedComputation(size_t start,
-                                                                                   size_t end)
+std::unique_ptr<IComputation>
+OffSpecSimulation::generateSingleThreadedComputation(size_t start, size_t n_elements)
 {
-    assert(start < end && end <= m_sim_elements.size());
-    const auto& begin = m_sim_elements.begin();
-    return std::make_unique<DWBAComputation>(*sample(), m_options, m_progress,
-                                             begin + start, begin + end);
+    assert(start < m_sim_elements.size() && start + n_elements <= m_sim_elements.size());
+    const auto& begin = m_sim_elements.begin() + start;
+    return std::make_unique<DWBAComputation>(*sample(), m_options, m_progress, begin,
+                                             begin + n_elements);
 }
 
 void OffSpecSimulation::normalizeIntensity(size_t index, double beam_intensity)
@@ -132,11 +132,11 @@ void OffSpecSimulation::initSimulationElementVector()
     }
 }
 
-void OffSpecSimulation::addBackGroundIntensity(size_t begin_ind, size_t end_ind)
+void OffSpecSimulation::addBackGroundIntensity(size_t start_ind, size_t n_elements)
 {
     if (!mP_background)
         return;
-    for (size_t i = begin_ind; i < end_ind; ++i) {
+    for (size_t i = start_ind, stop_point = start_ind + n_elements; i < stop_point; ++i) {
         SimulationElement& element = m_sim_elements[i];
         mP_background->addBackGround(element);
     }

--- a/Core/Simulation/OffSpecSimulation.cpp
+++ b/Core/Simulation/OffSpecSimulation.cpp
@@ -48,6 +48,18 @@ void OffSpecSimulation::prepareSimulation()
     Simulation::prepareSimulation();
 }
 
+OffSpecSimulation::OffSpecSimulation(const OffSpecSimulation& other)
+    : Simulation(other)
+    , mp_alpha_i_axis(nullptr)
+    , m_sim_elements(other.m_sim_elements)
+    , m_storage(other.m_storage)
+{
+    if(other.mp_alpha_i_axis)
+        mp_alpha_i_axis = other.mp_alpha_i_axis->clone();
+    m_intensity_map.copyFrom(other.m_intensity_map);
+    initialize();
+}
+
 size_t OffSpecSimulation::numberOfSimulationElements() const
 {
     checkInitialization();
@@ -101,17 +113,6 @@ void OffSpecSimulation::normalizeIntensity(size_t index, double beam_intensity)
         sin_alpha_i = 1.0;
     const double solid_angle = element.getSolidAngle();
     element.setIntensity(element.getIntensity() * beam_intensity * solid_angle / sin_alpha_i);
-}
-
-OffSpecSimulation::OffSpecSimulation(const OffSpecSimulation& other)
-    : Simulation(other)
-    , mp_alpha_i_axis(nullptr)
-    , m_storage(other.m_storage)
-{
-    if(other.mp_alpha_i_axis)
-        mp_alpha_i_axis = other.mp_alpha_i_axis->clone();
-    m_intensity_map.copyFrom(other.m_intensity_map);
-    initialize();
 }
 
 void OffSpecSimulation::initSimulationElementVector(bool init_storage)

--- a/Core/Simulation/OffSpecSimulation.cpp
+++ b/Core/Simulation/OffSpecSimulation.cpp
@@ -83,13 +83,6 @@ void OffSpecSimulation::setDetectorParameters(size_t n_x, double x_min, double x
     updateIntensityMap();
 }
 
-std::unique_ptr<IComputation> OffSpecSimulation::generateSingleThreadedComputation(
-        std::vector<SimulationElement>::iterator start,
-        std::vector<SimulationElement>::iterator end)
-{
-    return std::make_unique<DWBAComputation>(*sample(), m_options, m_progress, start, end);
-}
-
 std::unique_ptr<IComputation> OffSpecSimulation::generateSingleThreadedComputation(size_t start,
                                                                                    size_t end)
 {

--- a/Core/Simulation/OffSpecSimulation.cpp
+++ b/Core/Simulation/OffSpecSimulation.cpp
@@ -105,6 +105,7 @@ void OffSpecSimulation::normalizeIntensity(size_t index, double beam_intensity)
 OffSpecSimulation::OffSpecSimulation(const OffSpecSimulation& other)
     : Simulation(other)
     , mp_alpha_i_axis(nullptr)
+    , m_storage(other.m_storage)
 {
     if(other.mp_alpha_i_axis)
         mp_alpha_i_axis = other.mp_alpha_i_axis->clone();

--- a/Core/Simulation/OffSpecSimulation.cpp
+++ b/Core/Simulation/OffSpecSimulation.cpp
@@ -98,6 +98,16 @@ std::unique_ptr<IComputation> OffSpecSimulation::generateSingleThreadedComputati
                                              begin + start, begin + end);
 }
 
+void OffSpecSimulation::normalizeIntensity(size_t index, double beam_intensity)
+{
+    SimulationElement& element = m_sim_elements[index];
+    double sin_alpha_i = std::abs(std::sin(element.getAlphaI()));
+    if (sin_alpha_i == 0.0)
+        sin_alpha_i = 1.0;
+    const double solid_angle = element.getSolidAngle();
+    element.setIntensity(element.getIntensity() * beam_intensity * solid_angle / sin_alpha_i);
+}
+
 OffSpecSimulation::OffSpecSimulation(const OffSpecSimulation& other)
     : Simulation(other)
     , mp_alpha_i_axis(nullptr)

--- a/Core/Simulation/OffSpecSimulation.cpp
+++ b/Core/Simulation/OffSpecSimulation.cpp
@@ -89,6 +89,15 @@ std::unique_ptr<IComputation> OffSpecSimulation::generateSingleThreadedComputati
     return std::make_unique<DWBAComputation>(*sample(), m_options, m_progress, start, end);
 }
 
+std::unique_ptr<IComputation> OffSpecSimulation::generateSingleThreadedComputation(size_t start,
+                                                                                   size_t end)
+{
+    assert(start < end && end <= m_sim_elements.size());
+    const auto& begin = m_sim_elements.begin();
+    return std::make_unique<DWBAComputation>(*sample(), m_options, m_progress,
+                                             begin + start, begin + end);
+}
+
 OffSpecSimulation::OffSpecSimulation(const OffSpecSimulation& other)
     : Simulation(other)
     , mp_alpha_i_axis(nullptr)

--- a/Core/Simulation/OffSpecSimulation.cpp
+++ b/Core/Simulation/OffSpecSimulation.cpp
@@ -12,6 +12,7 @@
 //
 // ************************************************************************** //
 
+#include "IBackground.h"
 #include "OffSpecSimulation.h"
 #include "BornAgainNamespace.h"
 #include "DWBAComputation.h"
@@ -135,6 +136,16 @@ void OffSpecSimulation::initSimulationElementVector()
             m_instrument.createSimulationElements();
         m_sim_elements.insert(m_sim_elements.end(), sim_elements_alpha_i.begin(),
                               sim_elements_alpha_i.end());
+    }
+}
+
+void OffSpecSimulation::addBackGroundIntensity(size_t begin_ind, size_t end_ind)
+{
+    if (!mP_background)
+        return;
+    for (size_t i = begin_ind; i < end_ind; ++i) {
+        SimulationElement& element = m_sim_elements[i];
+        mP_background->addBackGround(element);
     }
 }
 

--- a/Core/Simulation/OffSpecSimulation.h
+++ b/Core/Simulation/OffSpecSimulation.h
@@ -58,10 +58,6 @@ public:
 private:
     OffSpecSimulation(const OffSpecSimulation& other);
 
-    virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(
-            std::vector<SimulationElement>::iterator start,
-            std::vector<SimulationElement>::iterator end) override;
-
     //! Generate a single threaded computation for a given range of simulation elements
     //! @param start Index of the first element to include into computation
     //! @param end Index of the element after the last one to include into computation

--- a/Core/Simulation/OffSpecSimulation.h
+++ b/Core/Simulation/OffSpecSimulation.h
@@ -89,6 +89,8 @@ private:
 
     virtual void normalizeIntensity(size_t index, double beam_intensity) override;
 
+    virtual void addBackGroundIntensity(size_t begin_ind, size_t end_ind) override;
+
     IAxis* mp_alpha_i_axis;
     OutputData<double> m_intensity_map;
 

--- a/Core/Simulation/OffSpecSimulation.h
+++ b/Core/Simulation/OffSpecSimulation.h
@@ -87,6 +87,8 @@ private:
 
     void initialize();
 
+    virtual void normalizeIntensity(size_t index, double beam_intensity) override;
+
     IAxis* mp_alpha_i_axis;
     OutputData<double> m_intensity_map;
 

--- a/Core/Simulation/OffSpecSimulation.h
+++ b/Core/Simulation/OffSpecSimulation.h
@@ -66,7 +66,8 @@ private:
     generateSingleThreadedComputation(size_t start, size_t n_elements) override;
 
     //! Initializes the vector of Simulation elements
-    void initSimulationElementVector() final;
+    //! @param init_storage Initialize storage for accumulating results
+    virtual void initSimulationElementVector(bool init_storage) override;
 
     //! Creates the appropriate data structure (e.g. 2D intensity map) from the calculated
     //! SimulationElement objects
@@ -87,6 +88,12 @@ private:
     virtual void normalizeIntensity(size_t index, double beam_intensity) override;
 
     virtual void addBackGroundIntensity(size_t start_ind, size_t n_elements) override;
+
+    virtual bool isStorageInited() const override {return !m_storage.empty();}
+
+    virtual void addDataToStorage(double weight) override;
+
+    virtual void moveDataFromStorage() override;
 
     IAxis* mp_alpha_i_axis;
     OutputData<double> m_intensity_map;

--- a/Core/Simulation/OffSpecSimulation.h
+++ b/Core/Simulation/OffSpecSimulation.h
@@ -31,7 +31,7 @@ public:
     OffSpecSimulation(const std::shared_ptr<class IMultiLayerBuilder> p_sample_builder);
     ~OffSpecSimulation() final {}
 
-    OffSpecSimulation* clone() const { return new OffSpecSimulation(*this); }
+    OffSpecSimulation* clone() const override { return new OffSpecSimulation(*this); }
 
     void accept(INodeVisitor* visitor) const final { visitor->visit(this); }
 
@@ -42,9 +42,12 @@ public:
     size_t numberOfSimulationElements() const final;
 
     //! Returns clone of the detector intensity map
-    OutputData<double>* getDetectorIntensity(
-        AxesUnits units_type = AxesUnits::DEFAULT) const {
-        (void) units_type; return m_intensity_map.clone(); }
+    OutputData<double>* getDetectorIntensity(AxesUnits units_type
+                                             = AxesUnits::DEFAULT) const override
+    {
+        (void)units_type;
+        return m_intensity_map.clone();
+    }
 
     //! Returns clone of the detector intensity map in the form of 2D histogram.
     Histogram2D* getIntensityData() const;
@@ -74,7 +77,7 @@ private:
     void transferResultsToIntensityMap() final;
 
     //! Default implementation only adds the detector axes
-    void updateIntensityMap() final;
+    virtual void updateIntensityMap() override final;
 
     //! Normalize, apply detector resolution and transfer detector image corresponding to
     //! alpha_i = mp_alpha_i_axis->getBin(index)

--- a/Core/Simulation/OffSpecSimulation.h
+++ b/Core/Simulation/OffSpecSimulation.h
@@ -97,6 +97,7 @@ private:
 
     IAxis* mp_alpha_i_axis;
     OutputData<double> m_intensity_map;
+    std::vector<SimulationElement> m_sim_elements;
     std::vector<SimulationElement> m_storage;
 };
 

--- a/Core/Simulation/OffSpecSimulation.h
+++ b/Core/Simulation/OffSpecSimulation.h
@@ -60,9 +60,9 @@ private:
 
     //! Generate a single threaded computation for a given range of simulation elements
     //! @param start Index of the first element to include into computation
-    //! @param end Index of the element after the last one to include into computation
-    virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(size_t start,
-                                                                            size_t end) override;
+    //! @param n_elements Number of elements to process
+    virtual std::unique_ptr<IComputation>
+    generateSingleThreadedComputation(size_t start, size_t n_elements) override;
 
     //! Initializes the vector of Simulation elements
     void initSimulationElementVector() final;
@@ -85,7 +85,7 @@ private:
 
     virtual void normalizeIntensity(size_t index, double beam_intensity) override;
 
-    virtual void addBackGroundIntensity(size_t begin_ind, size_t end_ind) override;
+    virtual void addBackGroundIntensity(size_t start_ind, size_t n_elements) override;
 
     IAxis* mp_alpha_i_axis;
     OutputData<double> m_intensity_map;

--- a/Core/Simulation/OffSpecSimulation.h
+++ b/Core/Simulation/OffSpecSimulation.h
@@ -16,6 +16,7 @@
 #define OFFSPECSIMULATION_H
 
 #include "Simulation.h"
+#include "SimulationElement.h"
 
 class Histogram2D;
 
@@ -89,7 +90,7 @@ private:
 
     IAxis* mp_alpha_i_axis;
     OutputData<double> m_intensity_map;
-
+    std::vector<SimulationElement> m_storage;
 };
 
 #endif // OFFSPECSIMULATION_H

--- a/Core/Simulation/OffSpecSimulation.h
+++ b/Core/Simulation/OffSpecSimulation.h
@@ -55,13 +55,18 @@ public:
     void setDetectorParameters(size_t n_x, double x_min, double x_max,
                                size_t n_y, double y_min, double y_max);
 
-protected:
-    virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(
-            std::vector<SimulationElement>::iterator start,
-            std::vector<SimulationElement>::iterator end);
-
 private:
     OffSpecSimulation(const OffSpecSimulation& other);
+
+    virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(
+            std::vector<SimulationElement>::iterator start,
+            std::vector<SimulationElement>::iterator end) override;
+
+    //! Generate a single threaded computation for a given range of simulation elements
+    //! @param start Index of the first element to include into computation
+    //! @param end Index of the element after the last one to include into computation
+    virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(size_t start,
+                                                                            size_t end) override;
 
     //! Initializes the vector of Simulation elements
     void initSimulationElementVector() final;

--- a/Core/Simulation/SimElementUtils.h
+++ b/Core/Simulation/SimElementUtils.h
@@ -1,0 +1,22 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Core/Simulation/SimElementUtils.h
+//! @brief     Defines a set of functions to operate on simulation elements.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#ifndef SIMELEMENTUTILS_H_
+#define SIMELEMENTUTILS_H_
+
+namespace SimElementUtils {
+
+}
+
+#endif /* SIMELEMENTUTILS_H_ */

--- a/Core/Simulation/SimElementUtils.h
+++ b/Core/Simulation/SimElementUtils.h
@@ -15,8 +15,27 @@
 #ifndef SIMELEMENTUTILS_H_
 #define SIMELEMENTUTILS_H_
 
+#include <vector>
+
+//! Set of templated utilities to operate on a vector of simulation elements
+//! @ingroup simulation
+
 namespace SimElementUtils {
 
+template <class SimElement>
+using const_iter = typename std::vector<SimElement>::const_iterator;
+
+template <class SimElement>
+using iter = typename std::vector<SimElement>::iterator;
+
+//! Add element vector to element vector with weight
+template <class SimElement>
+void addElementsWithWeight(const_iter<SimElement> first, const_iter<SimElement> last,
+                           iter<SimElement> result, double weight)
+{
+    for (auto it = first; it != last; ++it, ++result)
+        result->addIntensity(it->getIntensity() * weight);
+}
 }
 
 #endif /* SIMELEMENTUTILS_H_ */

--- a/Core/Simulation/SimElementUtils.h
+++ b/Core/Simulation/SimElementUtils.h
@@ -23,18 +23,14 @@
 namespace SimElementUtils {
 
 template <class SimElement>
-using const_iter = typename std::vector<SimElement>::const_iterator;
-
-template <class SimElement>
-using iter = typename std::vector<SimElement>::iterator;
-
-//! Add element vector to element vector with weight
-template <class SimElement>
-void addElementsWithWeight(const_iter<SimElement> first, const_iter<SimElement> last,
-                           iter<SimElement> result, double weight)
+void addElementsWithWeight(const std::vector<SimElement>& from, std::vector<SimElement>& to,
+                           double weight)
 {
-    for (auto it = first; it != last; ++it, ++result)
-        result->addIntensity(it->getIntensity() * weight);
+    assert(!from.empty());
+    assert(from.size() == to.size());
+    auto to_it = to.begin();
+    for (auto from_it = from.cbegin(); from_it != from.cend(); ++from_it, ++to_it)
+        to_it->addIntensity(from_it->getIntensity() * weight);
 }
 }
 

--- a/Core/Simulation/Simulation.cpp
+++ b/Core/Simulation/Simulation.cpp
@@ -291,7 +291,6 @@ void Simulation::runSingleSimulation()
     addBackGroundIntensity(batch_start, batch_end);
 }
 
-//! Normalize the detector counts to beam intensity, to solid angle, and to exposure angle.
 void Simulation::normalize(std::vector<SimulationElement>::iterator begin_it,
                            std::vector<SimulationElement>::iterator end_it) const
 {
@@ -304,6 +303,15 @@ void Simulation::normalize(std::vector<SimulationElement>::iterator begin_it,
         double solid_angle = it->getSolidAngle();
         it->setIntensity(it->getIntensity()*beam_intensity*solid_angle/sin_alpha_i);
     }
+}
+
+void Simulation::normalize(size_t start_ind, size_t end_ind)
+{
+    const double beam_intensity = getBeamIntensity();
+    if (beam_intensity == 0.0)
+        return; // no normalization when beam intensity is zero
+    for (size_t i = start_ind; i < end_ind; ++i)
+        normalizeIntensity(i, beam_intensity);
 }
 
 void Simulation::addBackGroundIntensity(std::vector<SimulationElement>::iterator begin_it,

--- a/Core/Simulation/Simulation.cpp
+++ b/Core/Simulation/Simulation.cpp
@@ -26,6 +26,10 @@
 #include <iomanip>
 #include <iostream>
 
+namespace {
+size_t getIndexStep(size_t total_size, size_t n_handlers);
+}
+
 Simulation::Simulation()
 {
     initialize();
@@ -322,6 +326,15 @@ std::vector<SimulationElement>::iterator Simulation::getBatchStart(int n_batches
     return m_sim_elements.begin() + current_batch*size_per_batch;
 }
 
+size_t Simulation::getBatchStartIndex(int n_batches, int current_batch)
+{
+    imposeConsistencyOfBatchNumbers(n_batches, current_batch);
+    const size_t total_size = numberOfSimulationElements();
+    const size_t size_per_batch = getIndexStep(total_size, static_cast<size_t>(n_batches));
+    const size_t start_index = current_batch * size_per_batch;
+    return start_index >= total_size ? total_size : start_index;
+}
+
 std::vector<SimulationElement>::iterator Simulation::getBatchEnd(int n_batches, int current_batch)
 {
     imposeConsistencyOfBatchNumbers(n_batches, current_batch);
@@ -333,6 +346,15 @@ std::vector<SimulationElement>::iterator Simulation::getBatchEnd(int n_batches, 
     if (end_index >= total_size)
         return m_sim_elements.end();
     return m_sim_elements.begin() + end_index;
+}
+
+size_t Simulation::getBatchEndIndex(int n_batches, int current_batch)
+{
+    imposeConsistencyOfBatchNumbers(n_batches, current_batch);
+    const size_t total_size = numberOfSimulationElements();
+    const size_t size_per_batch = getIndexStep(total_size, static_cast<size_t>(n_batches));
+    const size_t end_index = (current_batch + 1) * size_per_batch;
+    return end_index >= total_size ? total_size : end_index;
 }
 
 void Simulation::initialize()
@@ -351,4 +373,12 @@ void Simulation::imposeConsistencyOfBatchNumbers(int& n_batches, int& current_ba
         throw Exceptions::ClassInitializationException(
             "Simulation::imposeConsistencyOfBatchNumbers(): Batch number must be smaller than "
             "number of batches.");
+}
+
+namespace {
+size_t getIndexStep(size_t total_size, size_t n_handlers)
+{
+    size_t result = total_size / n_handlers;
+    return total_size % n_handlers ? ++result : result;
+}
 }

--- a/Core/Simulation/Simulation.cpp
+++ b/Core/Simulation/Simulation.cpp
@@ -19,6 +19,7 @@
 #include "IComputation.h"
 #include "ParameterPool.h"
 #include "ParameterSample.h"
+#include "SimElementUtils.h"
 #include "SimulationElement.h"
 #include "StringUtils.h"
 #include <thread>
@@ -148,8 +149,8 @@ void Simulation::runSimulation()
     for (size_t index = 0; index < param_combinations; ++index) {
         double weight = m_distribution_handler.setParameterValues(P_param_pool.get(), index);
         runSingleSimulation();
-        addElementsWithWeight(m_sim_elements.begin(), m_sim_elements.end(), total_intensity.begin(),
-                              weight);
+        SimElementUtils::addElementsWithWeight<SimulationElement>(
+            m_sim_elements.cbegin(), m_sim_elements.cend(), total_intensity.begin(), weight);
     }
     m_sim_elements = total_intensity;
     transferResultsToIntensityMap();

--- a/Core/Simulation/Simulation.cpp
+++ b/Core/Simulation/Simulation.cpp
@@ -208,11 +208,6 @@ void Simulation::addParameterDistribution(const ParameterDistribution& par_distr
     m_distribution_handler.addParameterDistribution(par_distr);
 }
 
-void Simulation::initSimulationElementVector()
-{
-    m_sim_elements = m_instrument.createSimulationElements();
-}
-
 void Simulation::updateSample()
 {
     m_sample_provider.updateSample();

--- a/Core/Simulation/Simulation.cpp
+++ b/Core/Simulation/Simulation.cpp
@@ -324,7 +324,6 @@ void Simulation::addBackGroundIntensity(std::vector<SimulationElement>::iterator
 
 std::vector<SimulationElement>::iterator Simulation::getBatchStart(int n_batches, int current_batch)
 {
-    imposeConsistencyOfBatchNumbers(n_batches, current_batch);
     int total_size = static_cast<int>(m_sim_elements.size());
     int size_per_batch = total_size/n_batches;
     if (total_size%n_batches)
@@ -336,7 +335,6 @@ std::vector<SimulationElement>::iterator Simulation::getBatchStart(int n_batches
 
 size_t Simulation::getBatchStartIndex(int n_batches, int current_batch)
 {
-    imposeConsistencyOfBatchNumbers(n_batches, current_batch);
     const size_t total_size = numberOfSimulationElements();
     const size_t size_per_batch = getIndexStep(total_size, static_cast<size_t>(n_batches));
     const size_t start_index = current_batch * size_per_batch;
@@ -345,7 +343,6 @@ size_t Simulation::getBatchStartIndex(int n_batches, int current_batch)
 
 std::vector<SimulationElement>::iterator Simulation::getBatchEnd(int n_batches, int current_batch)
 {
-    imposeConsistencyOfBatchNumbers(n_batches, current_batch);
     int total_size = static_cast<int>(m_sim_elements.size());
     int size_per_batch = total_size/n_batches;
     if (total_size%n_batches)
@@ -358,7 +355,6 @@ std::vector<SimulationElement>::iterator Simulation::getBatchEnd(int n_batches, 
 
 size_t Simulation::getBatchEndIndex(int n_batches, int current_batch)
 {
-    imposeConsistencyOfBatchNumbers(n_batches, current_batch);
     const size_t total_size = numberOfSimulationElements();
     const size_t size_per_batch = getIndexStep(total_size, static_cast<size_t>(n_batches));
     const size_t end_index = (current_batch + 1) * size_per_batch;
@@ -369,18 +365,6 @@ void Simulation::initialize()
 {
     registerChild(&m_instrument);
     registerChild(&m_sample_provider);
-}
-
-void Simulation::imposeConsistencyOfBatchNumbers(int& n_batches, int& current_batch)
-{
-    if (n_batches < 2) {
-        n_batches = 1;
-        current_batch = 0;
-    }
-    if (current_batch >= n_batches)
-        throw Exceptions::ClassInitializationException(
-            "Simulation::imposeConsistencyOfBatchNumbers(): Batch number must be smaller than "
-            "number of batches.");
 }
 
 namespace {

--- a/Core/Simulation/Simulation.cpp
+++ b/Core/Simulation/Simulation.cpp
@@ -286,20 +286,6 @@ void Simulation::runSingleSimulation()
     addBackGroundIntensity(batch_start, batch_end);
 }
 
-void Simulation::normalize(std::vector<SimulationElement>::iterator begin_it,
-                           std::vector<SimulationElement>::iterator end_it) const
-{
-    double beam_intensity = getBeamIntensity();
-    if (beam_intensity==0.0)
-        return; // no normalization when beam intensity is zero
-    for(auto it=begin_it; it!=end_it; ++it) {
-        double sin_alpha_i = std::abs(std::sin(it->getAlphaI()));
-        if (sin_alpha_i==0.0) sin_alpha_i = 1.0;
-        double solid_angle = it->getSolidAngle();
-        it->setIntensity(it->getIntensity()*beam_intensity*solid_angle/sin_alpha_i);
-    }
-}
-
 void Simulation::normalize(size_t start_ind, size_t end_ind)
 {
     const double beam_intensity = getBeamIntensity();
@@ -309,43 +295,12 @@ void Simulation::normalize(size_t start_ind, size_t end_ind)
         normalizeIntensity(i, beam_intensity);
 }
 
-void Simulation::addBackGroundIntensity(std::vector<SimulationElement>::iterator begin_it,
-                                        std::vector<SimulationElement>::iterator end_it) const
-{
-    if (mP_background) {
-        mP_background->addBackGround(begin_it, end_it);
-    }
-}
-
-std::vector<SimulationElement>::iterator Simulation::getBatchStart(int n_batches, int current_batch)
-{
-    int total_size = static_cast<int>(m_sim_elements.size());
-    int size_per_batch = total_size/n_batches;
-    if (total_size%n_batches)
-        ++size_per_batch;
-    if (current_batch*size_per_batch >= total_size)
-        return m_sim_elements.end();
-    return m_sim_elements.begin() + current_batch*size_per_batch;
-}
-
 size_t Simulation::getBatchStartIndex(size_t n_batches, size_t current_batch)
 {
     const size_t total_size = numberOfSimulationElements();
     const size_t size_per_batch = getIndexStep(total_size, static_cast<size_t>(n_batches));
     const size_t start_index = current_batch * size_per_batch;
     return start_index >= total_size ? total_size : start_index;
-}
-
-std::vector<SimulationElement>::iterator Simulation::getBatchEnd(int n_batches, int current_batch)
-{
-    int total_size = static_cast<int>(m_sim_elements.size());
-    int size_per_batch = total_size/n_batches;
-    if (total_size%n_batches)
-        ++size_per_batch;
-    int end_index = (current_batch + 1)*size_per_batch;
-    if (end_index >= total_size)
-        return m_sim_elements.end();
-    return m_sim_elements.begin() + end_index;
 }
 
 size_t Simulation::getBatchEndIndex(size_t n_batches, size_t current_batch)

--- a/Core/Simulation/Simulation.cpp
+++ b/Core/Simulation/Simulation.cpp
@@ -19,7 +19,6 @@
 #include "IComputation.h"
 #include "ParameterPool.h"
 #include "ParameterSample.h"
-#include "SimulationElement.h"
 #include "StringUtils.h"
 #include <thread>
 #include <gsl/gsl_errno.h>
@@ -55,7 +54,6 @@ Simulation::Simulation(const Simulation& other)
     , m_options(other.m_options)
     , m_distribution_handler(other.m_distribution_handler)
     , m_progress(other.m_progress)
-    , m_sim_elements(other.m_sim_elements)
     , m_instrument(other.m_instrument)
 {
     if (other.mP_background)

--- a/Core/Simulation/Simulation.cpp
+++ b/Core/Simulation/Simulation.cpp
@@ -222,7 +222,7 @@ void Simulation::updateSample()
 
 //! Runs a single simulation with fixed parameter values.
 //! If desired, the simulation is run in several threads.
-void Simulation::runSingleSimulation()
+void Simulation::runSingleSimulation(bool, double)
 {
     prepareSimulation();
     initSimulationElementVector();

--- a/Core/Simulation/Simulation.cpp
+++ b/Core/Simulation/Simulation.cpp
@@ -251,19 +251,14 @@ void Simulation::runSingleSimulation()
         std::vector<std::unique_ptr<std::thread>> threads;
         std::vector<std::unique_ptr<IComputation>> computations;
 
-        // Distribute Initialize n computations.
+        // Distribute computations on the threads.
         const size_t batch_size = batch_end - batch_start;
-        const size_t element_thread_step = getIndexStep(batch_size, n_threads);
-
         for (size_t i_thread = 0; i_thread < n_threads; ++i_thread) {
-            if (i_thread * element_thread_step >= batch_size)
+            const size_t begin = batch_start + getStartIndex(n_threads, i_thread, batch_size);
+            const size_t end = batch_start + getEndIndex(n_threads, i_thread, batch_size);
+            if (begin == end)
                 break;
-            const size_t begin_ind = batch_start + i_thread * element_thread_step;
-            const size_t end_thread_index = (i_thread + 1) * element_thread_step;
-            const size_t end_ind = end_thread_index >= batch_size
-                                       ? batch_end
-                                       : batch_start + end_thread_index;
-            computations.push_back(generateSingleThreadedComputation(begin_ind, end_ind));
+            computations.push_back(generateSingleThreadedComputation(begin, end));
         }
 
         // Run simulations in n threads.

--- a/Core/Simulation/Simulation.cpp
+++ b/Core/Simulation/Simulation.cpp
@@ -252,8 +252,8 @@ void Simulation::runSingleSimulation()
         if (total_batch_elements % m_options.getNumberOfThreads()) // there is a remainder
             ++element_thread_step;
 
-        for (int i_thread = 0; i_thread < m_options.getNumberOfThreads(); ++i_thread) {
-            if (i_thread*element_thread_step >= total_batch_elements)
+        for (size_t i_thread = 0; i_thread < m_options.getNumberOfThreads(); ++i_thread) {
+            if (i_thread * element_thread_step >= total_batch_elements)
                 break;
             std::vector<SimulationElement>::iterator begin_it = batch_start
                                                                 + i_thread * element_thread_step;

--- a/Core/Simulation/Simulation.cpp
+++ b/Core/Simulation/Simulation.cpp
@@ -333,7 +333,7 @@ std::vector<SimulationElement>::iterator Simulation::getBatchStart(int n_batches
     return m_sim_elements.begin() + current_batch*size_per_batch;
 }
 
-size_t Simulation::getBatchStartIndex(int n_batches, int current_batch)
+size_t Simulation::getBatchStartIndex(size_t n_batches, size_t current_batch)
 {
     const size_t total_size = numberOfSimulationElements();
     const size_t size_per_batch = getIndexStep(total_size, static_cast<size_t>(n_batches));
@@ -353,7 +353,7 @@ std::vector<SimulationElement>::iterator Simulation::getBatchEnd(int n_batches, 
     return m_sim_elements.begin() + end_index;
 }
 
-size_t Simulation::getBatchEndIndex(int n_batches, int current_batch)
+size_t Simulation::getBatchEndIndex(size_t n_batches, size_t current_batch)
 {
     const size_t total_size = numberOfSimulationElements();
     const size_t size_per_batch = getIndexStep(total_size, static_cast<size_t>(n_batches));

--- a/Core/Simulation/Simulation.h
+++ b/Core/Simulation/Simulation.h
@@ -97,9 +97,6 @@ public:
 protected:
     Simulation(const Simulation& other);
 
-    //! Initializes the vector of Simulation elements
-    virtual void initSimulationElementVector();
-
     //! Creates the appropriate data structure (e.g. 2D intensity map) from the calculated
     //! SimulationElement objects
     virtual void transferResultsToIntensityMap() =0;
@@ -139,6 +136,9 @@ protected:
 private:
     void initialize();
     void imposeConsistencyOfBatchNumbers(int& n_batches, int& current_batch);
+
+    //! Initializes the vector of Simulation elements
+    virtual void initSimulationElementVector() = 0;
 };
 
 #endif // SIMULATION_H

--- a/Core/Simulation/Simulation.h
+++ b/Core/Simulation/Simulation.h
@@ -112,7 +112,6 @@ protected:
     SimulationOptions m_options;
     DistributionHandler m_distribution_handler;
     ProgressHandler m_progress;
-    std::vector<SimulationElement> m_sim_elements;
     Instrument m_instrument;
     std::unique_ptr<IBackground> mP_background;
 

--- a/Core/Simulation/Simulation.h
+++ b/Core/Simulation/Simulation.h
@@ -113,6 +113,7 @@ protected:
 
     virtual void updateIntensityMap() {}
 
+    //! Normalize the detector counts to beam intensity, to solid angle, and to exposure angle.
     virtual void normalize(std::vector<SimulationElement>::iterator begin_it,
                    std::vector<SimulationElement>::iterator end_it) const;
 
@@ -151,6 +152,15 @@ private:
     //! @param end Index of the element after the last one to include into computation
     virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(size_t start,
                                                                             size_t end) = 0;
+
+    //! Normalize the detector counts to beam intensity, to solid angle, and to exposure angle.
+    //! @param start_ind Index of the first element to operate on
+    //! @param end_ind Index of the element after the last one to operate on
+    void normalize(size_t start_ind, size_t end_ind);
+
+    //! Normalize the detector counts to beam intensity, to solid angle, and to exposure angle
+    //! for single simulation element specified by _index_.
+    virtual void normalizeIntensity(size_t index, double beam_intensity) = 0;
 };
 
 #endif // SIMULATION_H

--- a/Core/Simulation/Simulation.h
+++ b/Core/Simulation/Simulation.h
@@ -130,7 +130,6 @@ protected:
 
 private:
     void initialize();
-    void imposeConsistencyOfBatchNumbers(int& n_batches, int& current_batch);
 
     //! Initializes the vector of Simulation elements
     virtual void initSimulationElementVector() = 0;

--- a/Core/Simulation/Simulation.h
+++ b/Core/Simulation/Simulation.h
@@ -104,21 +104,9 @@ protected:
     //! Update the sample by calling the sample builder, if present
     void updateSample();
 
-    //! Generate a single threaded computation for a given range of SimulationElement's
-    virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(
-            std::vector<SimulationElement>::iterator start,
-            std::vector<SimulationElement>::iterator end) = 0;
-
     void runSingleSimulation();
 
     virtual void updateIntensityMap() {}
-
-    //! Normalize the detector counts to beam intensity, to solid angle, and to exposure angle.
-    virtual void normalize(std::vector<SimulationElement>::iterator begin_it,
-                   std::vector<SimulationElement>::iterator end_it) const;
-
-    void addBackGroundIntensity(std::vector<SimulationElement>::iterator begin_it,
-                                std::vector<SimulationElement>::iterator end_it) const;
 
     SampleProvider m_sample_provider;
     SimulationOptions m_options;
@@ -134,14 +122,8 @@ private:
     //! Initializes the vector of Simulation elements
     virtual void initSimulationElementVector() = 0;
 
-    //! Returns the start iterator of simulation elements for the current batch
-    std::vector<SimulationElement>::iterator getBatchStart(int n_batches, int current_batch);
-
     //! Returns the index of the first simulation element to compute in current batch
     size_t getBatchStartIndex(size_t n_batches, size_t current_batch);
-
-    //! Returns the end iterator of simulation elements for the current batch
-    std::vector<SimulationElement>::iterator getBatchEnd(int n_batches, int current_batch);
 
     //! Returns the index of the simulation element after the last one to compute in current batch
     size_t getBatchEndIndex(size_t n_batches, size_t current_batch);

--- a/Core/Simulation/Simulation.h
+++ b/Core/Simulation/Simulation.h
@@ -153,6 +153,8 @@ private:
     virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(size_t start,
                                                                             size_t end) = 0;
 
+    virtual void addBackGroundIntensity(size_t begin_ind, size_t end_ind) = 0;
+
     //! Normalize the detector counts to beam intensity, to solid angle, and to exposure angle.
     //! @param start_ind Index of the first element to operate on
     //! @param end_ind Index of the element after the last one to operate on

--- a/Core/Simulation/Simulation.h
+++ b/Core/Simulation/Simulation.h
@@ -104,7 +104,7 @@ protected:
     //! Update the sample by calling the sample builder, if present
     void updateSample();
 
-    void runSingleSimulation();
+    void runSingleSimulation(bool use_storage = false, double weight = 1.0);
 
     virtual void updateIntensityMap() {}
 

--- a/Core/Simulation/Simulation.h
+++ b/Core/Simulation/Simulation.h
@@ -99,7 +99,7 @@ protected:
 
     //! Creates the appropriate data structure (e.g. 2D intensity map) from the calculated
     //! SimulationElement objects
-    virtual void transferResultsToIntensityMap() =0;
+    virtual void transferResultsToIntensityMap() {}
 
     //! Update the sample by calling the sample builder, if present
     void updateSample();
@@ -111,7 +111,7 @@ protected:
 
     void runSingleSimulation();
 
-    virtual void updateIntensityMap() =0;
+    virtual void updateIntensityMap() {}
 
     virtual void normalize(std::vector<SimulationElement>::iterator begin_it,
                    std::vector<SimulationElement>::iterator end_it) const;

--- a/Core/Simulation/Simulation.h
+++ b/Core/Simulation/Simulation.h
@@ -138,13 +138,13 @@ private:
     std::vector<SimulationElement>::iterator getBatchStart(int n_batches, int current_batch);
 
     //! Returns the index of the first simulation element to compute in current batch
-    size_t getBatchStartIndex(int n_batches, int current_batch);
+    size_t getBatchStartIndex(size_t n_batches, size_t current_batch);
 
     //! Returns the end iterator of simulation elements for the current batch
     std::vector<SimulationElement>::iterator getBatchEnd(int n_batches, int current_batch);
 
     //! Returns the index of the simulation element after the last one to compute in current batch
-    size_t getBatchEndIndex(int n_batches, int current_batch);
+    size_t getBatchEndIndex(size_t n_batches, size_t current_batch);
 
     //! Generate a single threaded computation for a given range of simulation elements
     //! @param start Index of the first element to include into computation

--- a/Core/Simulation/Simulation.h
+++ b/Core/Simulation/Simulation.h
@@ -124,16 +124,16 @@ private:
 
     //! Generate a single threaded computation for a given range of simulation elements
     //! @param start Index of the first element to include into computation
-    //! @param end Index of the element after the last one to include into computation
-    virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(size_t start,
-                                                                            size_t end) = 0;
+    //! @param n_elements Number of elements to process
+    virtual std::unique_ptr<IComputation>
+    generateSingleThreadedComputation(size_t start, size_t n_elements) = 0;
 
-    virtual void addBackGroundIntensity(size_t begin_ind, size_t end_ind) = 0;
+    virtual void addBackGroundIntensity(size_t start_ind, size_t n_elements) = 0;
 
     //! Normalize the detector counts to beam intensity, to solid angle, and to exposure angle.
     //! @param start_ind Index of the first element to operate on
-    //! @param end_ind Index of the element after the last one to operate on
-    void normalize(size_t start_ind, size_t end_ind);
+    //! @param n_elements Number of elements to process
+    void normalize(size_t start_ind, size_t n_elements);
 
     //! Normalize the detector counts to beam intensity, to solid angle, and to exposure angle
     //! for single simulation element specified by _index_.

--- a/Core/Simulation/Simulation.h
+++ b/Core/Simulation/Simulation.h
@@ -120,7 +120,8 @@ private:
     void initialize();
 
     //! Initializes the vector of Simulation elements
-    virtual void initSimulationElementVector() = 0;
+    //! @param init_storage Initialize storage for accumulating results
+    virtual void initSimulationElementVector(bool init_storage) = 0;
 
     //! Generate a single threaded computation for a given range of simulation elements
     //! @param start Index of the first element to include into computation
@@ -138,6 +139,12 @@ private:
     //! Normalize the detector counts to beam intensity, to solid angle, and to exposure angle
     //! for single simulation element specified by _index_.
     virtual void normalizeIntensity(size_t index, double beam_intensity) = 0;
+
+    virtual bool isStorageInited() const = 0;
+
+    virtual void addDataToStorage(double weight) = 0;
+
+    virtual void moveDataFromStorage() = 0;
 };
 
 #endif // SIMULATION_H

--- a/Core/Simulation/Simulation.h
+++ b/Core/Simulation/Simulation.h
@@ -137,8 +137,14 @@ private:
     //! Returns the start iterator of simulation elements for the current batch
     std::vector<SimulationElement>::iterator getBatchStart(int n_batches, int current_batch);
 
+    //! Returns the index of the first simulation element to compute in current batch
+    size_t getBatchStartIndex(int n_batches, int current_batch);
+
     //! Returns the end iterator of simulation elements for the current batch
     std::vector<SimulationElement>::iterator getBatchEnd(int n_batches, int current_batch);
+
+    //! Returns the index of the simulation element after the last one to compute in current batch
+    size_t getBatchEndIndex(int n_batches, int current_batch);
 
     //! Generate a single threaded computation for a given range of simulation elements
     //! @param start Index of the first element to include into computation

--- a/Core/Simulation/Simulation.h
+++ b/Core/Simulation/Simulation.h
@@ -139,6 +139,12 @@ private:
 
     //! Returns the end iterator of simulation elements for the current batch
     std::vector<SimulationElement>::iterator getBatchEnd(int n_batches, int current_batch);
+
+    //! Generate a single threaded computation for a given range of simulation elements
+    //! @param start Index of the first element to include into computation
+    //! @param end Index of the element after the last one to include into computation
+    virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(size_t start,
+                                                                            size_t end) = 0;
 };
 
 #endif // SIMULATION_H

--- a/Core/Simulation/Simulation.h
+++ b/Core/Simulation/Simulation.h
@@ -119,12 +119,6 @@ protected:
     void addBackGroundIntensity(std::vector<SimulationElement>::iterator begin_it,
                                 std::vector<SimulationElement>::iterator end_it) const;
 
-    //! Returns the start iterator of simulation elements for the current batch
-    std::vector<SimulationElement>::iterator getBatchStart(int n_batches, int current_batch);
-
-    //! Returns the end iterator of simulation elements for the current batch
-    std::vector<SimulationElement>::iterator getBatchEnd(int n_batches, int current_batch);
-
     SampleProvider m_sample_provider;
     SimulationOptions m_options;
     DistributionHandler m_distribution_handler;
@@ -139,6 +133,12 @@ private:
 
     //! Initializes the vector of Simulation elements
     virtual void initSimulationElementVector() = 0;
+
+    //! Returns the start iterator of simulation elements for the current batch
+    std::vector<SimulationElement>::iterator getBatchStart(int n_batches, int current_batch);
+
+    //! Returns the end iterator of simulation elements for the current batch
+    std::vector<SimulationElement>::iterator getBatchEnd(int n_batches, int current_batch);
 };
 
 #endif // SIMULATION_H

--- a/Core/Simulation/Simulation.h
+++ b/Core/Simulation/Simulation.h
@@ -122,12 +122,6 @@ private:
     //! Initializes the vector of Simulation elements
     virtual void initSimulationElementVector() = 0;
 
-    //! Returns the index of the first simulation element to compute in current batch
-    size_t getBatchStartIndex(size_t n_batches, size_t current_batch);
-
-    //! Returns the index of the simulation element after the last one to compute in current batch
-    size_t getBatchEndIndex(size_t n_batches, size_t current_batch);
-
     //! Generate a single threaded computation for a given range of simulation elements
     //! @param start Index of the first element to include into computation
     //! @param end Index of the element after the last one to include into computation

--- a/Core/Simulation/Simulation.h
+++ b/Core/Simulation/Simulation.h
@@ -101,11 +101,6 @@ protected:
     //! SimulationElement objects
     virtual void transferResultsToIntensityMap() {}
 
-    //! Update the sample by calling the sample builder, if present
-    void updateSample();
-
-    void runSingleSimulation(bool use_storage = false, double weight = 1.0);
-
     virtual void updateIntensityMap() {}
 
     SampleProvider m_sample_provider;
@@ -117,6 +112,11 @@ protected:
 
 private:
     void initialize();
+
+    //! Update the sample by calling the sample builder, if present
+    void updateSample();
+
+    void runSingleSimulation(bool use_storage = false, double weight = 1.0);
 
     //! Initializes the vector of Simulation elements
     //! @param init_storage Initialize storage for accumulating results

--- a/Core/Simulation/SpecularSimulation.cpp
+++ b/Core/Simulation/SpecularSimulation.cpp
@@ -42,6 +42,7 @@ SpecularSimulation::SpecularSimulation(const std::shared_ptr<IMultiLayerBuilder>
 
 SpecularSimulation::SpecularSimulation(const SpecularSimulation& other)
     : Simulation(other)
+    , m_sim_elements(other.m_sim_elements)
     , m_storage(other.m_storage)
 {
     initialize();

--- a/Core/Simulation/SpecularSimulation.cpp
+++ b/Core/Simulation/SpecularSimulation.cpp
@@ -120,6 +120,15 @@ std::unique_ptr<IComputation> SpecularSimulation::generateSingleThreadedComputat
     return std::make_unique<SpecularComputation>(*sample(), m_options, m_progress, start, end);
 }
 
+std::unique_ptr<IComputation> SpecularSimulation::generateSingleThreadedComputation(size_t start,
+                                                                            size_t end)
+{
+    assert(start < end && end <= m_sim_elements.size());
+    const auto& begin = m_sim_elements.begin();
+    return std::make_unique<SpecularComputation>(*sample(), m_options, m_progress,
+                                                 begin + start, begin + end);
+}
+
 OutputData<double>* SpecularSimulation::getDetectorIntensity(AxesUnits units_type) const
 {
     const size_t i_layer = 0; // detector intensity is proportional to reflectivity from the zeroth layer

--- a/Core/Simulation/SpecularSimulation.cpp
+++ b/Core/Simulation/SpecularSimulation.cpp
@@ -174,6 +174,11 @@ void SpecularSimulation::normalize(std::vector<SimulationElement>::iterator begi
     }
 }
 
+void SpecularSimulation::normalizeIntensity(size_t index, double beam_intensity)
+{
+    m_sim_elements[index].setIntensity(m_sim_elements[index].getIntensity() * beam_intensity);
+}
+
 void SpecularSimulation::validityCheck(size_t i_layer) const
 {
     const MultiLayer* current_sample = sample();

--- a/Core/Simulation/SpecularSimulation.cpp
+++ b/Core/Simulation/SpecularSimulation.cpp
@@ -115,13 +115,13 @@ SpecularSimulation::getDataByAbsValue(size_t i_layer, DataGetter fn_ptr) const
     return output_ptr;
 }
 
-std::unique_ptr<IComputation> SpecularSimulation::generateSingleThreadedComputation(size_t start,
-                                                                            size_t end)
+std::unique_ptr<IComputation>
+SpecularSimulation::generateSingleThreadedComputation(size_t start, size_t n_elements)
 {
-    assert(start < end && end <= m_sim_elements.size());
-    const auto& begin = m_sim_elements.begin();
-    return std::make_unique<SpecularComputation>(*sample(), m_options, m_progress,
-                                                 begin + start, begin + end);
+    assert(start < m_sim_elements.size() && start + n_elements <= m_sim_elements.size());
+    const auto& begin = m_sim_elements.begin() + start;
+    return std::make_unique<SpecularComputation>(*sample(), m_options, m_progress, begin,
+                                                 begin + n_elements);
 }
 
 OutputData<double>* SpecularSimulation::getDetectorIntensity(AxesUnits units_type) const
@@ -163,11 +163,11 @@ void SpecularSimulation::normalizeIntensity(size_t index, double beam_intensity)
     m_sim_elements[index].setIntensity(m_sim_elements[index].getIntensity() * beam_intensity);
 }
 
-void SpecularSimulation::addBackGroundIntensity(size_t begin_ind, size_t end_ind)
+void SpecularSimulation::addBackGroundIntensity(size_t start_ind, size_t n_elements)
 {
     if (!mP_background)
         return;
-    for (size_t i = begin_ind; i < end_ind; ++i) {
+    for (size_t i = start_ind, stop_point = start_ind + n_elements; i < stop_point; ++i) {
         SimulationElement& element = m_sim_elements[i];
         mP_background->addBackGround(element);
     }

--- a/Core/Simulation/SpecularSimulation.cpp
+++ b/Core/Simulation/SpecularSimulation.cpp
@@ -41,6 +41,7 @@ SpecularSimulation::SpecularSimulation(const std::shared_ptr<IMultiLayerBuilder>
 
 SpecularSimulation::SpecularSimulation(const SpecularSimulation& other)
     : Simulation(other)
+    , m_storage(other.m_storage)
 {
     initialize();
 }

--- a/Core/Simulation/SpecularSimulation.cpp
+++ b/Core/Simulation/SpecularSimulation.cpp
@@ -84,6 +84,11 @@ const IAxis* SpecularSimulation::getAlphaAxis() const
     return &m_instrument.getDetector()->getAxis(0);
 }
 
+void SpecularSimulation::initSimulationElementVector()
+{
+    m_sim_elements = m_instrument.createSimulationElements();
+}
+
 std::vector<complex_t> SpecularSimulation::getData(size_t i_layer, DataGetter fn_ptr) const
 {
     validityCheck(i_layer);

--- a/Core/Simulation/SpecularSimulation.cpp
+++ b/Core/Simulation/SpecularSimulation.cpp
@@ -19,6 +19,7 @@
 #include "SpecularMatrix.h"
 #include "MaterialUtils.h"
 #include "Histogram1D.h"
+#include "SimElementUtils.h"
 #include "SimulationElement.h"
 #include "SpecularComputation.h"
 #include "SpecularDetector1D.h"
@@ -86,9 +87,11 @@ const IAxis* SpecularSimulation::getAlphaAxis() const
     return &m_instrument.getDetector()->getAxis(0);
 }
 
-void SpecularSimulation::initSimulationElementVector()
+void SpecularSimulation::initSimulationElementVector(bool init_storage)
 {
     m_sim_elements = m_instrument.createSimulationElements();
+    if (init_storage)
+        m_storage = m_sim_elements;
 }
 
 std::vector<complex_t> SpecularSimulation::getData(size_t i_layer, DataGetter fn_ptr) const
@@ -172,6 +175,18 @@ void SpecularSimulation::addBackGroundIntensity(size_t start_ind, size_t n_eleme
         SimulationElement& element = m_sim_elements[i];
         mP_background->addBackGround(element);
     }
+}
+
+void SpecularSimulation::addDataToStorage(double weight)
+{
+    SimElementUtils::addElementsWithWeight(m_sim_elements, m_storage, weight);
+}
+
+void SpecularSimulation::moveDataFromStorage()
+{
+    assert(!m_storage.empty());
+    if (!m_storage.empty())
+        m_sim_elements = std::move(m_storage);
 }
 
 void SpecularSimulation::validityCheck(size_t i_layer) const

--- a/Core/Simulation/SpecularSimulation.cpp
+++ b/Core/Simulation/SpecularSimulation.cpp
@@ -115,12 +115,6 @@ SpecularSimulation::getDataByAbsValue(size_t i_layer, DataGetter fn_ptr) const
     return output_ptr;
 }
 
-std::unique_ptr<IComputation> SpecularSimulation::generateSingleThreadedComputation(
-    std::vector<SimulationElement>::iterator start, std::vector<SimulationElement>::iterator end)
-{
-    return std::make_unique<SpecularComputation>(*sample(), m_options, m_progress, start, end);
-}
-
 std::unique_ptr<IComputation> SpecularSimulation::generateSingleThreadedComputation(size_t start,
                                                                             size_t end)
 {
@@ -162,17 +156,6 @@ std::vector<complex_t> SpecularSimulation::getScalarT(size_t i_layer) const
 std::vector<complex_t> SpecularSimulation::getScalarKz(size_t i_layer) const
 {
     return getData(i_layer, &ILayerRTCoefficients::getScalarKz);
-}
-
-void SpecularSimulation::normalize(std::vector<SimulationElement>::iterator begin_it,
-                           std::vector<SimulationElement>::iterator end_it) const
-{
-    double beam_intensity = getBeamIntensity();
-    if (beam_intensity==0.0)
-        return; // no normalization when beam intensity is zero
-    for(auto it=begin_it; it!=end_it; ++it) {
-        it->setIntensity(it->getIntensity()*beam_intensity);
-    }
 }
 
 void SpecularSimulation::normalizeIntensity(size_t index, double beam_intensity)

--- a/Core/Simulation/SpecularSimulation.cpp
+++ b/Core/Simulation/SpecularSimulation.cpp
@@ -13,6 +13,7 @@
 // ************************************************************************** //
 
 #include "SpecularSimulation.h"
+#include "IBackground.h"
 #include "IMultiLayerBuilder.h"
 #include "MultiLayer.h"
 #include "SpecularMatrix.h"
@@ -177,6 +178,16 @@ void SpecularSimulation::normalize(std::vector<SimulationElement>::iterator begi
 void SpecularSimulation::normalizeIntensity(size_t index, double beam_intensity)
 {
     m_sim_elements[index].setIntensity(m_sim_elements[index].getIntensity() * beam_intensity);
+}
+
+void SpecularSimulation::addBackGroundIntensity(size_t begin_ind, size_t end_ind)
+{
+    if (!mP_background)
+        return;
+    for (size_t i = begin_ind; i < end_ind; ++i) {
+        SimulationElement& element = m_sim_elements[i];
+        mP_background->addBackGround(element);
+    }
 }
 
 void SpecularSimulation::validityCheck(size_t i_layer) const

--- a/Core/Simulation/SpecularSimulation.h
+++ b/Core/Simulation/SpecularSimulation.h
@@ -81,6 +81,9 @@ private:
 
     SpecularSimulation(const SpecularSimulation& other);
 
+    //! Initializes the vector of Simulation elements
+    virtual void initSimulationElementVector() override;
+
     std::vector<complex_t> getData(size_t i_layer, DataGetter fn_ptr) const;
 
     std::unique_ptr<OutputData<double>> getDataByAbsValue(size_t i_layer, DataGetter fn_ptr) const;

--- a/Core/Simulation/SpecularSimulation.h
+++ b/Core/Simulation/SpecularSimulation.h
@@ -88,10 +88,6 @@ private:
 
     std::unique_ptr<OutputData<double>> getDataByAbsValue(size_t i_layer, DataGetter fn_ptr) const;
 
-    // unused methods
-    virtual void transferResultsToIntensityMap() override {}
-    virtual void updateIntensityMap() override {}
-
     //! Generate a single threaded computation for a given range of SimulationElement's
     virtual std::unique_ptr<IComputation>
     generateSingleThreadedComputation(std::vector<SimulationElement>::iterator start,

--- a/Core/Simulation/SpecularSimulation.h
+++ b/Core/Simulation/SpecularSimulation.h
@@ -97,6 +97,12 @@ private:
     generateSingleThreadedComputation(std::vector<SimulationElement>::iterator start,
                                       std::vector<SimulationElement>::iterator end) override;
 
+    //! Generate a single threaded computation for a given range of simulation elements
+    //! @param start Index of the first element to include into computation
+    //! @param end Index of the element after the last one to include into computation
+    virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(size_t start,
+                                                                            size_t end) override;
+
     //! Normalize the detector counts to beam intensity, to solid angle, and to exposure angle.
     virtual void normalize(std::vector<SimulationElement>::iterator begin_it,
                            std::vector<SimulationElement>::iterator end_it) const override;

--- a/Core/Simulation/SpecularSimulation.h
+++ b/Core/Simulation/SpecularSimulation.h
@@ -90,9 +90,9 @@ private:
 
     //! Generate a single threaded computation for a given range of simulation elements
     //! @param start Index of the first element to include into computation
-    //! @param end Index of the element after the last one to include into computation
-    virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(size_t start,
-                                                                            size_t end) override;
+    //! @param n_elements Number of elements to process
+    virtual std::unique_ptr<IComputation>
+    generateSingleThreadedComputation(size_t start, size_t n_elements) override;
 
     //! Checks if simulation data is ready for retrieval
     void validityCheck(size_t i_layer) const;
@@ -104,7 +104,7 @@ private:
     //! for single simulation element specified by _index_.
     virtual void normalizeIntensity(size_t index, double beam_intensity) override;
 
-    virtual void addBackGroundIntensity(size_t begin_ind, size_t end_ind) override;
+    virtual void addBackGroundIntensity(size_t start_ind, size_t n_elements) override;
 };
 
 #endif // SPECULARSIMULATION_H

--- a/Core/Simulation/SpecularSimulation.h
+++ b/Core/Simulation/SpecularSimulation.h
@@ -114,6 +114,7 @@ private:
 
     virtual void moveDataFromStorage() override;
 
+    std::vector<SimulationElement> m_sim_elements;
     std::vector<SimulationElement> m_storage;
 };
 

--- a/Core/Simulation/SpecularSimulation.h
+++ b/Core/Simulation/SpecularSimulation.h
@@ -112,6 +112,8 @@ private:
     //! Normalize the detector counts to beam intensity, to solid angle, and to exposure angle
     //! for single simulation element specified by _index_.
     virtual void normalizeIntensity(size_t index, double beam_intensity) override;
+
+    virtual void addBackGroundIntensity(size_t begin_ind, size_t end_ind) override;
 };
 
 #endif // SPECULARSIMULATION_H

--- a/Core/Simulation/SpecularSimulation.h
+++ b/Core/Simulation/SpecularSimulation.h
@@ -16,6 +16,7 @@
 #define SPECULARSIMULATION_H
 
 #include "Simulation.h"
+#include "SimulationElement.h"
 #include "ILayerRTCoefficients.h"
 #include "OutputData.h"
 
@@ -105,6 +106,8 @@ private:
     virtual void normalizeIntensity(size_t index, double beam_intensity) override;
 
     virtual void addBackGroundIntensity(size_t start_ind, size_t n_elements) override;
+
+    std::vector<SimulationElement> m_storage;
 };
 
 #endif // SPECULARSIMULATION_H

--- a/Core/Simulation/SpecularSimulation.h
+++ b/Core/Simulation/SpecularSimulation.h
@@ -88,20 +88,11 @@ private:
 
     std::unique_ptr<OutputData<double>> getDataByAbsValue(size_t i_layer, DataGetter fn_ptr) const;
 
-    //! Generate a single threaded computation for a given range of SimulationElement's
-    virtual std::unique_ptr<IComputation>
-    generateSingleThreadedComputation(std::vector<SimulationElement>::iterator start,
-                                      std::vector<SimulationElement>::iterator end) override;
-
     //! Generate a single threaded computation for a given range of simulation elements
     //! @param start Index of the first element to include into computation
     //! @param end Index of the element after the last one to include into computation
     virtual std::unique_ptr<IComputation> generateSingleThreadedComputation(size_t start,
                                                                             size_t end) override;
-
-    //! Normalize the detector counts to beam intensity, to solid angle, and to exposure angle.
-    virtual void normalize(std::vector<SimulationElement>::iterator begin_it,
-                           std::vector<SimulationElement>::iterator end_it) const override;
 
     //! Checks if simulation data is ready for retrieval
     void validityCheck(size_t i_layer) const;

--- a/Core/Simulation/SpecularSimulation.h
+++ b/Core/Simulation/SpecularSimulation.h
@@ -83,7 +83,8 @@ private:
     SpecularSimulation(const SpecularSimulation& other);
 
     //! Initializes the vector of Simulation elements
-    virtual void initSimulationElementVector() override;
+    //! @param init_storage Initialize storage for accumulating results
+    virtual void initSimulationElementVector(bool init_storage) override;
 
     std::vector<complex_t> getData(size_t i_layer, DataGetter fn_ptr) const;
 
@@ -106,6 +107,12 @@ private:
     virtual void normalizeIntensity(size_t index, double beam_intensity) override;
 
     virtual void addBackGroundIntensity(size_t start_ind, size_t n_elements) override;
+
+    virtual bool isStorageInited() const override {return !m_storage.empty();}
+
+    virtual void addDataToStorage(double weight) override;
+
+    virtual void moveDataFromStorage() override;
 
     std::vector<SimulationElement> m_storage;
 };

--- a/Core/Simulation/SpecularSimulation.h
+++ b/Core/Simulation/SpecularSimulation.h
@@ -108,6 +108,10 @@ private:
 
     //! Initializes simulation
     void initialize();
+
+    //! Normalize the detector counts to beam intensity, to solid angle, and to exposure angle
+    //! for single simulation element specified by _index_.
+    virtual void normalizeIntensity(size_t index, double beam_intensity) override;
 };
 
 #endif // SPECULARSIMULATION_H

--- a/Tests/Functional/Core/CoreSpecial/BatchSimulation.cpp
+++ b/Tests/Functional/Core/CoreSpecial/BatchSimulation.cpp
@@ -35,9 +35,9 @@ bool BatchSimulation::runTest()
     const std::unique_ptr<OutputData<double>> result(reference->clone());
     result->setAllTo(0.0);
 
-    const int n_batches = 9;
+    const unsigned n_batches = 9;
     const double threshold = 2e-10;
-    for(int i_batch=0; i_batch<n_batches; ++i_batch) {
+    for(unsigned i_batch=0; i_batch < n_batches; ++i_batch) {
         const std::unique_ptr<Simulation> batch(simulation->clone());
         ThreadInfo threadInfo;
         threadInfo.n_threads = 1;

--- a/Tests/UnitTests/Core/Other/ThreadInfoTest.h
+++ b/Tests/UnitTests/Core/Other/ThreadInfoTest.h
@@ -16,5 +16,4 @@ TEST_F(ThreadInfoTest, DefaultValues)
     EXPECT_EQ(1, thread_info.n_batches);
     EXPECT_EQ(0, thread_info.current_batch);
     EXPECT_EQ(0, thread_info.n_threads);
-    EXPECT_EQ(0, thread_info.current_thread);
 }

--- a/Tests/UnitTests/Core/Other/ThreadInfoTest.h
+++ b/Tests/UnitTests/Core/Other/ThreadInfoTest.h
@@ -13,7 +13,7 @@ ThreadInfoTest::~ThreadInfoTest() = default;
 
 TEST_F(ThreadInfoTest, DefaultValues)
 {
-    EXPECT_EQ(1, thread_info.n_batches);
-    EXPECT_EQ(0, thread_info.current_batch);
-    EXPECT_EQ(0, thread_info.n_threads);
+    EXPECT_EQ(1u, thread_info.n_batches);
+    EXPECT_EQ(0u, thread_info.current_batch);
+    EXPECT_EQ(0u, thread_info.n_threads);
 }

--- a/auto/Wrap/doxygen_core.i
+++ b/auto/Wrap/doxygen_core.i
@@ -193,7 +193,7 @@ Calls the  INodeVisitor's visit method.
 // File: classBasicVector3D.xml
 %feature("docstring") BasicVector3D "
 
-Three-dimensional vector template, for use with integer, double, or complex components.
+Forked from CLHEP/Geometry by E. Chernyaev Evgueni.Tcherniaev@cern.ch, then reworked beyond recongnition. Removed split of point and vector semantics. Transforms are relegated to a separate class  Transform3D. Three-dimensional vector template, for use with integer, double, or complex components.
 
 C++ includes: BasicVector3D.h
 ";
@@ -746,7 +746,7 @@ C++ includes: ConstantBackground.h
 Calls the  INodeVisitor's visit method. 
 ";
 
-%feature("docstring")  ConstantBackground::addBackGround "void ConstantBackground::addBackGround(std::vector< SimulationElement >::iterator start, std::vector< SimulationElement >::iterator end) const override final
+%feature("docstring")  ConstantBackground::addBackGround "void ConstantBackground::addBackGround(SimulationElement &element) const override final
 ";
 
 
@@ -1683,12 +1683,12 @@ Calls the  INodeVisitor's visit method.
 
 Performs a single-threaded DWBA computation with given sample and simulation parameters.
 
-Controlled by the multi-threading machinery in  Simulation::runSingleSimulation().
+Controlled by the multi-threading machinery in Simulation::runSingleSimulation().
 
 C++ includes: DWBAComputation.h
 ";
 
-%feature("docstring")  DWBAComputation::DWBAComputation "DWBAComputation::DWBAComputation(const MultiLayer &multilayer, const SimulationOptions &options, ProgressHandler &progress, const std::vector< SimulationElement >::iterator &begin_it, const std::vector< SimulationElement >::iterator &end_it)
+%feature("docstring")  DWBAComputation::DWBAComputation "DWBAComputation::DWBAComputation(const MultiLayer &multilayer, const SimulationOptions &options, ProgressHandler &progress, std::vector< SimulationElement >::iterator begin_it, std::vector< SimulationElement >::iterator end_it)
 ";
 
 %feature("docstring")  DWBAComputation::~DWBAComputation "DWBAComputation::~DWBAComputation()
@@ -6177,7 +6177,10 @@ C++ includes: IBackground.h
 %feature("docstring")  IBackground::clone "virtual IBackground* IBackground::clone() const =0
 ";
 
-%feature("docstring")  IBackground::addBackGround "virtual void IBackground::addBackGround(std::vector< SimulationElement >::iterator start, std::vector< SimulationElement >::iterator end) const =0
+%feature("docstring")  IBackground::addBackGround "void IBackground::addBackGround(std::vector< SimulationElement >::iterator start, std::vector< SimulationElement >::iterator end) const
+";
+
+%feature("docstring")  IBackground::addBackGround "virtual void IBackground::addBackGround(SimulationElement &element) const =0
 ";
 
 
@@ -6306,12 +6309,12 @@ Creates region information with volumetric densities instead of absolute volume 
 
 Interface for a single-threaded computation with given range of SimulationElements and  ProgressHandler.
 
-Controlled by the multi-threading machinery in  Simulation::runSingleSimulation().
+Controlled by the multi-threading machinery in Simulation::runSingleSimulation().
 
 C++ includes: IComputation.h
 ";
 
-%feature("docstring")  IComputation::IComputation "IComputation::IComputation(const SimulationOptions &options, ProgressHandler &progress, const std::vector< SimulationElement >::iterator &start, const std::vector< SimulationElement >::iterator &end, const MultiLayer &sample)
+%feature("docstring")  IComputation::IComputation "IComputation::IComputation(const SimulationOptions &options, ProgressHandler &progress, std::vector< SimulationElement >::iterator start, std::vector< SimulationElement >::iterator end, const MultiLayer &sample)
 ";
 
 %feature("docstring")  IComputation::~IComputation "IComputation::~IComputation()
@@ -6673,7 +6676,7 @@ C++ includes: IFactory.h
 Creates object by calling creation function corresponded to given identifier. 
 ";
 
-%feature("docstring")  IFactory::create "std::unique_ptr<AbstractProduct> IFactory< Key, AbstractProduct >::create(const Key &item_key)
+%feature("docstring")  IFactory::create "std::unique_ptr<AbstractProduct> IFactory< Key, AbstractProduct >::create(const Key &item_key) const
 ";
 
 %feature("docstring")  IFactory::registerItem "bool IFactory< Key, AbstractProduct >::registerItem(const Key &item_key, CreateItemCallback CreateFn, const std::string &itemDescription=\"\")
@@ -6681,7 +6684,7 @@ Creates object by calling creation function corresponded to given identifier.
 Registers object's creation function and store object description. 
 ";
 
-%feature("docstring")  IFactory::contains "bool IFactory< Key, AbstractProduct >::contains(const Key &item_key)
+%feature("docstring")  IFactory::contains "bool IFactory< Key, AbstractProduct >::contains(const Key &item_key) const
 ";
 
 %feature("docstring")  IFactory::~IFactory "IFactory< Key, AbstractProduct >::~IFactory()
@@ -11873,7 +11876,7 @@ C++ includes: PoissonNoiseBackground.h
 Calls the  INodeVisitor's visit method. 
 ";
 
-%feature("docstring")  PoissonNoiseBackground::addBackGround "void PoissonNoiseBackground::addBackGround(std::vector< SimulationElement >::iterator start, std::vector< SimulationElement >::iterator end) const override final
+%feature("docstring")  PoissonNoiseBackground::addBackGround "void PoissonNoiseBackground::addBackGround(SimulationElement &element) const override final
 ";
 
 
@@ -13581,7 +13584,7 @@ Number of points for MonteCarlo integrator
 Sets number of threads to use during the simulation (0 - take the default value from the hardware) 
 ";
 
-%feature("docstring")  SimulationOptions::getNumberOfThreads "int SimulationOptions::getNumberOfThreads() const
+%feature("docstring")  SimulationOptions::getNumberOfThreads "unsigned SimulationOptions::getNumberOfThreads() const
 ";
 
 %feature("docstring")  SimulationOptions::setNumberOfBatches "void SimulationOptions::setNumberOfBatches(int nbatches)
@@ -13589,10 +13592,10 @@ Sets number of threads to use during the simulation (0 - take the default value 
 Sets number of batches to split. 
 ";
 
-%feature("docstring")  SimulationOptions::getNumberOfBatches "int SimulationOptions::getNumberOfBatches() const
+%feature("docstring")  SimulationOptions::getNumberOfBatches "unsigned SimulationOptions::getNumberOfBatches() const
 ";
 
-%feature("docstring")  SimulationOptions::getCurrentBatch "int SimulationOptions::getCurrentBatch() const
+%feature("docstring")  SimulationOptions::getCurrentBatch "unsigned SimulationOptions::getCurrentBatch() const
 ";
 
 %feature("docstring")  SimulationOptions::setThreadInfo "void SimulationOptions::setThreadInfo(const ThreadInfo &thread_info)
@@ -13600,7 +13603,7 @@ Sets number of batches to split.
 Sets the batch and thread information to be used. 
 ";
 
-%feature("docstring")  SimulationOptions::getHardwareConcurrency "int SimulationOptions::getHardwareConcurrency() const
+%feature("docstring")  SimulationOptions::getHardwareConcurrency "unsigned SimulationOptions::getHardwareConcurrency() const
 ";
 
 %feature("docstring")  SimulationOptions::setIncludeSpecular "void SimulationOptions::setIncludeSpecular(bool include_specular)
@@ -13740,12 +13743,12 @@ C++ includes: IFormFactorBorn.h
 
 Performs a single-threaded specular computation with given sample.
 
-Controlled by the multi-threading machinery in  Simulation::runSingleSimulation().
+Controlled by the multi-threading machinery in Simulation::runSingleSimulation().
 
 C++ includes: SpecularComputation.h
 ";
 
-%feature("docstring")  SpecularComputation::SpecularComputation "SpecularComputation::SpecularComputation(const MultiLayer &multilayer, const SimulationOptions &options, ProgressHandler &progress, const std::vector< SimulationElement >::iterator &begin_it, const std::vector< SimulationElement >::iterator &end_it)
+%feature("docstring")  SpecularComputation::SpecularComputation "SpecularComputation::SpecularComputation(const MultiLayer &multilayer, const SimulationOptions &options, ProgressHandler &progress, std::vector< SimulationElement >::iterator begin_it, std::vector< SimulationElement >::iterator end_it)
 ";
 
 %feature("docstring")  SpecularComputation::~SpecularComputation "SpecularComputation::~SpecularComputation()
@@ -14742,10 +14745,13 @@ C++ includes: ZLimits.h
 // File: namespace_0D450.xml
 
 
-// File: namespace_0D522.xml
+// File: namespace_0D455.xml
 
 
-// File: namespace_0D544.xml
+// File: namespace_0D523.xml
+
+
+// File: namespace_0D545.xml
 
 
 // File: namespace_0D73.xml
@@ -15336,6 +15342,11 @@ ba.ParameterDistribution(\"/Particle/Height\", distr_1, 10, 0.0, ba.RealLimits.l
 ";
 
 
+// File: namespaceSimElementUtils.xml
+%feature("docstring")  SimElementUtils::addElementsWithWeight "void SimElementUtils::addElementsWithWeight(const std::vector< SimElement > &from, std::vector< SimElement > &to, double weight)
+";
+
+
 // File: namespaceStandardSimulations.xml
 %feature("docstring")  StandardSimulations::PolarizedDWBAMagCylinders2 "GISASSimulation * StandardSimulations::PolarizedDWBAMagCylinders2()
 ";
@@ -15654,17 +15665,9 @@ global helper function for comparison of axes
 
 
 // File: SimulationElement_8cpp.xml
-%feature("docstring")  addElementsWithWeight "void addElementsWithWeight(std::vector< SimulationElement >::const_iterator first, std::vector< SimulationElement >::const_iterator last, std::vector< SimulationElement >::iterator result, double weight)
-
-Add element vector to element vector with weight. 
-";
 
 
 // File: SimulationElement_8h.xml
-%feature("docstring")  addElementsWithWeight "void addElementsWithWeight(std::vector< SimulationElement >::const_iterator first, std::vector< SimulationElement >::const_iterator last, std::vector< SimulationElement >::iterator result, double weight)
-
-Add element vector to element vector with weight. 
-";
 
 
 // File: VariableBinAxis_8cpp.xml
@@ -17105,6 +17108,9 @@ Generate vertices of centered ellipse with given semi-axes at height z.
 
 
 // File: OffSpecSimulation_8h.xml
+
+
+// File: SimElementUtils_8h.xml
 
 
 // File: Simulation_8cpp.xml

--- a/auto/Wrap/libBornAgainCore.py
+++ b/auto/Wrap/libBornAgainCore.py
@@ -2626,7 +2626,7 @@ class kvector_t(_object):
     """
 
 
-    Three-dimensional vector template, for use with integer, double, or complex components.
+    Forked from CLHEP/Geometry by E. Chernyaev Evgueni.Tcherniaev@cern.ch, then reworked beyond recongnition. Removed split of point and vector semantics. Transforms are relegated to a separate class  Transform3D. Three-dimensional vector template, for use with integer, double, or complex components.
 
     C++ includes: BasicVector3D.h
 
@@ -3138,7 +3138,7 @@ class cvector_t(_object):
     """
 
 
-    Three-dimensional vector template, for use with integer, double, or complex components.
+    Forked from CLHEP/Geometry by E. Chernyaev Evgueni.Tcherniaev@cern.ch, then reworked beyond recongnition. Removed split of point and vector semantics. Transforms are relegated to a separate class  Transform3D. Three-dimensional vector template, for use with integer, double, or complex components.
 
     C++ includes: BasicVector3D.h
 
@@ -16569,9 +16569,9 @@ class SimulationOptions(_object):
 
     def getNumberOfThreads(self):
         """
-        getNumberOfThreads(SimulationOptions self) -> int
+        getNumberOfThreads(SimulationOptions self) -> unsigned int
 
-        int SimulationOptions::getNumberOfThreads() const
+        unsigned SimulationOptions::getNumberOfThreads() const
 
         """
         return _libBornAgainCore.SimulationOptions_getNumberOfThreads(self)
@@ -16591,9 +16591,9 @@ class SimulationOptions(_object):
 
     def getNumberOfBatches(self):
         """
-        getNumberOfBatches(SimulationOptions self) -> int
+        getNumberOfBatches(SimulationOptions self) -> unsigned int
 
-        int SimulationOptions::getNumberOfBatches() const
+        unsigned SimulationOptions::getNumberOfBatches() const
 
         """
         return _libBornAgainCore.SimulationOptions_getNumberOfBatches(self)
@@ -16601,9 +16601,9 @@ class SimulationOptions(_object):
 
     def getCurrentBatch(self):
         """
-        getCurrentBatch(SimulationOptions self) -> int
+        getCurrentBatch(SimulationOptions self) -> unsigned int
 
-        int SimulationOptions::getCurrentBatch() const
+        unsigned SimulationOptions::getCurrentBatch() const
 
         """
         return _libBornAgainCore.SimulationOptions_getCurrentBatch(self)
@@ -16623,9 +16623,9 @@ class SimulationOptions(_object):
 
     def getHardwareConcurrency(self):
         """
-        getHardwareConcurrency(SimulationOptions self) -> int
+        getHardwareConcurrency(SimulationOptions self) -> unsigned int
 
-        int SimulationOptions::getHardwareConcurrency() const
+        unsigned SimulationOptions::getHardwareConcurrency() const
 
         """
         return _libBornAgainCore.SimulationOptions_getHardwareConcurrency(self)
@@ -17854,14 +17854,15 @@ class IBackground(ICloneable, INode):
         return _libBornAgainCore.IBackground_clone(self)
 
 
-    def addBackGround(self, start, end):
+    def addBackGround(self, *args):
         """
         addBackGround(IBackground self, std::vector< SimulationElement,std::allocator< SimulationElement > >::iterator start, std::vector< SimulationElement,std::allocator< SimulationElement > >::iterator end)
+        addBackGround(IBackground self, SimulationElement & element)
 
-        virtual void IBackground::addBackGround(std::vector< SimulationElement >::iterator start, std::vector< SimulationElement >::iterator end) const =0
+        virtual void IBackground::addBackGround(SimulationElement &element) const =0
 
         """
-        return _libBornAgainCore.IBackground_addBackGround(self, start, end)
+        return _libBornAgainCore.IBackground_addBackGround(self, *args)
 
 IBackground_swigregister = _libBornAgainCore.IBackground_swigregister
 IBackground_swigregister(IBackground)
@@ -17933,14 +17934,14 @@ class ConstantBackground(IBackground):
         return _libBornAgainCore.ConstantBackground_accept(self, visitor)
 
 
-    def addBackGround(self, start, end):
+    def addBackGround(self, element):
         """
-        addBackGround(ConstantBackground self, std::vector< SimulationElement,std::allocator< SimulationElement > >::iterator start, std::vector< SimulationElement,std::allocator< SimulationElement > >::iterator end)
+        addBackGround(ConstantBackground self, SimulationElement & element)
 
-        void ConstantBackground::addBackGround(std::vector< SimulationElement >::iterator start, std::vector< SimulationElement >::iterator end) const override final
+        void ConstantBackground::addBackGround(SimulationElement &element) const override final
 
         """
-        return _libBornAgainCore.ConstantBackground_addBackGround(self, start, end)
+        return _libBornAgainCore.ConstantBackground_addBackGround(self, element)
 
 ConstantBackground_swigregister = _libBornAgainCore.ConstantBackground_swigregister
 ConstantBackground_swigregister(ConstantBackground)
@@ -25471,14 +25472,14 @@ class PoissonNoiseBackground(IBackground):
         return _libBornAgainCore.PoissonNoiseBackground_accept(self, visitor)
 
 
-    def addBackGround(self, start, end):
+    def addBackGround(self, element):
         """
-        addBackGround(PoissonNoiseBackground self, std::vector< SimulationElement,std::allocator< SimulationElement > >::iterator start, std::vector< SimulationElement,std::allocator< SimulationElement > >::iterator end)
+        addBackGround(PoissonNoiseBackground self, SimulationElement & element)
 
-        void PoissonNoiseBackground::addBackGround(std::vector< SimulationElement >::iterator start, std::vector< SimulationElement >::iterator end) const override final
+        void PoissonNoiseBackground::addBackGround(SimulationElement &element) const override final
 
         """
-        return _libBornAgainCore.PoissonNoiseBackground_addBackGround(self, start, end)
+        return _libBornAgainCore.PoissonNoiseBackground_addBackGround(self, element)
 
 PoissonNoiseBackground_swigregister = _libBornAgainCore.PoissonNoiseBackground_swigregister
 PoissonNoiseBackground_swigregister(PoissonNoiseBackground)
@@ -26497,10 +26498,6 @@ class ThreadInfo(_object):
     __swig_getmethods__["n_threads"] = _libBornAgainCore.ThreadInfo_n_threads_get
     if _newclass:
         n_threads = _swig_property(_libBornAgainCore.ThreadInfo_n_threads_get, _libBornAgainCore.ThreadInfo_n_threads_set)
-    __swig_setmethods__["current_thread"] = _libBornAgainCore.ThreadInfo_current_thread_set
-    __swig_getmethods__["current_thread"] = _libBornAgainCore.ThreadInfo_current_thread_get
-    if _newclass:
-        current_thread = _swig_property(_libBornAgainCore.ThreadInfo_current_thread_get, _libBornAgainCore.ThreadInfo_current_thread_set)
     __swig_setmethods__["n_batches"] = _libBornAgainCore.ThreadInfo_n_batches_set
     __swig_getmethods__["n_batches"] = _libBornAgainCore.ThreadInfo_n_batches_get
     if _newclass:
@@ -26572,7 +26569,7 @@ class SampleBuilderFactoryTemp(_object):
         """
         contains(SampleBuilderFactoryTemp self, std::string const & item_key) -> bool
 
-        bool IFactory< Key, AbstractProduct >::contains(const Key &item_key)
+        bool IFactory< Key, AbstractProduct >::contains(const Key &item_key) const
 
         """
         return _libBornAgainCore.SampleBuilderFactoryTemp_contains(self, item_key)
@@ -26721,7 +26718,7 @@ class SimulationFactoryTemp(_object):
         """
         contains(SimulationFactoryTemp self, std::string const & item_key) -> bool
 
-        bool IFactory< Key, AbstractProduct >::contains(const Key &item_key)
+        bool IFactory< Key, AbstractProduct >::contains(const Key &item_key) const
 
         """
         return _libBornAgainCore.SimulationFactoryTemp_contains(self, item_key)


### PR DESCRIPTION
1. Iterator-based methods replaced by index-based methods in Simulation
2. Simulation elements moved down to leaf classes in Simulation hierarchy

Seems that part of Simulation functionality can be isolated in a separate hierarchy with a templated class