### PR TITLE
Refactoring in FitObject and IDetector

### DIFF
--- a/Core/Fitting/FitObject.h
+++ b/Core/Fitting/FitObject.h
@@ -82,7 +82,6 @@ public:
 
 private:
     void init_parameters();
-    void init_dataset(const OutputData<double>& real_data);
 
     std::unique_ptr<Simulation> m_simulation;
     SimulationResult m_simulation_result;

--- a/Core/Instrument/IntensityDataFunctions.cpp
+++ b/Core/Instrument/IntensityDataFunctions.cpp
@@ -13,12 +13,18 @@
 // ************************************************************************** //
 
 #include "IntensityDataFunctions.h"
+#include "ArrayUtils.h"
 #include "BornAgainNamespace.h"
 #include "ConvolutionDetectorResolution.h"
+#include "DetectorFunctions.h"
 #include "FourierTransform.h"
+#include "IDetector.h"
 #include "IHistogram.h"
+#include "Instrument.h"
 #include "Numeric.h"
+#include "Simulation.h"
 #include "SimulationResult.h"
+#include "UnitConverterUtils.h"
 #include <math.h>
 
 //! Returns sum of relative differences between each pair of elements:
@@ -29,14 +35,14 @@ double IntensityDataFunctions::RelativeDifference(const SimulationResult& dat,
     if (dat.size() != ref.size())
         throw std::runtime_error("Error in IntensityDataFunctions::RelativeDifference: "
                                  "different number of elements");
-    if (dat.size()==0) return 0.0;
+    if (dat.size() == 0)
+        return 0.0;
     double sum_of_diff = 0.0;
-    for (size_t i=0; i<dat.size(); ++i) {
+    for (size_t i = 0; i < dat.size(); ++i) {
         sum_of_diff += Numeric::get_relative_difference(dat[i], ref[i]);
     }
     return sum_of_diff / dat.size();
 }
-
 
 //! Returns relative difference between two data sets sum(dat[i] - ref[i])/ref[i]).
 double IntensityDataFunctions::getRelativeDifference(const OutputData<double>& dat,
@@ -272,4 +278,49 @@ IntensityDataFunctions::createFFT(const OutputData<double>& data)
     auto array_2d = IntensityDataFunctions::create2DArrayfromOutputData(data);
     auto fft_array_2d = IntensityDataFunctions::FT2DArray(array_2d);
     return IntensityDataFunctions::createOutputDatafrom2DArray(fft_array_2d);
+}
+
+SimulationResult IntensityDataFunctions::ConvertData(const Simulation& simulation,
+                                                     const OutputData<double>& data,
+                                                     bool put_masked_areas_to_zero)
+{
+    auto converter = UnitConverterUtils::createConverter(simulation);
+    auto roi_data
+        = UnitConverterUtils::createOutputData(*converter.get(), converter->defaultUnits());
+
+    auto detector = simulation.getInstrument().getDetector();
+
+    if (roi_data->hasSameDimensions(data)) {
+        // data is already cropped to ROI
+        if (put_masked_areas_to_zero) {
+            detector->iterate(
+                [&](IDetector::const_iterator it) {
+                    (*roi_data)[it.roiIndex()] = data[it.roiIndex()];
+                }, /*visit_masked*/ false);
+        } else {
+            roi_data->setRawDataVector(data.getRawDataVector());
+        }
+
+    } else if (DetectorFunctions::hasSameDimensions(*detector, data)) {
+        // exp data has same shape as the detector, we have to put orig data to smaller roi map
+        detector->iterate(
+            [&](IDetector::const_iterator it) {
+                (*roi_data)[it.roiIndex()] = data[it.detectorIndex()];
+            },
+            /*visit_masked*/ !put_masked_areas_to_zero);
+
+    } else {
+        throw std::runtime_error("FitObject::init_dataset() -> Error. Detector and exp data have "
+                                 "different shape.");
+    }
+
+    return SimulationResult(*roi_data, *converter);
+}
+
+SimulationResult IntensityDataFunctions::ConvertData(const Simulation& simulation,
+                                                     const std::vector<std::vector<double>>& data,
+                                                     bool put_masked_areas_to_zero)
+{
+    auto output_data = ArrayUtils::createData2D(data);
+    return IntensityDataFunctions::ConvertData(simulation, *output_data, put_masked_areas_to_zero);
 }

--- a/Core/Instrument/IntensityDataFunctions.h
+++ b/Core/Instrument/IntensityDataFunctions.h
@@ -25,7 +25,8 @@ class Simulation;
 //! Functions to work with intensity data.
 //! @ingroup tools
 
-namespace IntensityDataFunctions {
+namespace IntensityDataFunctions
+{
 //! Returns sum of relative differences between each pair of elements:
 //! (a, b) -> 2*abs(a - b)/(a + b)      ( and zero if  a-b=0 )
 BA_CORE_API_ double RelativeDifference(const SimulationResult& dat, const SimulationResult& ref);
@@ -87,14 +88,13 @@ BA_CORE_API_ std::unique_ptr<OutputData<double>> createFFT(const OutputData<doub
 //! @param simulation: Simulation object with possible ROI and masks defined.
 //! @param data: User data with amplitudes with the shape of data matching the detector.
 //! @return SimulationResult object.
-SimulationResult ConvertData(const Simulation& simulation,
-                             const OutputData<double>& data,
-                             bool put_masked_areas_to_zero = true);
+BA_CORE_API_ SimulationResult ConvertData(const Simulation& simulation,
+                                          const OutputData<double>& data,
+                                          bool put_masked_areas_to_zero = true);
 
-SimulationResult ConvertData(const Simulation& simulation,
-                             const std::vector<std::vector<double>>& data,
-                             bool put_masked_areas_to_zero = true);
-
+BA_CORE_API_ SimulationResult ConvertData(const Simulation& simulation,
+                                          const std::vector<std::vector<double>>& data,
+                                          bool put_masked_areas_to_zero = true);
 
 }; // namespace IntensityDataFunctions
 

--- a/Core/Instrument/IntensityDataFunctions.h
+++ b/Core/Instrument/IntensityDataFunctions.h
@@ -20,6 +20,7 @@
 
 class IHistogram;
 class SimulationResult;
+class Simulation;
 
 //! Functions to work with intensity data.
 //! @ingroup tools
@@ -79,6 +80,21 @@ createOutputDatafrom2DArray(const std::vector<std::vector<double>>& array_2d);
 BA_CORE_API_ std::unique_ptr<OutputData<double>> createFFT(const OutputData<double>& data);
 
 #endif // SWIG
+
+//! Convert user data to SimulationResult object for later drawing in various axes units.
+//! User data will be cropped to the ROI defined in the simulation, amplitudes in areas
+//! corresponding to the masked areas of the detector will be set to zero.
+//! @param simulation: Simulation object with possible ROI and masks defined.
+//! @param data: User data with amplitudes with the shape of data matching the detector.
+//! @return SimulationResult object.
+SimulationResult ConvertData(const Simulation& simulation,
+                             const OutputData<double>& data,
+                             bool put_masked_areas_to_zero = true);
+
+SimulationResult ConvertData(const Simulation& simulation,
+                             const std::vector<std::vector<double>>& data,
+                             bool put_masked_areas_to_zero = true);
+
 
 }; // namespace IntensityDataFunctions
 

--- a/auto/Wrap/libBornAgainCore.py
+++ b/auto/Wrap/libBornAgainCore.py
@@ -20814,6 +20814,15 @@ def FT2DArray(signal):
 
     """
     return _libBornAgainCore.FT2DArray(signal)
+
+def ConvertData(*args):
+    """
+    ConvertData(Simulation simulation, IntensityData data, bool put_masked_areas_to_zero=True) -> SimulationResult
+    ConvertData(Simulation simulation, IntensityData data) -> SimulationResult
+    ConvertData(Simulation simulation, vdouble2d_t data, bool put_masked_areas_to_zero=True) -> SimulationResult
+    ConvertData(Simulation simulation, vdouble2d_t data) -> SimulationResult
+    """
+    return _libBornAgainCore.ConvertData(*args)
 class IntensityDataIOFactory(_object):
     """
 


### PR DESCRIPTION
* Put intensities to zero in masked areas of simulated image to avoid negative amplitudes (because of detector resolution)
* Global function to convert user data to SimulationResult