### PR TITLE
Correct common typos discovered by lintian.

### DIFF
--- a/Core/Aggregate/InterferenceFunction2DParaCrystal.cpp
+++ b/Core/Aggregate/InterferenceFunction2DParaCrystal.cpp
@@ -209,7 +209,7 @@ double InterferenceFunction2DParaCrystal::interference1D(double qx, double qy, d
         throw Exceptions::NullPointerException(
             "InterferenceFunction2DParaCrystal::"
             "interference1D() -> Error! Probability distributions for "
-            "interference funtion not properly initialized");
+            "interference function not properly initialized");
 
     double result(0.0);
     double length = index ? m_lattice->length2() : m_lattice->length1();

--- a/Core/Aggregate/InterferenceFunctionRadialParaCrystal.cpp
+++ b/Core/Aggregate/InterferenceFunctionRadialParaCrystal.cpp
@@ -83,7 +83,7 @@ double InterferenceFunctionRadialParaCrystal::evaluate(const kvector_t q) const
     if (!mP_pdf)
         throw Exceptions::NullPointerException("InterferenceFunctionRadialParaCrystal::"
                 "evaluate() -> Error! Probability distribution for "
-                "interference funtion not properly initialized");
+                "interference function not properly initialized");
     double result=0.0;
     double qxr = q.x();
     double qyr = q.y();

--- a/Core/Fitting/FitSuiteImpl.cpp
+++ b/Core/Fitting/FitSuiteImpl.cpp
@@ -191,7 +191,7 @@ void FitSuiteImpl::link_fit_parameters()
     if(FitSuiteUtils::hasConflicts(*m_kernel->fitParameters())) {
         std::ostringstream message;
         message << "FitSuite::runFit() -> Error. Fit parameters are conflicting with each other, "
-                << "meaning that one sample parameter can be controled by "
+                << "meaning that one sample parameter can be controlled by "
                 << "two different fit parameters.\n";
         message << FitSuiteUtils::fitParameterSettingsToString(*m_kernel->fitParameters());
         throw Exceptions::RuntimeErrorException(message.str());

--- a/Core/Fitting/FitSuiteObjects.h
+++ b/Core/Fitting/FitSuiteObjects.h
@@ -55,7 +55,7 @@ public:
     double getChiSquaredValue() const { return m_chi_squared_value; }
 
     //! Returns residuals for single data element
-    //! @param global_index index accross all element in FitElement vector
+    //! @param global_index index across all element in FitElement vector
     double getResidualValue(size_t global_index);
 
     void setNfreeParameters(int nfree_parameters) { m_nfree_parameters = nfree_parameters; }

--- a/Core/Instrument/IntensityDataFunctions.cpp
+++ b/Core/Instrument/IntensityDataFunctions.cpp
@@ -163,7 +163,7 @@ IntensityDataFunctions::createClippedDataSet(const OutputData<double>& origin, d
 // be converted into 0.5 (which is a bin center expressed in bin fraction coordinates).
 // The coordinate -5.0 (outside of axis definition) will be converted to -0.5
 // (center of non-existing bin #-1).
-// Used for Mask convertion.
+// Used for Mask conversion.
 
 double IntensityDataFunctions::coordinateToBinf(double coordinate, const IAxis& axis)
 {

--- a/Core/Mask/Polygon.cpp
+++ b/Core/Mask/Polygon.cpp
@@ -64,7 +64,7 @@ void PolygonPrivate::get_points(std::vector<double>& xpos, std::vector<double>& 
 //! @param y Vector of y-coordinates of polygon points.
 
 // IMPORTANT Input parameters are not "const reference" to be able to work from python
-// (auto convertion of python list to vector<double>).
+// (auto conversion of python list to vector<double>).
 Polygon::Polygon(const std::vector<double> x, const std::vector<double> y)
     : IShape2D("Polygon"), m_d(new PolygonPrivate)
 {
@@ -72,7 +72,7 @@ Polygon::Polygon(const std::vector<double> x, const std::vector<double> y)
 }
 
 // IMPORTANT Input parameter is not "const reference" to be able to work from python
-// (auto convertion of python list to vector<vector<double>>).
+// (auto conversion of python list to vector<vector<double>>).
     //! Polygon defined by two  dimensional array with (x,y) coordinates of polygon points.
     //! The size of second dimension should be 2. If polygon is unclosed (the last point
     //! doesn't repeat the first one), it will be closed automatically.

--- a/Core/Material/MaterialBySLDImpl.h
+++ b/Core/Material/MaterialBySLDImpl.h
@@ -56,7 +56,7 @@ public:
 
 private:
     //! Constructs a wavelength-independent material with a given complex-valued
-    //! scattering lenght density (SLD). SLD units are \f$ nm^{-2} \f$.
+    //! scattering length density (SLD). SLD units are \f$ nm^{-2} \f$.
     MaterialBySLDImpl(const std::string& name, double sld_real, double sld_imag,
                       kvector_t magnetization);
 

--- a/Core/Material/MaterialFactoryFuncs.h
+++ b/Core/Material/MaterialFactoryFuncs.h
@@ -46,7 +46,7 @@ BA_CORE_API_ Material MaterialBySLD();
 //! @ingroup materials
 
 //! Constructs a wavelength-independent material with a given complex-valued
-//! scattering lenght density (SLD).
+//! scattering length density (SLD).
 //! SLD values for a wide variety of materials can be found on
 //! https://sld-calculator.appspot.com/
 //! and

--- a/GUI/coregui/Models/BeamDistributionItem.cpp
+++ b/GUI/coregui/Models/BeamDistributionItem.cpp
@@ -121,7 +121,7 @@ void BeamDistributionItem::resetToValue(double value)
     distributionItem->setItemValue(DistributionNoneItem::P_VALUE, value);
 }
 
-//! Scales the values provided by distribution (to perform deg->rad convertion in the case
+//! Scales the values provided by distribution (to perform deg->rad conversion in the case
 //! of AngleDistributionItems.
 
 double BeamDistributionItem::scaleFactor() const

--- a/GUI/coregui/Models/DetectorItems.h
+++ b/GUI/coregui/Models/DetectorItems.h
@@ -51,7 +51,7 @@ protected:
     virtual std::unique_ptr<IDetector2D> createDomainDetector() const = 0;
     std::unique_ptr<IResolutionFunction2D> createResolutionFunction() const;
 
-    //! Scales the values provided by axes (to perform deg->rad convertion on the way to domain).
+    //! Scales the values provided by axes (to perform deg->rad conversion on the way to domain).
     virtual double axesToDomainUnitsFactor() const { return 1.0; }
 
     void addMasksToDomain(IDetector2D* detector) const;

--- a/GUI/coregui/Models/LayerRoughnessItems.cpp
+++ b/GUI/coregui/Models/LayerRoughnessItems.cpp
@@ -17,7 +17,7 @@
 
 namespace {
 const QString hurst_tooltip =
-    "Hurst parameter which decribes how jagged the interface,\n "
+    "Hurst parameter which describes how jagged the interface,\n "
     "dimensionless [0.0, 1.0], where 0.0 gives more spikes, \n1.0 more smoothness.";
 }
 

--- a/GUI/coregui/Views/FitWidgets/FitComparisonController.h
+++ b/GUI/coregui/Views/FitWidgets/FitComparisonController.h
@@ -22,7 +22,7 @@ class SessionModel;
 class IntensityDataItem;
 class PropertyRepeater;
 
-//! Provides syncronization between certain properties of fit related IntensityDataItems.
+//! Provides synchronization between certain properties of fit related IntensityDataItems.
 //! Part of FitComparisonWidget.
 
 class BA_CORE_API_ FitComparisonController : public QObject

--- a/GUI/coregui/Views/InstrumentWidgets/DetectorMaskDelegate.h
+++ b/GUI/coregui/Views/InstrumentWidgets/DetectorMaskDelegate.h
@@ -25,7 +25,7 @@ class MaskEditor;
 class SessionModel;
 class DetectorItem;
 
-//! The DetectorMaskDelegate class provides syncronization between DetectorItem (defined
+//! The DetectorMaskDelegate class provides synchronization between DetectorItem (defined
 //! in InstrumentModel) and temporary IntensityDataItem (defined in temporary SessionModel).
 //! The later one is used by MaskEditor for mask drawing.
 

--- a/GUI/coregui/Views/MaskWidgets/MaskUnitsConverter.cpp
+++ b/GUI/coregui/Views/MaskWidgets/MaskUnitsConverter.cpp
@@ -135,5 +135,5 @@ double MaskUnitsConverter::convert(double value, int axis_index)
         return IntensityDataFunctions::coordinateFromBinf(value, mp_data->getAxis(axis_index));
     }
 
-    throw GUIHelpers::Error("MaskUnitsConverter::convertX() -> Error. Unknown convertion");
+    throw GUIHelpers::Error("MaskUnitsConverter::convertX() -> Error. Unknown conversion");
 }

--- a/GUI/coregui/Views/MaskWidgets/PolygonView.cpp
+++ b/GUI/coregui/Views/MaskWidgets/PolygonView.cpp
@@ -166,7 +166,7 @@ void PolygonView::update_polygon()
     m_block_on_point_update = false;
 }
 
-//! When polygon moves as a whole thing accross the scene, given method updates coordinates
+//! When polygon moves as a whole thing across the scene, given method updates coordinates
 //! of PolygonPointItem's
 void PolygonView::update_points()
 {

--- a/GUI/coregui/Views/SampleDesigner/DesignerHelper.cpp
+++ b/GUI/coregui/Views/SampleDesigner/DesignerHelper.cpp
@@ -133,7 +133,7 @@ QPixmap DesignerHelper::getPixmapParticle()
     return pixmap;
 }
 
-// non-linear convertion of layer's thickness in nanometers to screen size to have reasonable
+// non-linear conversion of layer's thickness in nanometers to screen size to have reasonable
 // graphics representation
 int DesignerHelper::nanometerToScreen(double nanometer)
 {

--- a/GUI/coregui/Views/SampleDesigner/DesignerHelper.h
+++ b/GUI/coregui/Views/SampleDesigner/DesignerHelper.h
@@ -87,7 +87,7 @@ public:
         return left->y() < right->y();
     }
 
-    //! non-linear convertion of layer's thickness in nanometers to screen size
+    //! non-linear conversion of layer's thickness in nanometers to screen size
     //! to have reasonable graphics representation of layer in the form of QRect
     static int nanometerToScreen(double nanometer);
 

--- a/Tests/Functional/Python/PyCore/histogram2d.py
+++ b/Tests/Functional/Python/PyCore/histogram2d.py
@@ -8,7 +8,7 @@ class Histogram2DTest(unittest.TestCase):
     def test_constructFromNumpyInt(self):
         """
         Testing construction of 2D histogram from numpy array.
-        Automatic convertion under Python3 is not working, that's why it is float64 and not int64
+        Automatic conversion under Python3 is not working, that's why it is float64 and not int64
         """
         arr = numpy.array([[ 1,  2,  3,  4,  5],
                            [ 6,  7,  8,  9, 10],

--- a/Tests/Functional/Python/PyCore/mesocrystal1.py
+++ b/Tests/Functional/Python/PyCore/mesocrystal1.py
@@ -62,7 +62,7 @@ class MySampleBuilder(IMultiLayerBuilder):
         air_layer = Layer(p_air_material)
         avg_layer = Layer(p_average_layer_material, self.meso_height.value)
         substrate_layer = Layer(p_substrate_material)
-        p_interference_funtion = InterferenceFunctionNone()
+        p_interference_function = InterferenceFunctionNone()
         particle_layout = ParticleLayout()
 
         n_max_phi_rotation_steps = 2
@@ -81,7 +81,7 @@ class MySampleBuilder(IMultiLayerBuilder):
                 particle_layout.addParticle(meso, 1.0, kvector_t(0,0,0), total_transform)
 
         particle_layout.setTotalParticleSurfaceDensity(surface_density)
-        particle_layout.setInterferenceFunction(p_interference_funtion)
+        particle_layout.setInterferenceFunction(p_interference_function)
 
         avg_layer.addLayout(particle_layout)
 

--- a/Tests/UnitTests/Core/DataStructure/IntensityDataFunctionsTest.h
+++ b/Tests/UnitTests/Core/DataStructure/IntensityDataFunctionsTest.h
@@ -127,7 +127,7 @@ TEST_F(IntensityDataFunctionsTest, coordinateToFromBinf)
     EXPECT_EQ(3.5, IntensityDataFunctions::coordinateFromBinf(8.5, axis));
 }
 
-//! Transformation of coordinates from one OutputData to another using convertion from axes
+//! Transformation of coordinates from one OutputData to another using conversion from axes
 //! coordinates to bin-fraction-coordinates and then to another axes coordinates.
 
 TEST_F(IntensityDataFunctionsTest, outputDataCoordinatesToFromBinf)


### PR DESCRIPTION
Hi,

while working on the debian packaging (*slowly* getting there!) I discovered some common misspellings with lintian (a debian static package analysis tool). As far as I can tell, this doesn't change API so should be safe to apply.

Cheers

Mika