### PR TITLE
Fix Boost include for GUI

### DIFF
--- a/GUI/main/CMakeLists.txt
+++ b/GUI/main/CMakeLists.txt
@@ -7,6 +7,7 @@ set(executable_name BornAgain)
 # source files
 # -----------------------------------------------------------------------------
 include_directories(
+    ${Boost_INCLUDE_DIRS}
     ${BornAgainGUI_INCLUDE_DIRS}
     ${QtAddOn_INCLUDE_DIRS}
     ${GSL_INCLUDE_DIR}


### PR DESCRIPTION
The following fix is necessary to ensure that the Boost installation as
found by CMake will be used, instead of the one that is installed in
/usr/include.