### PR TITLE
Returned regex in the list of dependencies

### DIFF
--- a/cmake/bornagain/modules/SearchInstalledSoftware.cmake
+++ b/cmake/bornagain/modules/SearchInstalledSoftware.cmake
@@ -18,7 +18,7 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 add_definitions(-DBOOST_ALL_DYN_LINK) # line is needed for MSVC
 #add_definitions(-DBOOST_LIB_DIAGNOSTIC) # shows during compilation auto-linked libraries
-set(boost_libraries_required program_options iostreams system filesystem)
+set(boost_libraries_required program_options iostreams regex system filesystem)
 if(WIN32)
     set(boost_libraries_required ${boost_libraries_required} zlib bzip2)
 endif()


### PR DESCRIPTION
boost-system and boost-regex both come from inter-dependencies of boost libraries. Should be removed from cmake files after all the other boost libs 