### PR TITLE
Redmine issue 2106: using DataItem1DView in fit view for 1D data

### DIFF
--- a/GUI/coregui/Models/DataItem1DView.cpp
+++ b/GUI/coregui/Models/DataItem1DView.cpp
@@ -147,22 +147,10 @@ void DataItem1DView::setAxesRangeToData()
     setUpperY(data_range.second);
 }
 
-void DataItem1DView::updateAxesUnits(const InstrumentItem* instrument)
-{
-    auto items = dataItems();
-    std::for_each(items.begin(), items.end(),
-                  [instrument](DataItem* item) { item->updateAxesUnits(instrument); });
-}
-
 void DataItem1DView::resetToDefault()
 {
-    auto items = dataItems();
-    std::for_each(items.begin(), items.end(),
-                  [](DataItem* item) { item->resetToDefault(); });
-
-    setXaxisTitle(x_axis_default_name);
-    setYaxisTitle(y_axis_default_name);
-    setAxesRangeToData();
+    //TODO: implement when applying DataITem1DView in ImportView
+    throw GUIHelpers::Error("Error in DataItem1DView::resetToDefault: not implemented");
 }
 
 QPair<QVector<double>, QVector<double>> DataItem1DView::graphData(Data1DProperties* property_item)

--- a/GUI/coregui/Models/DataItem1DView.cpp
+++ b/GUI/coregui/Models/DataItem1DView.cpp
@@ -165,6 +165,16 @@ void DataItem1DView::resetToDefault()
     setAxesRangeToData();
 }
 
+QPair<QVector<double>, QVector<double>> DataItem1DView::graphData(Data1DProperties* property_item)
+{
+    const auto data = DataViewUtils::getTranslatedData(this, property_item->dataItem());
+    if (!data)
+        return {};
+    data->getRawDataVector();
+    return {QVector<double>::fromStdVector(data->getAxis(0).getBinCenters()),
+            QVector<double>::fromStdVector(data->getRawDataVector())};
+}
+
 void DataItem1DView::setLowerX(double xmin)
 {
     getItem(P_XAXIS)->setItemValue(BasicAxisItem::P_MIN, xmin);

--- a/GUI/coregui/Models/DataItem1DView.cpp
+++ b/GUI/coregui/Models/DataItem1DView.cpp
@@ -53,6 +53,13 @@ DataItem1DView::DataItem1DView()
     ComboProperty combo = ComboProperty() << Constants::UnitsNbins;
     addProperty(P_AXES_UNITS, combo.variant());
 
+    mapper()->setOnPropertyChange([this](const QString& name) {
+        if (name != P_AXES_UNITS)
+            return;
+        setAxesRangeToData();
+        DataViewUtils::updateAxesTitle(this);
+    });
+
     setLowerX(default_min);
     setUpperX(default_max);
     setLowerY(default_min);
@@ -220,7 +227,10 @@ void DataItem1DView::updateAxesZoomLevel()
 
 DataItem* DataItem1DView::basicDataItem()
 {
-    return propertyItem(0)->dataItem();
+    auto basic_property_item = propertyItem(0);
+    if (!basic_property_item)
+        return nullptr;
+    return basic_property_item->dataItem();
 }
 
 //! Init ymin, ymax to match the intensity values range.

--- a/GUI/coregui/Models/DataItem1DView.h
+++ b/GUI/coregui/Models/DataItem1DView.h
@@ -62,7 +62,6 @@ public:
     void setXaxisTitle(QString xtitle);
     void setYaxisTitle(QString ytitle);
     void setAxesRangeToData();
-    void updateAxesUnits(const InstrumentItem* instrument);
 
     //! Returns data view to default state (no dimensional units, default axes' names)
     void resetToDefault();

--- a/GUI/coregui/Models/DataItem1DView.h
+++ b/GUI/coregui/Models/DataItem1DView.h
@@ -67,6 +67,9 @@ public:
     //! Returns data view to default state (no dimensional units, default axes' names)
     void resetToDefault();
 
+    //! Returns point data for drawing
+    QPair<QVector<double>, QVector<double>> graphData(Data1DProperties* property_item);
+
 public slots:
     void setLowerX(double xmin);
     void setUpperX(double xmax);

--- a/GUI/coregui/Models/DataItem1DView.h
+++ b/GUI/coregui/Models/DataItem1DView.h
@@ -45,23 +45,13 @@ public:
     double getLowerX() const;
     double getUpperX() const;
 
-    //! returns min and max range of x-axis as given by IntensityData
-    double getXmin() const;
-    double getXmax() const;
-
     //! returns lower and upper zoom ranges of y-axis
     double getLowerY() const;
     double getUpperY() const;
 
-    //! returns min and max range of y-axis as given by IntensityData
-    double getYmin() const;
-    double getYmax() const;
-
     bool isLog() const;
     QString getXaxisTitle() const;
     QString getYaxisTitle() const;
-
-    QPair<double, double> dataRange() const;
 
     const BasicAxisItem* xAxisItem() const;
     BasicAxisItem* xAxisItem();
@@ -86,6 +76,8 @@ public slots:
 
 private:
     void updateAxesZoomLevel();
+    DataItem* basicDataItem();
+    QPair<double, double> dataRange(const OutputData<double> *data) const;
 };
 
 #endif // DATAITEM1DVIEW_H

--- a/GUI/coregui/Models/DataItemView.cpp
+++ b/GUI/coregui/Models/DataItemView.cpp
@@ -37,7 +37,10 @@ template BA_CORE_API_ std::vector<Data1DProperties*> DataItemView::propertyItems
 template<class T>
 T* DataItemView::propertyItem(size_t i) const
 {
-    auto property_item = dynamic_cast<T*>(getItems()[static_cast<int>(i)]);
+    auto children = getItems();
+    if (children.empty())
+        return nullptr;
+    auto property_item = dynamic_cast<T*>(children[static_cast<int>(i)]);
     assert(property_item);
     return property_item;
 }

--- a/GUI/coregui/Models/DataViewUtils.cpp
+++ b/GUI/coregui/Models/DataViewUtils.cpp
@@ -1,0 +1,82 @@
+#include "DataViewUtils.h"
+#include "ComboProperty.h"
+#include "DataItem1DView.h"
+#include "DomainObjectBuilder.h"
+#include "GUIHelpers.h"
+#include "InstrumentItems.h"
+#include "IUnitConverter.h"
+#include "JobItem.h"
+#include "RealDataItem.h"
+#include "SessionModel.h"
+
+namespace {
+const QMap<QString, AxesUnits> unit_from_names = {{Constants::UnitsNbins, AxesUnits::NBINS},
+                                                  {Constants::UnitsRadians, AxesUnits::RADIANS},
+                                                  {Constants::UnitsDegrees, AxesUnits::DEGREES},
+                                                  {Constants::UnitsMm, AxesUnits::MM},
+                                                  {Constants::UnitsQyQz, AxesUnits::QSPACE}};
+
+const QMap<AxesUnits, QString> names_from_units = {{AxesUnits::NBINS, Constants::UnitsNbins},
+                                                   {AxesUnits::RADIANS, Constants::UnitsRadians},
+                                                   {AxesUnits::MM, Constants::UnitsMm},
+                                                   {AxesUnits::QSPACE, Constants::UnitsQyQz},
+                                                   {AxesUnits::DEGREES, Constants::UnitsDegrees}};
+
+JobItem* parentJobItem(SessionItem* item)
+{
+    assert(item);
+    do {
+        if (item->modelType() == Constants::JobItemType)
+            return dynamic_cast<JobItem*>(item);
+    } while ((item = item->parent()));
+    throw GUIHelpers::Error("Error in parentJobItem: passed item is not owned by any job item");
+}
+
+ComboProperty availableUnits(const IUnitConverter* converter)
+{
+    assert(converter);
+
+    ComboProperty result;
+    for (auto units : converter->availableUnits())
+        result << names_from_units[units];
+
+    result.setValue(names_from_units[converter->defaultUnits()]);
+    return result;
+}
+
+void updateAxesTitle(DataItem1DView* view_item, const IUnitConverter* converter,
+                     AxesUnits units)
+{
+    view_item->setXaxisTitle(QString::fromStdString(converter->axisName(0, units)));
+    if (converter->dimension() > 1)
+        view_item->setYaxisTitle(QString::fromStdString(converter->axisName(1, units)));
+}
+}
+
+void DataViewUtils::initDataView(JobItem* jobItem)
+{
+    assert(jobItem->isValidForFitting());
+    assert(jobItem->instrumentItem()->modelType() == Constants::SpecularInstrumentType);
+    assert(!jobItem->getItem(JobItem::T_DATAVIEW));
+
+    SessionModel* model = jobItem->model();
+    auto view_item = dynamic_cast<DataItem1DView*>(model->insertNewItem(
+        Constants::DataItem1DViewType, jobItem->index(), -1, JobItem::T_DATAVIEW));
+
+    assert(view_item);
+    setUnitProperties(view_item);
+
+    view_item->addItem(jobItem->realDataItem()->dataItem());
+    view_item->addItem(jobItem->dataItem());
+}
+
+void DataViewUtils::setUnitProperties(DataItem1DView* view_item)
+{
+    auto job_item = parentJobItem(view_item);
+    assert(job_item);
+
+    auto converter = DomainObjectBuilder::createUnitConverter(job_item->instrumentItem());
+    view_item->setItemValue(DataItem1DView::P_AXES_UNITS,
+                            availableUnits(converter.get()).variant());
+    updateAxesTitle(view_item, converter.get(), converter->defaultUnits());
+}

--- a/GUI/coregui/Models/DataViewUtils.h
+++ b/GUI/coregui/Models/DataViewUtils.h
@@ -1,0 +1,31 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Models/DataViewUtils.h
+//! @brief     Defines namespace DataViewUtils
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#ifndef DATAVIEWUTILS_H
+#define DATAVIEWUTILS_H
+
+class DataItem1DView;
+class JobItem;
+
+namespace DataViewUtils
+{
+//! Initializes DataItem1DView and assigns it to the passed JobItem
+void initDataView(JobItem* jobItem);
+
+//! Sets units and axis labels to DataItem1DView.
+//! The item should be attached to a valid JobItem.
+void setUnitProperties(DataItem1DView* view_item);
+};
+
+#endif // DATAVIEWUTILS_H

--- a/GUI/coregui/Models/DataViewUtils.h
+++ b/GUI/coregui/Models/DataViewUtils.h
@@ -27,9 +27,7 @@ namespace DataViewUtils
 //! Initializes DataItem1DView and assigns it to the passed JobItem
 void initDataView(JobItem* jobItem);
 
-//! Sets units and axis labels to DataItem1DView.
-//! The item should be attached to a valid JobItem.
-void setUnitProperties(DataItem1DView* view_item);
+void updateAxesTitle(DataItem1DView* view_item);
 
 std::unique_ptr<OutputData<double>> getTranslatedData(DataItem1DView* view_item,
                                                       DataItem* data_item);

--- a/GUI/coregui/Models/DataViewUtils.h
+++ b/GUI/coregui/Models/DataViewUtils.h
@@ -15,8 +15,12 @@
 #ifndef DATAVIEWUTILS_H
 #define DATAVIEWUTILS_H
 
+#include <memory>
+
+class DataItem;
 class DataItem1DView;
 class JobItem;
+template<class T> class OutputData;
 
 namespace DataViewUtils
 {
@@ -26,6 +30,9 @@ void initDataView(JobItem* jobItem);
 //! Sets units and axis labels to DataItem1DView.
 //! The item should be attached to a valid JobItem.
 void setUnitProperties(DataItem1DView* view_item);
+
+std::unique_ptr<OutputData<double>> getTranslatedData(DataItem1DView* view_item,
+                                                      DataItem* data_item);
 };
 
 #endif // DATAVIEWUTILS_H

--- a/GUI/coregui/Models/JobItem.cpp
+++ b/GUI/coregui/Models/JobItem.cpp
@@ -86,7 +86,8 @@ JobItem::JobItem() : SessionItem(Constants::JobItemType)
     registerTag(T_FIT_SUITE, 1, 1, QStringList() << Constants::FitSuiteType);
 
     mapper()->setOnChildPropertyChange([this](SessionItem* item, const QString& name) {
-        if (item->parent() == this && name == DataItem::P_AXES_UNITS)
+        if (item->parent() == this && dynamic_cast<DataItem*>(item)
+            && name == DataItem::P_AXES_UNITS)
             dynamic_cast<DataItem*>(item)->updateAxesUnits(instrumentItem());
     });
 

--- a/GUI/coregui/Models/JobModelFunctions.cpp
+++ b/GUI/coregui/Models/JobModelFunctions.cpp
@@ -13,7 +13,7 @@
 // ************************************************************************** //
 
 #include "JobModelFunctions.h"
-#include "DataItem1DView.h"
+#include "DataViewUtils.h"
 #include "DetectorFunctions.h"
 #include "DetectorItems.h"
 #include "DomainObjectBuilder.h"
@@ -79,7 +79,7 @@ void JobModelFunctions::setupJobItemForFit(JobItem* jobItem, const RealDataItem*
     if (jobItem->instrumentItem()->modelType() == Constants::GISASInstrumentType)
         JobModelFunctions::cropRealData(jobItem);
     if (jobItem->instrumentItem()->modelType() == Constants::SpecularInstrumentType)
-        JobModelFunctions::initDataView(jobItem);
+        DataViewUtils::initDataView(jobItem);
 
     JobModelFunctions::createFitContainers(jobItem);
 }
@@ -185,19 +185,4 @@ void JobModelFunctions::createFitContainers(JobItem* jobItem)
 
     minimizerContainerItem = model->insertNewItem(
         Constants::MinimizerContainerType, fitSuiteItem->index(), -1, FitSuiteItem::T_MINIMIZER);
-}
-
-void JobModelFunctions::initDataView(JobItem* jobItem)
-{
-    assert(jobItem->isValidForFitting());
-    assert(jobItem->instrumentItem()->modelType() == Constants::SpecularInstrumentType);
-
-    SessionModel* model = jobItem->model();
-    auto view_item = dynamic_cast<DataItem1DView*>(model->insertNewItem(
-        Constants::DataItem1DViewType, jobItem->index(), -1, JobItem::T_DATAVIEW));
-
-    assert(view_item);
-
-    view_item->addItem(jobItem->realDataItem()->dataItem());
-    view_item->addItem(jobItem->dataItem());
 }

--- a/GUI/coregui/Views/FitWidgets/FitComparisonWidget1D_New.cpp
+++ b/GUI/coregui/Views/FitWidgets/FitComparisonWidget1D_New.cpp
@@ -1,0 +1,136 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Views/FitWidgets/FitComparisonWidget1D.cpp
+//! @brief     Implements class FitComparisonWidget1D
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#include "FitComparisonWidget1D_New.h"
+#include "FitComparisonController.h"
+#include "FitFlowWidget.h"
+#include "FitSuiteItem.h"
+#include "IntensityDataPropertyWidget.h"
+#include "JobItem.h"
+#include "PlotStatusLabel.h"
+#include "RealDataItem.h"
+#include "SessionModel.h"
+#include "SpecularDataItem.h"
+#include "SpecularPlot.h"
+#include "SpecularPlotCanvas.h"
+#include <QAction>
+#include <QGridLayout>
+#include <QVBoxLayout>
+
+FitComparisonWidget1D_New::FitComparisonWidget1D_New(QWidget *parent)
+    : SessionItemWidget(parent)
+    , m_data_plot(new SpecularPlotCanvas)
+    , m_diff_plot(new SpecularPlotCanvas)
+    , m_fitFlowWidget(new FitFlowWidget)
+    , m_statusLabel(new PlotStatusLabel(nullptr, this))
+    , m_propertyWidget(new IntensityDataPropertyWidget)
+    , m_resetViewAction(new QAction(this))
+    , m_comparisonController(new FitComparisonController1D(this))
+{
+    auto vlayout = new QVBoxLayout;
+    vlayout->setMargin(0);
+    vlayout->setSpacing(0);
+
+    auto gridLayout = new QGridLayout;
+    gridLayout->setMargin(0);
+    gridLayout->setSpacing(0);
+
+    gridLayout->addWidget(m_data_plot, 0, 0, 1, -1);
+    gridLayout->addWidget(m_diff_plot, 1, 0);
+    gridLayout->addWidget(m_fitFlowWidget, 1, 1);
+
+    vlayout->addLayout(gridLayout);
+    vlayout->addWidget(m_statusLabel);
+
+    auto hlayout = new QHBoxLayout;
+    hlayout->setMargin(0);
+    hlayout->setSpacing(0);
+    hlayout->addLayout(vlayout);
+    hlayout->addWidget(m_propertyWidget);
+    setLayout(hlayout);
+
+    m_resetViewAction->setText("Reset View");
+    m_resetViewAction->setIcon(QIcon(":/images/toolbar16light_refresh.svg"));
+    m_resetViewAction->setToolTip("Reset View");
+    connect(m_resetViewAction, &QAction::triggered, this, &FitComparisonWidget1D_New::onResetViewAction);
+
+    m_propertyWidget->setVisible(false);
+}
+
+FitComparisonWidget1D_New::~FitComparisonWidget1D_New() = default;
+
+QList<QAction*> FitComparisonWidget1D_New::actionList()
+{
+    return QList<QAction*>() << m_resetViewAction << m_propertyWidget->actionList();
+}
+
+void FitComparisonWidget1D_New::subscribeToItem()
+{
+    if (!jobItem()->isValidForFitting())
+        return;
+
+    jobItem()->mapper()->setOnPropertyChange(
+        [this](const QString& name) {
+            if (name == JobItem::P_STATUS) {
+                if (jobItem()->isCompleted())
+                    onResetViewAction();
+            }
+        },
+        this);
+
+    m_comparisonController->setItem(jobItem());
+
+    m_data_plot->setItem(simulatedDataItem());
+    m_diff_plot->setItem(m_comparisonController->diffItem());
+    m_fitFlowWidget->setItem(jobItem()->fitSuiteItem());
+
+    m_statusLabel->reset();
+    m_statusLabel->addPlot(m_data_plot->specularPlot());
+    m_statusLabel->addPlot(m_diff_plot->specularPlot());
+
+    m_propertyWidget->setItem(simulatedDataItem());
+}
+
+void FitComparisonWidget1D_New::unsubscribeFromItem()
+{
+    if (!currentItem())
+        return;
+
+    m_comparisonController->clear();
+}
+
+void FitComparisonWidget1D_New::onResetViewAction()
+{
+    realDataItem()->resetView();
+    simulatedDataItem()->resetView();
+    m_comparisonController->resetDiffItem();
+}
+
+JobItem* FitComparisonWidget1D_New::jobItem()
+{
+    JobItem* jobItem = dynamic_cast<JobItem*>(currentItem());
+    return jobItem;
+}
+
+SpecularDataItem* FitComparisonWidget1D_New::realDataItem()
+{
+    assert(dynamic_cast<SpecularDataItem*>(jobItem()->realDataItem()->dataItem()));
+    return dynamic_cast<SpecularDataItem*>(jobItem()->realDataItem()->dataItem());
+}
+
+SpecularDataItem* FitComparisonWidget1D_New::simulatedDataItem()
+{
+    assert(dynamic_cast<SpecularDataItem*>(jobItem()->dataItem()));
+    return dynamic_cast<SpecularDataItem*>(jobItem()->dataItem());
+}

--- a/GUI/coregui/Views/FitWidgets/FitComparisonWidget1D_New.cpp
+++ b/GUI/coregui/Views/FitWidgets/FitComparisonWidget1D_New.cpp
@@ -13,11 +13,14 @@
 // ************************************************************************** //
 
 #include "FitComparisonWidget1D_New.h"
+#include "DataItem1DView.h"
 #include "FitComparisonController.h"
 #include "FitFlowWidget.h"
 #include "FitSuiteItem.h"
 #include "IntensityDataPropertyWidget.h"
 #include "JobItem.h"
+#include "Plot1D.h"
+#include "Plot1DCanvas.h"
 #include "PlotStatusLabel.h"
 #include "RealDataItem.h"
 #include "SessionModel.h"
@@ -28,15 +31,15 @@
 #include <QGridLayout>
 #include <QVBoxLayout>
 
-FitComparisonWidget1D_New::FitComparisonWidget1D_New(QWidget *parent)
+FitComparisonWidget1D_New::FitComparisonWidget1D_New(QWidget* parent)
     : SessionItemWidget(parent)
-    , m_data_plot(new SpecularPlotCanvas)
-    , m_diff_plot(new SpecularPlotCanvas)
+    , m_data_plot(new Plot1DCanvas)
+    //, m_diff_plot(new SpecularPlotCanvas)
     , m_fitFlowWidget(new FitFlowWidget)
     , m_statusLabel(new PlotStatusLabel(nullptr, this))
     , m_propertyWidget(new IntensityDataPropertyWidget)
     , m_resetViewAction(new QAction(this))
-    , m_comparisonController(new FitComparisonController1D(this))
+    //, m_comparisonController(new FitComparisonController1D(this))
 {
     auto vlayout = new QVBoxLayout;
     vlayout->setMargin(0);
@@ -47,7 +50,7 @@ FitComparisonWidget1D_New::FitComparisonWidget1D_New(QWidget *parent)
     gridLayout->setSpacing(0);
 
     gridLayout->addWidget(m_data_plot, 0, 0, 1, -1);
-    gridLayout->addWidget(m_diff_plot, 1, 0);
+    // gridLayout->addWidget(m_diff_plot, 1, 0);
     gridLayout->addWidget(m_fitFlowWidget, 1, 1);
 
     vlayout->addLayout(gridLayout);
@@ -63,7 +66,8 @@ FitComparisonWidget1D_New::FitComparisonWidget1D_New(QWidget *parent)
     m_resetViewAction->setText("Reset View");
     m_resetViewAction->setIcon(QIcon(":/images/toolbar16light_refresh.svg"));
     m_resetViewAction->setToolTip("Reset View");
-    connect(m_resetViewAction, &QAction::triggered, this, &FitComparisonWidget1D_New::onResetViewAction);
+    connect(m_resetViewAction, &QAction::triggered, this,
+            &FitComparisonWidget1D_New::onResetViewAction);
 
     m_propertyWidget->setVisible(false);
 }
@@ -89,17 +93,17 @@ void FitComparisonWidget1D_New::subscribeToItem()
         },
         this);
 
-    m_comparisonController->setItem(jobItem());
+    //m_comparisonController->setItem(jobItem());
 
-    m_data_plot->setItem(simulatedDataItem());
-    m_diff_plot->setItem(m_comparisonController->diffItem());
+    m_data_plot->setItem(viewItem());
+    // m_diff_plot->setItem(m_comparisonController->diffItem());
     m_fitFlowWidget->setItem(jobItem()->fitSuiteItem());
 
     m_statusLabel->reset();
-    m_statusLabel->addPlot(m_data_plot->specularPlot());
-    m_statusLabel->addPlot(m_diff_plot->specularPlot());
+    m_statusLabel->addPlot(m_data_plot->plot1D());
+    // m_statusLabel->addPlot(m_diff_plot->specularPlot());
 
-    m_propertyWidget->setItem(simulatedDataItem());
+    m_propertyWidget->setItem(viewItem());
 }
 
 void FitComparisonWidget1D_New::unsubscribeFromItem()
@@ -107,14 +111,13 @@ void FitComparisonWidget1D_New::unsubscribeFromItem()
     if (!currentItem())
         return;
 
-    m_comparisonController->clear();
+    //m_comparisonController->clear();
 }
 
 void FitComparisonWidget1D_New::onResetViewAction()
 {
-    realDataItem()->resetView();
-    simulatedDataItem()->resetView();
-    m_comparisonController->resetDiffItem();
+    viewItem()->resetView();
+    //m_comparisonController->resetDiffItem();
 }
 
 JobItem* FitComparisonWidget1D_New::jobItem()
@@ -123,14 +126,9 @@ JobItem* FitComparisonWidget1D_New::jobItem()
     return jobItem;
 }
 
-SpecularDataItem* FitComparisonWidget1D_New::realDataItem()
+DataItem1DView* FitComparisonWidget1D_New::viewItem()
 {
-    assert(dynamic_cast<SpecularDataItem*>(jobItem()->realDataItem()->dataItem()));
-    return dynamic_cast<SpecularDataItem*>(jobItem()->realDataItem()->dataItem());
-}
-
-SpecularDataItem* FitComparisonWidget1D_New::simulatedDataItem()
-{
-    assert(dynamic_cast<SpecularDataItem*>(jobItem()->dataItem()));
-    return dynamic_cast<SpecularDataItem*>(jobItem()->dataItem());
+    auto view_item = dynamic_cast<DataItem1DView*>(jobItem()->dataItemView());
+    assert(view_item);
+    return view_item;
 }

--- a/GUI/coregui/Views/FitWidgets/FitComparisonWidget1D_New.h
+++ b/GUI/coregui/Views/FitWidgets/FitComparisonWidget1D_New.h
@@ -17,10 +17,12 @@
 
 #include "SessionItemWidget.h"
 
+class DataItem1DView;
 class FitComparisonController1D;
 class FitFlowWidget;
 class IntensityDataPropertyWidget;
 class JobItem;
+class Plot1DCanvas;
 class PlotStatusLabel;
 class QAction;
 class SpecularDataItem;
@@ -47,17 +49,16 @@ protected:
 
 private:
     JobItem* jobItem();
-    SpecularDataItem* realDataItem();
-    SpecularDataItem* simulatedDataItem();
+    DataItem1DView* viewItem();
 
-    SpecularPlotCanvas* m_data_plot;
-    SpecularPlotCanvas* m_diff_plot;
+    Plot1DCanvas* m_data_plot;
+    //SpecularPlotCanvas* m_diff_plot;
     FitFlowWidget* m_fitFlowWidget;
     PlotStatusLabel* m_statusLabel;
     IntensityDataPropertyWidget* m_propertyWidget;
 
     QAction* m_resetViewAction;
-    FitComparisonController1D* m_comparisonController;
+    //FitComparisonController1D* m_comparisonController;
 };
 
 #endif // FITCOMPARISONWIDGET1D_NEW_H

--- a/GUI/coregui/Views/FitWidgets/FitComparisonWidget1D_New.h
+++ b/GUI/coregui/Views/FitWidgets/FitComparisonWidget1D_New.h
@@ -1,0 +1,63 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Views/FitWidgets/FitComparisonWidget1D_New.h
+//! @brief     Defines class FitComparisonWidget1D
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#ifndef FITCOMPARISONWIDGET1D_NEW_H
+#define FITCOMPARISONWIDGET1D_NEW_H
+
+#include "SessionItemWidget.h"
+
+class FitComparisonController1D;
+class FitFlowWidget;
+class IntensityDataPropertyWidget;
+class JobItem;
+class PlotStatusLabel;
+class QAction;
+class SpecularDataItem;
+class SpecularPlotCanvas;
+
+//! The FitComparisonWidget class plots realdata, simulated data and relative difference map
+//! during the course of the fit.
+
+class BA_CORE_API_ FitComparisonWidget1D_New : public SessionItemWidget
+{
+    Q_OBJECT
+public:
+    explicit FitComparisonWidget1D_New(QWidget* parent = nullptr);
+    ~FitComparisonWidget1D_New() override;
+
+    virtual QList<QAction*> actionList() override;
+
+private slots:
+    void onResetViewAction();
+
+protected:
+    void subscribeToItem() override;
+    void unsubscribeFromItem() override;
+
+private:
+    JobItem* jobItem();
+    SpecularDataItem* realDataItem();
+    SpecularDataItem* simulatedDataItem();
+
+    SpecularPlotCanvas* m_data_plot;
+    SpecularPlotCanvas* m_diff_plot;
+    FitFlowWidget* m_fitFlowWidget;
+    PlotStatusLabel* m_statusLabel;
+    IntensityDataPropertyWidget* m_propertyWidget;
+
+    QAction* m_resetViewAction;
+    FitComparisonController1D* m_comparisonController;
+};
+
+#endif // FITCOMPARISONWIDGET1D_NEW_H

--- a/GUI/coregui/Views/IntensityDataWidgets/Plot1D.cpp
+++ b/GUI/coregui/Views/IntensityDataWidgets/Plot1D.cpp
@@ -122,10 +122,10 @@ void Plot1D::subscribeToItem()
         },
         this);
 
-    std::for_each(m_graph_map.begin(), m_graph_map.end(), [this](auto pair) {
+    std::for_each(m_graph_map.begin(), m_graph_map.end(), [caller=this](auto pair) {
         auto property_item = pair.first;
         property_item->dataItem()->mapper()->setOnValueChange(
-            [this, property_item]() { refreshPlotData(property_item); }, this);
+            [caller, property_item]() { caller->refreshPlotData(property_item); }, caller);
     });
 
     setConnected(true);
@@ -134,8 +134,8 @@ void Plot1D::subscribeToItem()
 void Plot1D::unsubscribeFromItem()
 {
     m_custom_plot->clearGraphs();
-    std::for_each(m_graph_map.begin(), m_graph_map.end(), [this](auto pair) {
-        pair.first->dataItem()->mapper()->unsubscribe(this);
+    std::for_each(m_graph_map.begin(), m_graph_map.end(), [caller=this](auto pair) {
+        pair.first->dataItem()->mapper()->unsubscribe(caller);
     });
     m_graph_map.clear();
     setConnected(false);

--- a/GUI/coregui/Views/IntensityDataWidgets/Plot1D.cpp
+++ b/GUI/coregui/Views/IntensityDataWidgets/Plot1D.cpp
@@ -2,8 +2,8 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/SpecularDataWidgets/SpecularPlotWithDataView.cpp
-//! @brief     Implements class SpecularPlotWithDataView
+//! @file      GUI/coregui/Views/SpecularDataWidgets/Plot1D.cpp
+//! @brief     Implements class Plot1D
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -12,7 +12,7 @@
 //
 // ************************************************************************** //
 
-#include "SpecularPlotWithDataView.h"
+#include "Plot1D.h"
 #include "AxesItems.h"
 #include "ColorMapUtils.h"
 #include "DataItem.h"
@@ -30,7 +30,7 @@ const int replot_update_interval = 10;
 int getBin(double x, const QCPGraph* graph);
 }
 
-SpecularPlotWithDataView::SpecularPlotWithDataView(QWidget* parent)
+Plot1D::Plot1D(QWidget* parent)
     : ScientificPlot(parent, PLOT_TYPE::Plot1D), m_custom_plot(new QCustomPlot),
       m_update_timer(new UpdateTimer(replot_update_interval, this)), m_block_update(true)
 {
@@ -48,7 +48,7 @@ SpecularPlotWithDataView::SpecularPlotWithDataView(QWidget* parent)
     setMouseTrackingEnabled(true);
 }
 
-PlotEventInfo SpecularPlotWithDataView::eventInfo(double xpos, double ypos) const
+PlotEventInfo Plot1D::eventInfo(double xpos, double ypos) const
 {
     PlotEventInfo result(plotType());
     if (!viewItem())
@@ -63,18 +63,18 @@ PlotEventInfo SpecularPlotWithDataView::eventInfo(double xpos, double ypos) cons
     return result;
 }
 
-void SpecularPlotWithDataView::setLog(bool log)
+void Plot1D::setLog(bool log)
 {
     ColorMapUtils::setLogz(m_custom_plot->yAxis, log);
     ColorMapUtils::setLogz(m_custom_plot->yAxis2, log);
 }
 
-void SpecularPlotWithDataView::resetView()
+void Plot1D::resetView()
 {
     viewItem()->resetView();
 }
 
-void SpecularPlotWithDataView::onPropertyChanged(const QString& property_name)
+void Plot1D::onPropertyChanged(const QString& property_name)
 {
     if (m_block_update)
         return;
@@ -85,7 +85,7 @@ void SpecularPlotWithDataView::onPropertyChanged(const QString& property_name)
     }
 }
 
-void SpecularPlotWithDataView::onXaxisRangeChanged(QCPRange newRange)
+void Plot1D::onXaxisRangeChanged(QCPRange newRange)
 {
     m_block_update = true;
     viewItem()->setLowerX(newRange.lower);
@@ -93,7 +93,7 @@ void SpecularPlotWithDataView::onXaxisRangeChanged(QCPRange newRange)
     m_block_update = false;
 }
 
-void SpecularPlotWithDataView::onYaxisRangeChanged(QCPRange newRange)
+void Plot1D::onYaxisRangeChanged(QCPRange newRange)
 {
     m_block_update = true;
     viewItem()->setLowerY(newRange.lower);
@@ -101,12 +101,12 @@ void SpecularPlotWithDataView::onYaxisRangeChanged(QCPRange newRange)
     m_block_update = false;
 }
 
-void SpecularPlotWithDataView::onTimeToReplot()
+void Plot1D::onTimeToReplot()
 {
     m_custom_plot->replot();
 }
 
-void SpecularPlotWithDataView::subscribeToItem()
+void Plot1D::subscribeToItem()
 {
     initPlots();
     refreshPlotData();
@@ -127,14 +127,14 @@ void SpecularPlotWithDataView::subscribeToItem()
     setConnected(true);
 }
 
-void SpecularPlotWithDataView::unsubscribeFromItem()
+void Plot1D::unsubscribeFromItem()
 {
     m_custom_plot->clearGraphs();
     m_graph_map.clear();
     setConnected(false);
 }
 
-void SpecularPlotWithDataView::initPlots()
+void Plot1D::initPlots()
 {
     auto property_items = viewItem()->propertyItems<Data1DProperties>();
     std::for_each(
@@ -146,45 +146,45 @@ void SpecularPlotWithDataView::initPlots()
         });
 }
 
-void SpecularPlotWithDataView::setConnected(bool isConnected)
+void Plot1D::setConnected(bool isConnected)
 {
     setAxesRangeConnected(isConnected);
     setUpdateTimerConnected(isConnected);
 }
 
-void SpecularPlotWithDataView::setAxesRangeConnected(bool isConnected)
+void Plot1D::setAxesRangeConnected(bool isConnected)
 {
     if (isConnected) {
         connect(m_custom_plot->xAxis,
                 static_cast<void (QCPAxis::*)(const QCPRange&)>(&QCPAxis::rangeChanged), this,
-                &SpecularPlotWithDataView::onXaxisRangeChanged, Qt::UniqueConnection);
+                &Plot1D::onXaxisRangeChanged, Qt::UniqueConnection);
 
         connect(m_custom_plot->yAxis,
                 static_cast<void (QCPAxis::*)(const QCPRange&)>(&QCPAxis::rangeChanged), this,
-                &SpecularPlotWithDataView::onYaxisRangeChanged, Qt::UniqueConnection);
+                &Plot1D::onYaxisRangeChanged, Qt::UniqueConnection);
 
     } else {
         disconnect(m_custom_plot->xAxis,
                    static_cast<void (QCPAxis::*)(const QCPRange&)>(&QCPAxis::rangeChanged), this,
-                   &SpecularPlotWithDataView::onXaxisRangeChanged);
+                   &Plot1D::onXaxisRangeChanged);
 
         disconnect(m_custom_plot->yAxis,
                    static_cast<void (QCPAxis::*)(const QCPRange&)>(&QCPAxis::rangeChanged), this,
-                   &SpecularPlotWithDataView::onYaxisRangeChanged);
+                   &Plot1D::onYaxisRangeChanged);
     }
 }
 
-void SpecularPlotWithDataView::setUpdateTimerConnected(bool isConnected)
+void Plot1D::setUpdateTimerConnected(bool isConnected)
 {
     if (isConnected)
         connect(m_update_timer, &UpdateTimer::timeToUpdate, this,
-                &SpecularPlotWithDataView::onTimeToReplot, Qt::UniqueConnection);
+                &Plot1D::onTimeToReplot, Qt::UniqueConnection);
     else
         disconnect(m_update_timer, &UpdateTimer::timeToUpdate, this,
-                   &SpecularPlotWithDataView::onTimeToReplot);
+                   &Plot1D::onTimeToReplot);
 }
 
-void SpecularPlotWithDataView::refreshPlotData()
+void Plot1D::refreshPlotData()
 {
     auto view_item = viewItem();
     assert(view_item);
@@ -201,7 +201,7 @@ void SpecularPlotWithDataView::refreshPlotData()
     m_block_update = false;
 }
 
-void SpecularPlotWithDataView::setAxesRangeFromItem(DataItem1DView* item)
+void Plot1D::setAxesRangeFromItem(DataItem1DView* item)
 {
     m_custom_plot->setInteractions(QCP::iRangeDrag | QCP::iRangeZoom);
     m_custom_plot->axisRect()->setupFullAxesBox(true);
@@ -213,13 +213,13 @@ void SpecularPlotWithDataView::setAxesRangeFromItem(DataItem1DView* item)
     setAxesRangeConnected(true);
 }
 
-void SpecularPlotWithDataView::setAxesLabelsFromItem(DataItem1DView* item)
+void Plot1D::setAxesLabelsFromItem(DataItem1DView* item)
 {
     setLabel(item->xAxisItem(), m_custom_plot->xAxis, item->getXaxisTitle());
     setLabel(item->yAxisItem(), m_custom_plot->yAxis, item->getYaxisTitle());
 }
 
-void SpecularPlotWithDataView::setLabel(const BasicAxisItem* item, QCPAxis* axis, QString label)
+void Plot1D::setLabel(const BasicAxisItem* item, QCPAxis* axis, QString label)
 {
     assert(item && axis);
     if (item->getItemValue(BasicAxisItem::P_TITLE_IS_VISIBLE).toBool())
@@ -228,7 +228,7 @@ void SpecularPlotWithDataView::setLabel(const BasicAxisItem* item, QCPAxis* axis
         axis->setLabel(QString());
 }
 
-void SpecularPlotWithDataView::setDataFromItem(DataItem1DView* item)
+void Plot1D::setDataFromItem(DataItem1DView* item)
 {
     assert(item);
     auto property_items = item->propertyItems<Data1DProperties>();
@@ -247,20 +247,20 @@ void SpecularPlotWithDataView::setDataFromItem(DataItem1DView* item)
                   });
 }
 
-DataItem1DView* SpecularPlotWithDataView::viewItem()
+DataItem1DView* Plot1D::viewItem()
 {
     return const_cast<DataItem1DView*>(
-        static_cast<const SpecularPlotWithDataView*>(this)->viewItem());
+        static_cast<const Plot1D*>(this)->viewItem());
 }
 
-const DataItem1DView* SpecularPlotWithDataView::viewItem() const
+const DataItem1DView* Plot1D::viewItem() const
 {
     const auto result = dynamic_cast<const DataItem1DView*>(currentItem());
     Q_ASSERT(result);
     return result;
 }
 
-void SpecularPlotWithDataView::modifyAxesProperties(const QString& axisName,
+void Plot1D::modifyAxesProperties(const QString& axisName,
                                                     const QString& propertyName)
 {
     if (m_block_update)
@@ -292,7 +292,7 @@ void SpecularPlotWithDataView::modifyAxesProperties(const QString& axisName,
     }
 }
 
-void SpecularPlotWithDataView::replot()
+void Plot1D::replot()
 {
     m_update_timer->scheduleUpdate();
 }

--- a/GUI/coregui/Views/IntensityDataWidgets/Plot1D.h
+++ b/GUI/coregui/Views/IntensityDataWidgets/Plot1D.h
@@ -93,7 +93,7 @@ private:
     void setLabel(const BasicAxisItem* item, QCPAxis* axis, QString label);
 
     //! Sets data item values to graphs.
-    void setDataFromItem(DataItem1DView* item);
+    void setDataFromItem(DataItem1DView* view_item);
 
     DataItem1DView* viewItem();
     const DataItem1DView* viewItem() const;

--- a/GUI/coregui/Views/IntensityDataWidgets/Plot1D.h
+++ b/GUI/coregui/Views/IntensityDataWidgets/Plot1D.h
@@ -81,6 +81,7 @@ private:
 
     //! Refresh axes' labels, range and graph data.
     void refreshPlotData();
+    void refreshPlotData(Data1DProperties* item);
 
     //! Sets (xmin,xmax) and (ymin,ymax) of SpecularPlot from specular item.
     //! Also sets logarithmic scale on y-axis if necessary.
@@ -92,8 +93,11 @@ private:
     //! Sets label to axis
     void setLabel(const BasicAxisItem* item, QCPAxis* axis, QString label);
 
-    //! Sets data item values to graphs.
-    void setDataFromItem(DataItem1DView* view_item);
+    //! Sets data to graphs.
+    void updateAllGraphs();
+
+    //! Sets data to the graph corresponding to the passed Data1DProperties.
+    void updateGraph(Data1DProperties* item);
 
     DataItem1DView* viewItem();
     const DataItem1DView* viewItem() const;

--- a/GUI/coregui/Views/IntensityDataWidgets/Plot1D.h
+++ b/GUI/coregui/Views/IntensityDataWidgets/Plot1D.h
@@ -2,8 +2,8 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/SpecularDataWidgets/SpecularPlotWithDataView.h
-//! @brief     Defines class SpecularPlotWithDataView
+//! @file      GUI/coregui/Views/SpecularDataWidgets/Plot1D.h
+//! @brief     Defines class Plot1D
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -12,8 +12,8 @@
 //
 // ************************************************************************** //
 
-#ifndef SPECULARPLOTWITHDATAVIEW_H
-#define SPECULARPLOTWITHDATAVIEW_H
+#ifndef PLOT1D_H
+#define PLOT1D_H
 
 #include "ScientificPlot.h"
 #include "qcustomplot.h"
@@ -29,12 +29,12 @@ class UpdateTimer;
 //! DataItem1DView. Provides minimal functionality for data plotting and axes interaction. Should be
 //! a component for more complicated plotting widgets.
 
-class SpecularPlotWithDataView : public ScientificPlot
+class Plot1D : public ScientificPlot
 {
     Q_OBJECT
 
 public:
-    explicit SpecularPlotWithDataView(QWidget* parent = nullptr);
+    explicit Plot1D(QWidget* parent = nullptr);
 
     QSize sizeHint() const override { return QSize(500, 400); }
     QSize minimumSizeHint() const override { return QSize(128, 128); }
@@ -110,4 +110,4 @@ private:
     bool m_block_update;
 };
 
-#endif // SPECULARPLOTWITHDATAVIEW_H
+#endif // PLOT1D_H

--- a/GUI/coregui/Views/JobWidgets/JobResultsPresenter.cpp
+++ b/GUI/coregui/Views/JobWidgets/JobResultsPresenter.cpp
@@ -14,6 +14,7 @@
 
 #include "JobResultsPresenter.h"
 #include "FitComparisonWidget.h"
+#include "FitComparisonWidget1D_New.h"
 #include "FitComparisonWidget1D.h"
 #include "GUIHelpers.h"
 #include "IntensityDataProjectionsWidget.h"
@@ -65,7 +66,7 @@ JobResultsPresenter::JobResultsPresenter(QWidget* parent)
     registerWidget(Constants::IntensityProjectionsPresentation,
                    create_new<IntensityDataProjectionsWidget>);
 
-    registerWidget(Constants::FitComparisonPresentation1D, create_new<FitComparisonWidget1D>);
+    registerWidget(Constants::FitComparisonPresentation1D, create_new<FitComparisonWidget1D_New>);
     registerWidget(Constants::FitComparisonPresentation2D, create_new<FitComparisonWidget>);
 
     registerWidget(Constants::SpecularDataPresentation, create_new<SpecularDataWidget>);

--- a/GUI/coregui/Views/SessionModelView.cpp
+++ b/GUI/coregui/Views/SessionModelView.cpp
@@ -27,7 +27,7 @@
 #include <QVBoxLayout>
 
 namespace {
-const bool show_test_view = true;
+const bool show_test_view = false;
 }
 
 SessionModelView::SessionModelView(MainWindow *mainWindow)

--- a/GUI/coregui/Views/SpecularDataWidgets/Plot1DCanvas.cpp
+++ b/GUI/coregui/Views/SpecularDataWidgets/Plot1DCanvas.cpp
@@ -14,14 +14,13 @@
 
 #include "Plot1DCanvas.h"
 #include "FontScalingEvent.h"
+#include "Plot1D.h"
 #include "PlotStatusLabel.h"
-#include "SpecularPlot.h"
-#include "SpecularDataItem.h"
 #include <QVBoxLayout>
 
-Plot1DCanvas::Plot1DCanvas(QWidget *parent)
+Plot1DCanvas::Plot1DCanvas(QWidget* parent)
     : SessionItemWidget(parent)
-    , m_plot(new SpecularPlot)
+    , m_plot(new Plot1D)
     , m_canvasEvent(new FontScalingEvent(m_plot, this))
     , m_statusLabel(new PlotStatusLabel(m_plot, this))
 {
@@ -35,16 +34,16 @@ Plot1DCanvas::Plot1DCanvas(QWidget *parent)
 
     setLayout(layout);
 
-    setStatusLabelEnabled(false);
+    setStatusLabelEnabled(true);
 }
 
-void Plot1DCanvas::setItem(SessionItem* specularDataItem)
+void Plot1DCanvas::setItem(SessionItem* dataItemView)
 {
-    SessionItemWidget::setItem(specularDataItem);
-    m_plot->setItem(dynamic_cast<SpecularDataItem*>(specularDataItem));
+    SessionItemWidget::setItem(dataItemView);
+    m_plot->setItem(dataItemView);
 }
 
-SpecularPlot* Plot1DCanvas::specularPlot()
+Plot1D* Plot1DCanvas::plot1D()
 {
     return m_plot;
 }

--- a/GUI/coregui/Views/SpecularDataWidgets/Plot1DCanvas.cpp
+++ b/GUI/coregui/Views/SpecularDataWidgets/Plot1DCanvas.cpp
@@ -1,0 +1,66 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Views/SpecularDataWidgets/Plot1DCanvas.cpp
+//! @brief     Implements class Plot1DCanvas
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#include "Plot1DCanvas.h"
+#include "FontScalingEvent.h"
+#include "PlotStatusLabel.h"
+#include "SpecularPlot.h"
+#include "SpecularDataItem.h"
+#include <QVBoxLayout>
+
+Plot1DCanvas::Plot1DCanvas(QWidget *parent)
+    : SessionItemWidget(parent)
+    , m_plot(new SpecularPlot)
+    , m_canvasEvent(new FontScalingEvent(m_plot, this))
+    , m_statusLabel(new PlotStatusLabel(m_plot, this))
+{
+    this->installEventFilter(m_canvasEvent);
+    QVBoxLayout* layout = new QVBoxLayout;
+    layout->setMargin(0);
+    layout->setSpacing(0);
+
+    layout->addWidget(m_plot);
+    layout->addWidget(m_statusLabel);
+
+    setLayout(layout);
+
+    setStatusLabelEnabled(false);
+}
+
+void Plot1DCanvas::setItem(SessionItem* specularDataItem)
+{
+    SessionItemWidget::setItem(specularDataItem);
+    m_plot->setItem(dynamic_cast<SpecularDataItem*>(specularDataItem));
+}
+
+SpecularPlot* Plot1DCanvas::specularPlot()
+{
+    return m_plot;
+}
+
+QCustomPlot* Plot1DCanvas::customPlot()
+{
+    return m_plot->customPlot();
+}
+
+void Plot1DCanvas::setStatusLabelEnabled(bool flag)
+{
+    m_statusLabel->setLabelEnabled(flag);
+    m_statusLabel->setHidden(!flag);
+}
+
+void Plot1DCanvas::onStatusString(const QString& name)
+{
+    m_statusLabel->setText(name);
+}

--- a/GUI/coregui/Views/SpecularDataWidgets/Plot1DCanvas.h
+++ b/GUI/coregui/Views/SpecularDataWidgets/Plot1DCanvas.h
@@ -20,7 +20,7 @@
 class FontScalingEvent;
 class PlotStatusLabel;
 class QCustomPlot;
-class SpecularPlot;
+class Plot1D;
 
 //! The Plot1DCanvas class contains SpecularPlotWithDataView
 //! for specular data presentation, and provides
@@ -33,9 +33,9 @@ class BA_CORE_API_ Plot1DCanvas : public SessionItemWidget
 public:
     explicit Plot1DCanvas(QWidget* parent = nullptr);
 
-    void setItem(SessionItem* specularDataItem) override;
+    void setItem(SessionItem* dataItemView) override;
 
-    SpecularPlot* specularPlot();
+    Plot1D* plot1D();
     QCustomPlot* customPlot();
 
     void setStatusLabelEnabled(bool flag);
@@ -44,7 +44,7 @@ public slots:
     void onStatusString(const QString& name);
 
 private:
-    SpecularPlot* m_plot;
+    Plot1D* m_plot;
     FontScalingEvent* m_canvasEvent;
     PlotStatusLabel* m_statusLabel;
 };

--- a/GUI/coregui/Views/SpecularDataWidgets/Plot1DCanvas.h
+++ b/GUI/coregui/Views/SpecularDataWidgets/Plot1DCanvas.h
@@ -1,0 +1,52 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Views/SpecularDataWidgets/Plot1DCanvas.h
+//! @brief     Defines class Plot1DCanvas
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#ifndef PLOT1DCANVAS_H
+#define PLOT1DCANVAS_H
+
+#include "SessionItemWidget.h"
+
+class FontScalingEvent;
+class PlotStatusLabel;
+class QCustomPlot;
+class SpecularPlot;
+
+//! The Plot1DCanvas class contains SpecularPlotWithDataView
+//! for specular data presentation, and provides
+//! status string appearance.
+
+class BA_CORE_API_ Plot1DCanvas : public SessionItemWidget
+{
+    Q_OBJECT
+
+public:
+    explicit Plot1DCanvas(QWidget* parent = nullptr);
+
+    void setItem(SessionItem* specularDataItem) override;
+
+    SpecularPlot* specularPlot();
+    QCustomPlot* customPlot();
+
+    void setStatusLabelEnabled(bool flag);
+
+public slots:
+    void onStatusString(const QString& name);
+
+private:
+    SpecularPlot* m_plot;
+    FontScalingEvent* m_canvasEvent;
+    PlotStatusLabel* m_statusLabel;
+};
+
+#endif // PLOT1DCANVAS_H

--- a/GUI/coregui/Views/TestView.cpp
+++ b/GUI/coregui/Views/TestView.cpp
@@ -22,7 +22,7 @@
 #include "MaterialEditor.h"
 #include "MinimizerItem.h"
 #include "MinimizerSettingsWidget.h"
-#include "Plot1D.h"
+#include "Plot1DCanvas.h"
 #include "RealDataItem.h"
 #include "SampleModel.h"
 #include "SpecularDataItem.h"
@@ -215,7 +215,7 @@ void TestView::test_specular_data_widget()
     QVBoxLayout* layout = new QVBoxLayout;
     layout->setMargin(0);
     layout->setSpacing(0);
-    auto widget = new Plot1D(this);
+    auto widget = new Plot1DCanvas(this);
     widget->setItem(job_item->dataItemView());
     layout->addWidget(widget);
     setLayout(layout);

--- a/GUI/coregui/Views/TestView.cpp
+++ b/GUI/coregui/Views/TestView.cpp
@@ -55,7 +55,7 @@ TestView::TestView(MainWindow *mainWindow)
 //    test_AccordionWidget();
 //    test_RunFitWidget();
 //    test_ba3d();
-    test_specular_data_widget();
+//    test_specular_data_widget();
 }
 
 void TestView::test_ComponentProxyModel()

--- a/GUI/coregui/Views/TestView.cpp
+++ b/GUI/coregui/Views/TestView.cpp
@@ -14,6 +14,7 @@
 
 #include "TestView.h"
 #include "AccordionWidget.h"
+#include "ApplicationModels.h"
 #include "DataItem1DView.h"
 #include "JobModel.h"
 #include "JobItem.h"
@@ -21,11 +22,10 @@
 #include "MaterialEditor.h"
 #include "MinimizerItem.h"
 #include "MinimizerSettingsWidget.h"
-#include "ApplicationModels.h"
+#include "Plot1D.h"
 #include "RealDataItem.h"
 #include "SampleModel.h"
 #include "SpecularDataItem.h"
-#include "SpecularPlotWithDataView.h"
 #include "TestComponentView.h"
 #include "mainwindow.h"
 #include <QTreeView>
@@ -215,7 +215,7 @@ void TestView::test_specular_data_widget()
     QVBoxLayout* layout = new QVBoxLayout;
     layout->setMargin(0);
     layout->setSpacing(0);
-    auto widget = new SpecularPlotWithDataView(this);
+    auto widget = new Plot1D(this);
     widget->setItem(job_item->dataItemView());
     layout->addWidget(widget);
     setLayout(layout);

--- a/Tests/UnitTests/GUI/TestDataItemViews.h
+++ b/Tests/UnitTests/GUI/TestDataItemViews.h
@@ -1,5 +1,6 @@
 #include "google_test.h"
 #include "ApplicationModels.h"
+#include "ComboProperty.h"
 #include "DataItem.h"
 #include "DataItemView.h"
 #include "DataProperties.h"


### PR DESCRIPTION
1. DataItem1DView does not change the state of DataItem anymore.
2. Connection of DataItem1DView to the instrument (for units conversion) is now done through finding parenting JobItem and using its InstrumentItem.
3. Unit conversion is done "on the fly", when graph data is requested, i.e. DataItem1DView does not store output data 