### PR TITLE
Allow RealDataItem to carry 1D output data

### DIFF
--- a/GUI/coregui/Models/DataItem.cpp
+++ b/GUI/coregui/Models/DataItem.cpp
@@ -22,7 +22,6 @@ const QString DataItem::P_AXES_UNITS = "Axes Units";
 
 void DataItem::setOutputData(OutputData<double>* data)
 {
-    Q_ASSERT(data);
     m_data.reset(data);
 }
 

--- a/GUI/coregui/Models/IntensityDataItem.cpp
+++ b/GUI/coregui/Models/IntensityDataItem.cpp
@@ -78,6 +78,10 @@ IntensityDataItem::IntensityDataItem() : DataItem(Constants::IntensityDataType)
 
 void IntensityDataItem::setOutputData(OutputData<double>* data)
 {
+    assert(data && "Assertion failed in IntensityDataItem::setOutputData: nullptr data passed");
+    if (data->getRank() != 2)
+        throw GUIHelpers::Error(
+            "Error in IntensityDataItem::setOutputData: cannot handle non-2D data");
     DataItem::setOutputData(data);
 
     updateAxesZoomLevel();

--- a/GUI/coregui/Models/IntensityDataItemUtils.cpp
+++ b/GUI/coregui/Models/IntensityDataItemUtils.cpp
@@ -27,8 +27,8 @@ IntensityDataItem* IntensityDataItemUtils::intensityDataItem(SessionItem* parent
 
     if (parent->modelType() == Constants::JobItemType)
         return &parent->item<IntensityDataItem>(JobItem::T_OUTPUT);
-    else if(parent->modelType() == Constants::RealDataType)
-        return &parent->item<IntensityDataItem>(RealDataItem::T_INTENSITY_DATA);
+    else if(auto real_data = dynamic_cast<RealDataItem*>(parent))
+        return real_data->intensityDataItem();
     else if(parent->modelType() == Constants::IntensityDataType)
         return dynamic_cast<IntensityDataItem *>(parent);
     else

--- a/GUI/coregui/Models/JobModel.cpp
+++ b/GUI/coregui/Models/JobModel.cpp
@@ -136,9 +136,9 @@ QVector<SessionItem *> JobModel::nonXMLData() const
         if (auto intensityItem = jobItem->getItem(JobItem::T_OUTPUT))
             result.push_back(intensityItem);
 
-        if (auto realData = jobItem->getItem(JobItem::T_REALDATA)) {
-            if (auto intensityItem = realData->getItem(RealDataItem::T_INTENSITY_DATA))
-                result.push_back(intensityItem);
+        if (auto real_data = dynamic_cast<RealDataItem*>(jobItem->getItem(JobItem::T_REALDATA))) {
+            if (auto data_item = real_data->dataItem())
+                result.push_back(data_item);
         }
     }
 

--- a/GUI/coregui/Models/RealDataItem.h
+++ b/GUI/coregui/Models/RealDataItem.h
@@ -26,10 +26,11 @@ template <class T> class OutputData;
 
 class BA_CORE_API_ RealDataItem : public SessionItem
 {
+    static const QString T_INTENSITY_DATA;
+
 public:
     static const QString P_INSTRUMENT_ID;
     static const QString P_INSTRUMENT_NAME;
-    static const QString T_INTENSITY_DATA;
     RealDataItem();
 
     IntensityDataItem* intensityDataItem();

--- a/GUI/coregui/Models/RealDataModel.cpp
+++ b/GUI/coregui/Models/RealDataModel.cpp
@@ -13,6 +13,7 @@
 // ************************************************************************** //
 
 #include "RealDataModel.h"
+#include "DataItem.h"
 #include "RealDataItem.h"
 
 RealDataModel::RealDataModel(QObject *parent)
@@ -34,7 +35,7 @@ QVector<SessionItem *> RealDataModel::nonXMLData() const
     QVector<SessionItem *> result;
 
     for (auto realData : topItems<RealDataItem>()) {
-        if (auto intensityItem = realData->getItem(RealDataItem::T_INTENSITY_DATA))
+        if (auto intensityItem = realData->dataItem())
             result.push_back(intensityItem);
     }
 

--- a/GUI/coregui/Models/SessionItem.cpp
+++ b/GUI/coregui/Models/SessionItem.cpp
@@ -264,10 +264,10 @@ SessionItem* SessionItem::takeItem(int row, const QString& tag)
     const QString tagName = tag.isEmpty() ? defaultTag() : tag;
 
     if (!m_tags->isValid(tagName))
-        throw GUIHelpers::Error("SessionItem::insertItem() -> Invalid tag, modelType.");
+        throw GUIHelpers::Error("SessionItem::takeItem() -> Invalid tag, modelType.");
 
     if (m_tags->isSingleItemTag(tagName))
-        throw GUIHelpers::Error("SessionItem::insertItem() -> Single item tag.");
+        throw GUIHelpers::Error("SessionItem::takeItem() -> Single item tag.");
 
     int index = m_tags->indexFromTagRow(tagName, row);
     Q_ASSERT(index >= 0 && index <= m_children.size());

--- a/GUI/coregui/Models/SpecularDataItem.cpp
+++ b/GUI/coregui/Models/SpecularDataItem.cpp
@@ -48,6 +48,10 @@ SpecularDataItem::SpecularDataItem() : DataItem(Constants::SpecularDataType)
 
 void SpecularDataItem::setOutputData(OutputData<double>* data)
 {
+    assert(data && "Assertion failed in SpecularDataItem::setOutputData: nullptr data passed");
+    if (data->getRank() != 1)
+        throw GUIHelpers::Error(
+            "Error in SpecularDataItem::setOutputData: cannot handle non-1D data");
     DataItem::setOutputData(data);
 
     updateAxesZoomLevel();

--- a/GUI/coregui/Views/ImportDataWidgets/RealDataMaskWidget.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/RealDataMaskWidget.cpp
@@ -61,8 +61,7 @@ void RealDataMaskWidget::unsubscribeFromItem()
 
 IntensityDataItem* RealDataMaskWidget::intensityDataItem()
 {
-    IntensityDataItem* result = dynamic_cast<IntensityDataItem*>(
-                currentItem()->getItem(RealDataItem::T_INTENSITY_DATA));
+    IntensityDataItem* result = dynamic_cast<RealDataItem*>(currentItem())->intensityDataItem();
     Q_ASSERT(result);
     return result;
 }

--- a/Tests/UnitTests/GUI/TestLinkInstrument.h
+++ b/Tests/UnitTests/GUI/TestLinkInstrument.h
@@ -15,6 +15,24 @@ class TestLinkInstrument : public ::testing::Test
 {
 public:
     ~TestLinkInstrument();
+
+    std::unique_ptr<OutputData<double>> createData(double value = 0.0)
+    {
+        std::unique_ptr<OutputData<double>> result(new OutputData<double>());
+        result->addAxis("x", 5, -1.0, 1.0);
+        result->addAxis("y", 10, 0.0, 2.0);
+        result->setAllTo(value);
+        return result;
+    }
+
+    //! Helper function to create test RealData
+    RealDataItem* createRealData(SessionModel& model)
+    {
+        RealDataItem* result = dynamic_cast<RealDataItem*>(
+            model.insertNewItem(Constants::RealDataType));
+        result->setOutputData(createData().release());
+        return result;
+    }
 };
 
 TestLinkInstrument::~TestLinkInstrument() = default;
@@ -65,8 +83,7 @@ TEST_F(TestLinkInstrument, test_canLinkToInstrument)
     QString identifier = instrument->getItemValue(InstrumentItem::P_IDENTIFIER).toString();
 
     // populating real data model, setting intensity data
-    RealDataItem* realData
-        = dynamic_cast<RealDataItem*>(realDataModel.insertNewItem(Constants::RealDataType));
+    RealDataItem* realData = createRealData(realDataModel);
     JobItemUtils::createDefaultDetectorMap(realData->dataItem(), instrument);
 
     QVERIFY(manager.canLinkDataToInstrument(realData, identifier));

--- a/Tests/UnitTests/GUI/TestProjectDocument.h
+++ b/Tests/UnitTests/GUI/TestProjectDocument.h
@@ -24,6 +24,24 @@ public:
         auto instrument = models->instrumentModel()->instrumentItem();
         instrument->setItemValue(InstrumentItem::P_IDENTIFIER, GUIHelpers::createUuid());
     }
+
+    std::unique_ptr<OutputData<double>> createData(double value = 0.0)
+    {
+        std::unique_ptr<OutputData<double>> result(new OutputData<double>());
+        result->addAxis("x", 5, -1.0, 1.0);
+        result->addAxis("y", 10, 0.0, 2.0);
+        result->setAllTo(value);
+        return result;
+    }
+
+    //! Helper function to create test RealData
+    RealDataItem* createRealData(SessionModel& model)
+    {
+        RealDataItem* result = dynamic_cast<RealDataItem*>(
+            model.insertNewItem(Constants::RealDataType));
+        result->setOutputData(createData().release());
+        return result;
+    }
 };
 
 TestProjectDocument::~TestProjectDocument() = default;
@@ -106,8 +124,7 @@ TEST_F(TestProjectDocument, test_projectDocumentWithData)
     TestUtils::create_dir(projectDir);
 
     ApplicationModels models;
-    RealDataItem* realData = dynamic_cast<RealDataItem*>(
-        models.realDataModel()->insertNewItem(Constants::RealDataType));
+    RealDataItem* realData = createRealData(*models.realDataModel());
     Q_ASSERT(realData);
     DataItem* intensityItem = realData->dataItem();
     JobItemUtils::createDefaultDetectorMap(intensityItem,

--- a/Tests/UnitTests/GUI/TestSaveService.h
+++ b/Tests/UnitTests/GUI/TestSaveService.h
@@ -25,6 +25,24 @@ public:
         auto instrument = models->instrumentModel()->instrumentItem();
         instrument->setItemValue(InstrumentItem::P_IDENTIFIER, GUIHelpers::createUuid());
     }
+
+    std::unique_ptr<OutputData<double>> createData(double value = 0.0)
+    {
+        std::unique_ptr<OutputData<double>> result(new OutputData<double>());
+        result->addAxis("x", 5, -1.0, 1.0);
+        result->addAxis("y", 10, 0.0, 2.0);
+        result->setAllTo(value);
+        return result;
+    }
+
+    //! Helper function to create test RealData
+    RealDataItem* createRealData(SessionModel& model)
+    {
+        RealDataItem* result = dynamic_cast<RealDataItem*>(
+            model.insertNewItem(Constants::RealDataType));
+        result->setOutputData(createData().release());
+        return result;
+    }
 };
 
 TestSaveService::~TestSaveService() = default;
@@ -143,8 +161,7 @@ TEST_F(TestSaveService, test_saveServiceWithData)
     const QString projectFileName(projectDir + "/document.pro");
 
     ApplicationModels models;
-    RealDataItem* realData = dynamic_cast<RealDataItem*>(
-        models.realDataModel()->insertNewItem(Constants::RealDataType));
+    RealDataItem* realData = createRealData(*models.realDataModel());
     Q_ASSERT(realData);
     DataItem* intensityItem = realData->dataItem();
     JobItemUtils::createDefaultDetectorMap(intensityItem,
@@ -179,8 +196,7 @@ TEST_F(TestSaveService, test_autosaveEnabled)
     const QString projectFileName(projectDir + "/document.pro");
 
     ApplicationModels models;
-    RealDataItem* realData = dynamic_cast<RealDataItem*>(
-        models.realDataModel()->insertNewItem(Constants::RealDataType));
+    RealDataItem* realData = createRealData(*models.realDataModel());
     DataItem* intensityItem = realData->dataItem();
     JobItemUtils::createDefaultDetectorMap(intensityItem,
                                            models.instrumentModel()->instrumentItem());


### PR DESCRIPTION
Redmine: #2051

1. Underlying DataItem can be accessed only through dataItem method
2. If OutputData is not set, dataItem() throws an exception
3. Automatic choice of DataItem type depending on the rank of OutputData