### PR TITLE
GUI ParticleDistribution implementation

### DIFF
--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.cpp
@@ -30,11 +30,7 @@
 #include "Lattice2DItems.h"
 #include "Units.h"
 #include "ParticleCompositionItem.h"
-#include "IParticle.h"
-#include "IFormFactorDecorator.h"
-#include "Particle.h"
 #include "ParticleCoreShellItem.h"
-#include "ParticleCoreShell.h"
 
 RealSpaceBuilder::RealSpaceBuilder(QWidget* parent)
     : QWidget(parent)
@@ -68,10 +64,10 @@ void RealSpaceBuilder::populate(RealSpaceModel* model,
     else if (item.modelType() == Constants::ParticleType)
         populateParticle(model, item);
 
-    else if (item.modelType() == Constants::ParticleCoreShellType)
+    else if (item.modelType() == Constants::ParticleCompositionType)
         populateParticle(model, item);
 
-    else if (item.modelType() == Constants::ParticleCompositionType)
+    else if (item.modelType() == Constants::ParticleCoreShellType)
         populateParticle(model, item);
 }
 
@@ -168,107 +164,18 @@ void RealSpaceBuilder::populateParticle(RealSpaceModel* model,
     {
         auto particleCompositionItem = dynamic_cast<const ParticleCompositionItem*>(&particleItem);
         auto particleComposition = particleCompositionItem->createParticleComposition();
-        populateParticleComposition(model, particleComposition.get(), origin);
+        RealSpaceBuilderUtils::populateParticleComposition(model, particleComposition.get(), origin);
     }
     else if( particleItem.modelType() == Constants::ParticleCoreShellType)
     {
         auto particleCoreShellItem = dynamic_cast<const ParticleCoreShellItem*>(&particleItem);
         auto particleCoreShell = particleCoreShellItem->createParticleCoreShell();
-        populateParticleCoreShell(model, particleCoreShell.get(), origin);
+        RealSpaceBuilderUtils::populateParticleCoreShell(model, particleCoreShell.get(), origin);
     }
     else if(particleItem.modelType() == Constants::ParticleType)
     {
         auto pItem = dynamic_cast<const ParticleItem*>(&particleItem);
         auto particle = pItem->createParticle();
-        auto particle3D = TransformTo3D::createParticle3D(particleItem);
-
-        RealSpaceBuilderUtils::applyParticleTransformations(particle.get(), particle3D.get(), origin);
-        RealSpaceBuilderUtils::applyParticleColor(particle.get(), particle3D.get());
-
-        if (particle3D)
-            model->add(particle3D.release());
+        RealSpaceBuilderUtils::populateSingleParticle(model, particle.get(), origin);
     }
-}
-
-void RealSpaceBuilder::populateParticleComposition(RealSpaceModel *model,
-                                                   const ParticleComposition *particleComposition,
-                                                   const QVector3D &origin) const
-{
-    SafePointerVector<IParticle> pc_vector = particleComposition->decompose();
-
-    for (IParticle* pc_particle : pc_vector)
-    {
-        if(dynamic_cast<ParticleCoreShell*>(pc_particle))
-        {
-            auto particleCoreShell = dynamic_cast<ParticleCoreShell*>(pc_particle);
-            populateParticleCoreShell(model, particleCoreShell, origin);
-        }
-        else
-        {
-            auto particle = dynamic_cast<Particle*>(pc_particle);
-            populateSingleParticle(model, particle, origin);
-        }
-    }
-}
-
-void RealSpaceBuilder::populateParticleCoreShell(RealSpaceModel *model,
-                                                 const ParticleCoreShell *particleCoreShell,
-                                                 const QVector3D &origin) const
-{
-    const IFormFactor* coreParticleff = particleCoreShell->coreParticle()->createFormFactor();
-    const IFormFactor* shellParticleff = particleCoreShell->shellParticle()->createFormFactor();
-
-    // TRUE as long as coreParticleff is of IFormFactorDecorator (or its derived) type
-    while(dynamic_cast<const IFormFactorDecorator*>(coreParticleff))
-        coreParticleff =
-                dynamic_cast<const IFormFactorDecorator*>(coreParticleff)->getFormFactor();
-
-    // TRUE as long as shellParticleff is of IFormFactorDecorator (or its derived) type
-    while(dynamic_cast<const IFormFactorDecorator*>(shellParticleff))
-        shellParticleff =
-                dynamic_cast<const IFormFactorDecorator*>(shellParticleff)->getFormFactor();
-
-    auto coreParticle3D = TransformTo3D::createParticlefromIFormFactor(coreParticleff);
-    auto shellParticle3D = TransformTo3D::createParticlefromIFormFactor(shellParticleff);
-
-    // core
-    RealSpaceBuilderUtils::applyParticleCoreShellTransformations(particleCoreShell->coreParticle(),
-                                                                 coreParticle3D.get(),
-                                                                 particleCoreShell,
-                                                                 origin);
-    RealSpaceBuilderUtils::applyParticleColor(particleCoreShell->coreParticle(),
-                                              coreParticle3D.get());
-
-    // shell (set an alpha value of 0.5 for transparency)
-    RealSpaceBuilderUtils::applyParticleCoreShellTransformations(particleCoreShell->shellParticle(),
-                                                                 shellParticle3D.get(),
-                                                                 particleCoreShell,
-                                                                 origin);
-    RealSpaceBuilderUtils::applyParticleColor(particleCoreShell->shellParticle(),
-                                              shellParticle3D.get(), 0.5);
-
-    if (coreParticle3D)
-        model->add(coreParticle3D.release());
-
-    if (shellParticle3D)
-        model->addBlend(shellParticle3D.release()); // use addBlend() for transparent object
-}
-
-void RealSpaceBuilder::populateSingleParticle(RealSpaceModel *model, const Particle *particle,
-                                              const QVector3D &origin) const
-{
-    const IFormFactor* ff = particle->createFormFactor();
-
-    // TRUE as long as ff is of IFormFactorDecorator (or its derived) type
-    while(dynamic_cast<const IFormFactorDecorator*>(ff))
-        ff = dynamic_cast<const IFormFactorDecorator*>(ff)->getFormFactor();
-
-    auto particle3D = TransformTo3D::createParticlefromIFormFactor(ff);
-
-    RealSpaceBuilderUtils::applyParticleTransformations(particle, particle3D.get(),
-                                                        origin);
-    RealSpaceBuilderUtils::applyParticleColor(particle, particle3D.get());
-
-    if (particle3D)
-        model->add(particle3D.release());
 }

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.cpp
@@ -31,6 +31,8 @@
 #include "Units.h"
 #include "ParticleCompositionItem.h"
 #include "ParticleCoreShellItem.h"
+#include "ParticleCoreShell.h"
+#include "Particle.h"
 
 RealSpaceBuilder::RealSpaceBuilder(QWidget* parent)
     : QWidget(parent)

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.cpp
@@ -33,6 +33,7 @@
 #include "ParticleCoreShellItem.h"
 #include "ParticleCoreShell.h"
 #include "Particle.h"
+#include "ParticleDistributionItem.h"
 
 RealSpaceBuilder::RealSpaceBuilder(QWidget* parent)
     : QWidget(parent)
@@ -70,6 +71,9 @@ void RealSpaceBuilder::populate(RealSpaceModel* model,
         populateParticle(model, item);
 
     else if (item.modelType() == Constants::ParticleCoreShellType)
+        populateParticle(model, item);
+
+    else if (item.modelType() == Constants::ParticleDistributionType)
         populateParticle(model, item);
 }
 
@@ -173,6 +177,12 @@ void RealSpaceBuilder::populateParticle(RealSpaceModel* model,
         auto particleCoreShellItem = dynamic_cast<const ParticleCoreShellItem*>(&particleItem);
         auto particleCoreShell = particleCoreShellItem->createParticleCoreShell();
         RealSpaceBuilderUtils::populateParticleCoreShell(model, particleCoreShell.get(), origin);
+    }
+    else if(particleItem.modelType() == Constants::ParticleDistributionType)
+    {
+        auto particleDistributionItem = dynamic_cast<const ParticleDistributionItem*>(&particleItem);
+        auto particleDistribution = particleDistributionItem->createParticleDistribution();
+        RealSpaceBuilderUtils::populateParticleDistribution(model, particleDistribution.get(), origin);
     }
     else if(particleItem.modelType() == Constants::ParticleType)
     {

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.cpp
@@ -206,20 +206,7 @@ void RealSpaceBuilder::populateParticleComposition(RealSpaceModel *model,
         else
         {
             auto particle = dynamic_cast<Particle*>(pc_particle);
-            const IFormFactor* ff = pc_particle->createFormFactor();
-
-            // TRUE as long as ff is of IFormFactorDecorator (or its derived) type
-            while(dynamic_cast<const IFormFactorDecorator*>(ff))
-                ff = dynamic_cast<const IFormFactorDecorator*>(ff)->getFormFactor();
-
-            auto particle3D = TransformTo3D::createParticlefromIFormFactor(ff);
-
-            RealSpaceBuilderUtils::applyParticleTransformations(particle, particle3D.get(),
-                                                                origin);
-            RealSpaceBuilderUtils::applyParticleColor(particle, particle3D.get());
-
-            if (particle3D)
-                model->add(particle3D.release());
+            populateSingleParticle(model, particle, origin);
         }
     }
 }
@@ -265,4 +252,23 @@ void RealSpaceBuilder::populateParticleCoreShell(RealSpaceModel *model,
 
     if (shellParticle3D)
         model->addBlend(shellParticle3D.release()); // use addBlend() for transparent object
+}
+
+void RealSpaceBuilder::populateSingleParticle(RealSpaceModel *model, const Particle *particle,
+                                              const QVector3D &origin) const
+{
+    const IFormFactor* ff = particle->createFormFactor();
+
+    // TRUE as long as ff is of IFormFactorDecorator (or its derived) type
+    while(dynamic_cast<const IFormFactorDecorator*>(ff))
+        ff = dynamic_cast<const IFormFactorDecorator*>(ff)->getFormFactor();
+
+    auto particle3D = TransformTo3D::createParticlefromIFormFactor(ff);
+
+    RealSpaceBuilderUtils::applyParticleTransformations(particle, particle3D.get(),
+                                                        origin);
+    RealSpaceBuilderUtils::applyParticleColor(particle, particle3D.get());
+
+    if (particle3D)
+        model->add(particle3D.release());
 }

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.h
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.h
@@ -26,6 +26,7 @@ class Shape3D;
 class SceneGeometry;
 class ParticleCoreShell;
 class ParticleComposition;
+class Particle;
 
 class BA_CORE_API_ RealSpaceBuilder : public QWidget
 {
@@ -66,6 +67,9 @@ public:
     void populateParticleCoreShell(RealSpaceModel *model,
                                    const ParticleCoreShell* particleCoreShell,
                                    const QVector3D &origin) const;
+
+    void populateSingleParticle(RealSpaceModel *model, const Particle* particle,
+                                const QVector3D &origin) const;
 
 };
 

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.h
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.h
@@ -24,9 +24,6 @@ class SessionItem;
 class RealSpaceModel;
 class Shape3D;
 class SceneGeometry;
-class ParticleCoreShell;
-class ParticleComposition;
-class Particle;
 
 class BA_CORE_API_ RealSpaceBuilder : public QWidget
 {
@@ -59,18 +56,6 @@ public:
 
     void populateParticle(RealSpaceModel* model, const SessionItem& particleItem,
                           const QVector3D& origin = QVector3D()) const;
-
-    void populateParticleComposition(RealSpaceModel *model,
-                                     const ParticleComposition* particleComposition,
-                                     const QVector3D &origin) const;
-
-    void populateParticleCoreShell(RealSpaceModel *model,
-                                   const ParticleCoreShell* particleCoreShell,
-                                   const QVector3D &origin) const;
-
-    void populateSingleParticle(RealSpaceModel *model, const Particle* particle,
-                                const QVector3D &origin) const;
-
 };
 
 #endif // REALSPACEBUILDER_H

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilderUtils.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilderUtils.cpp
@@ -34,13 +34,11 @@
 #include "MaterialItem.h"
 #include "ParticleCoreShell.h"
 #include "Rotations.h"
-
 #include "ParticleCompositionItem.h"
 #include "IParticle.h"
 #include "IFormFactorDecorator.h"
 #include "Particle.h"
 #include "ParticleCoreShellItem.h"
-#include "ParticleCoreShell.h"
 #include "TransformTo3D.h"
 
 // compute cumulative abundances of particles
@@ -341,8 +339,7 @@ void RealSpaceBuilderUtils::applyParticleTransformations(const Particle* particl
         const IRotation* rotation = particle->rotation();
 
         if(rotation)
-            particle_rotate =
-                    RealSpaceBuilderUtils::implementParticleRotationfromIRotation(rotation);
+            particle_rotate = implementParticleRotationfromIRotation(rotation);
 
         // translation
         float x = static_cast<float>(particle->position().x());
@@ -380,8 +377,7 @@ void RealSpaceBuilderUtils::applyParticleCoreShellTransformations(
         const IRotation* rotation = P_clone->rotation();
 
         if(rotation)
-            particle_rotate =
-                    RealSpaceBuilderUtils::implementParticleRotationfromIRotation(rotation);
+            particle_rotate = implementParticleRotationfromIRotation(rotation);
 
         // translation
         kvector_t positionCoreShell = particleCoreShell->position();
@@ -429,12 +425,12 @@ void RealSpaceBuilderUtils::populateParticleComposition(
         if(dynamic_cast<ParticleCoreShell*>(pc_particle))
         {
             auto particleCoreShell = dynamic_cast<ParticleCoreShell*>(pc_particle);
-            RealSpaceBuilderUtils::populateParticleCoreShell(model, particleCoreShell, origin);
+            populateParticleCoreShell(model, particleCoreShell, origin);
         }
         else
         {
             auto particle = dynamic_cast<Particle*>(pc_particle);
-            RealSpaceBuilderUtils::populateSingleParticle(model, particle, origin);
+            populateSingleParticle(model, particle, origin);
         }
     }
 }
@@ -459,20 +455,14 @@ void RealSpaceBuilderUtils::populateParticleCoreShell(
     auto shellParticle3D = TransformTo3D::createParticlefromIFormFactor(shellParticleff);
 
     // core
-    RealSpaceBuilderUtils::applyParticleCoreShellTransformations(particleCoreShell->coreParticle(),
-                                                                 coreParticle3D.get(),
-                                                                 particleCoreShell,
-                                                                 origin);
-    RealSpaceBuilderUtils::applyParticleColor(particleCoreShell->coreParticle(),
-                                              coreParticle3D.get());
+    applyParticleCoreShellTransformations(particleCoreShell->coreParticle(), coreParticle3D.get(),
+                                          particleCoreShell, origin);
+    applyParticleColor(particleCoreShell->coreParticle(), coreParticle3D.get());
 
     // shell (set an alpha value of 0.5 for transparency)
-    RealSpaceBuilderUtils::applyParticleCoreShellTransformations(particleCoreShell->shellParticle(),
-                                                                 shellParticle3D.get(),
-                                                                 particleCoreShell,
-                                                                 origin);
-    RealSpaceBuilderUtils::applyParticleColor(particleCoreShell->shellParticle(),
-                                              shellParticle3D.get(), 0.5);
+    applyParticleCoreShellTransformations(particleCoreShell->shellParticle(), shellParticle3D.get(),
+                                          particleCoreShell, origin);
+    applyParticleColor(particleCoreShell->shellParticle(), shellParticle3D.get(), 0.5);
 
     if (coreParticle3D)
         model->add(coreParticle3D.release());
@@ -492,8 +482,8 @@ void RealSpaceBuilderUtils::populateSingleParticle(
 
     auto particle3D = TransformTo3D::createParticlefromIFormFactor(ff);
 
-    RealSpaceBuilderUtils::applyParticleTransformations(particle, particle3D.get(), origin);
-    RealSpaceBuilderUtils::applyParticleColor(particle, particle3D.get());
+    applyParticleTransformations(particle, particle3D.get(), origin);
+    applyParticleColor(particle, particle3D.get());
 
     if (particle3D)
         model->add(particle3D.release());

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilderUtils.h
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilderUtils.h
@@ -25,7 +25,9 @@ class SceneGeometry;
 class RealSpaceBuilder;
 class IRotation;
 class Particle;
+class ParticleComposition;
 class ParticleCoreShell;
+
 namespace RealSpace{ namespace Particles { class Particle; } }
 
 namespace RealSpaceBuilderUtils
@@ -73,6 +75,18 @@ BA_CORE_API_ void applyParticleCoreShellTransformations(const Particle *particle
 BA_CORE_API_ void applyParticleColor(const Particle *particle,
                                      RealSpace::Particles::Particle *particle3D,
                                      double alpha = 1);
+
+// Methods to populate different Particle Types
+BA_CORE_API_ void populateParticleComposition(RealSpaceModel *model,
+                                 const ParticleComposition* particleComposition,
+                                 const QVector3D &origin);
+
+BA_CORE_API_ void populateParticleCoreShell(RealSpaceModel *model,
+                               const ParticleCoreShell* particleCoreShell,
+                               const QVector3D &origin);
+
+BA_CORE_API_ void populateSingleParticle(RealSpaceModel *model, const Particle* particle,
+                            const QVector3D &origin);
 
 } // namespace RealSpaceBuilderUtils
 

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilderUtils.h
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilderUtils.h
@@ -27,6 +27,7 @@ class IRotation;
 class Particle;
 class ParticleComposition;
 class ParticleCoreShell;
+class ParticleDistribution;
 namespace RealSpace{ namespace Particles { class Particle; } }
 
 namespace RealSpaceBuilderUtils
@@ -83,6 +84,10 @@ BA_CORE_API_ void populateParticleComposition(RealSpaceModel *model,
 BA_CORE_API_ void populateParticleCoreShell(RealSpaceModel *model,
                                             const ParticleCoreShell* particleCoreShell,
                                             const QVector3D &origin);
+
+BA_CORE_API_ void populateParticleDistribution(RealSpaceModel *model,
+                                               const ParticleDistribution* particleDistribution,
+                                               const QVector3D &origin);
 
 BA_CORE_API_ void populateSingleParticle(RealSpaceModel *model, const Particle* particle,
                                          const QVector3D &origin);

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilderUtils.h
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilderUtils.h
@@ -27,7 +27,6 @@ class IRotation;
 class Particle;
 class ParticleComposition;
 class ParticleCoreShell;
-
 namespace RealSpace{ namespace Particles { class Particle; } }
 
 namespace RealSpaceBuilderUtils
@@ -78,15 +77,15 @@ BA_CORE_API_ void applyParticleColor(const Particle *particle,
 
 // Methods to populate different Particle Types
 BA_CORE_API_ void populateParticleComposition(RealSpaceModel *model,
-                                 const ParticleComposition* particleComposition,
-                                 const QVector3D &origin);
+                                              const ParticleComposition* particleComposition,
+                                              const QVector3D &origin);
 
 BA_CORE_API_ void populateParticleCoreShell(RealSpaceModel *model,
-                               const ParticleCoreShell* particleCoreShell,
-                               const QVector3D &origin);
+                                            const ParticleCoreShell* particleCoreShell,
+                                            const QVector3D &origin);
 
 BA_CORE_API_ void populateSingleParticle(RealSpaceModel *model, const Particle* particle,
-                            const QVector3D &origin);
+                                         const QVector3D &origin);
 
 } // namespace RealSpaceBuilderUtils
 


### PR DESCRIPTION
In this pull request the following have been implemented:

1. A separate function to populate a single particle
2. Functions for populating various particle types (e.g. ParticleComposition, ParticleCoreShell, single particle) have been moved from RealSpaceBuilder.cpp to RealSpaceBuilderUtils.cpp
3. Function for populating ParticleDistribution has been implemented

**Note** - In order to view in the GUI the standard sample "Cylinders with size distribution", please change the TotalParticleDensity to a smaller value (e.g. 0.001). Otherwise the program takes an enormous amount of time to execute.