### PR TITLE
3D view Prevent update on simple item move on QGraphicsScene

### DIFF
--- a/GUI/ba3d/ba3d/view/canvas.cpp
+++ b/GUI/ba3d/ba3d/view/canvas.cpp
@@ -13,57 +13,64 @@
 // ************************************************************************** //
 
 #include "canvas.h"
+#include "../model/geometry.h"
+#include "../model/model.h"
 #include "buffer.h"
 #include "camera.h"
 #include "program.h"
-#include "../model/geometry.h"
-#include "../model/model.h"
 
 #include <QMouseEvent>
-#include <qmath.h>
 #include <math.h>
+#include <qmath.h>
 
-namespace {
-    const float zoom_in_scale = 1.25f;
-    const float zoom_out_scale = 0.8f;
+namespace
+{
+const float zoom_in_scale = 1.25f;
+const float zoom_out_scale = 0.8f;
 
-    const float rot_speed_h = 0.4f; // camera rotation speed in horizontal direction
-    const float rot_speed_v = 0.4f; // camera rotation speed in vertical direction
+const float rot_speed_h = 0.4f; // camera rotation speed in horizontal direction
+const float rot_speed_v = 0.4f; // camera rotation speed in vertical direction
 }
 
-namespace RealSpace {
+namespace RealSpace
+{
 
 Canvas::Canvas()
-    : aspectRatio(1), colorBgR(1), colorBgG(1), colorBgB(1)
-    , camera(nullptr), program(nullptr), model(nullptr) {
-    connect(&geometryStore(), &GeometryStore::deletingGeometry,
-            this, &Canvas::releaseBuffer);
+    : aspectRatio(1), colorBgR(1), colorBgG(1), colorBgB(1), camera(nullptr), program(nullptr),
+      model(nullptr)
+{
+    connect(&geometryStore(), &GeometryStore::deletingGeometry, this, &Canvas::releaseBuffer);
 }
 
-Canvas::~Canvas() {
+Canvas::~Canvas()
+{
     releaseBuffers();
 }
 
-void Canvas::setBgColor(QColor const& c) {
+void Canvas::setBgColor(QColor const& c)
+{
     colorBgR = float(c.redF());
     colorBgG = float(c.greenF());
     colorBgB = float(c.blueF());
     update();
 }
 
-void Canvas::setCamera(Camera* c) {
+void Canvas::setCamera(Camera* c)
+{
     camera = c;
     setCamera();
 }
 
-void Canvas::setProgram(Program* p) {
+void Canvas::setProgram(Program* p)
+{
     program = p;
     if (program)
         program->needsInit();
     update();
 }
 
-void Canvas::setModel(Model* m) {
+void Canvas::setModel(Model* m)
+{
     releaseBuffers();
 
     disconnect(modelUpdated);
@@ -78,11 +85,13 @@ void Canvas::setModel(Model* m) {
     setCamera();
 }
 
-Model* Canvas::getModel() {
+Model* Canvas::getModel()
+{
     return model;
 }
 
-void Canvas::setCamera(bool full) {
+void Canvas::setCamera(bool full)
+{
     if (camera) {
         camera->setAspectRatio(aspectRatio);
         if (full && model)
@@ -92,20 +101,23 @@ void Canvas::setCamera(bool full) {
     update();
 }
 
-void Canvas::initializeGL() {
+void Canvas::initializeGL()
+{
     initializeOpenGLFunctions();
     glEnable(GL_DEPTH_TEST);
     glEnable(GL_CULL_FACE);
 }
 
-void Canvas::resizeGL(int w, int h) {
+void Canvas::resizeGL(int w, int h)
+{
     int w1 = qMax(1, w), h1 = qMax(1, h);
     viewport.setRect(0, 0, w1, h1);
     aspectRatio = float(w1) / float(h1);
     setCamera(false);
 }
 
-void Canvas::paintGL() {
+void Canvas::paintGL()
+{
     glClearColor(colorBgR, colorBgG, colorBgB, 1);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
@@ -118,22 +130,26 @@ void Canvas::paintGL() {
         model->draw(*this);
 
         // transparent objects
-        glEnable(GL_BLEND); glDepthMask(false);
-        glBlendFunc (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        glEnable(GL_BLEND);
+        glDepthMask(false);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         model->drawBlend(*this);
-        glDisable(GL_BLEND); glDepthMask(true);
+        glDisable(GL_BLEND);
+        glDepthMask(true);
 
         program->release();
     }
 }
 
-QVector3D Canvas::unproject(QPoint const& p) {
+QVector3D Canvas::unproject(QPoint const& p)
+{
     float x = p.x(), y = viewport.height() - p.y();
     return QVector3D(x, y, 1).unproject(matModel, matProj, viewport);
 }
 
-void Canvas::mousePressEvent(QMouseEvent* e) {
-    switch (e->button())  {
+void Canvas::mousePressEvent(QMouseEvent* e)
+{
+    switch (e->button()) {
     case Qt::LeftButton:
         mouseButton = btnTURN;
         break;
@@ -147,30 +163,31 @@ void Canvas::mousePressEvent(QMouseEvent* e) {
 
     if (camera) {
         matModel = camera->matModel;
-        matProj  = camera->matProj;
+        matProj = camera->matProj;
         e_last = e->pos();
     }
 }
 
-void Canvas::mouseMoveEvent(QMouseEvent* e) {
+void Canvas::mouseMoveEvent(QMouseEvent* e)
+{
     if (camera) {
         float delta_x = e->pos().x() - e_last.x();
         float delta_y = e->pos().y() - e_last.y();
 
         switch (mouseButton) {
         case btnTURN: {
-            if(delta_x != 0)
-                horizontalCameraTurn(-delta_x*rot_speed_h); // -ve for consistency with Blender
+            if (delta_x != 0)
+                horizontalCameraTurn(-delta_x * rot_speed_h); // -ve for consistency with Blender
 
-            if(delta_y != 0)
-                verticalCameraTurn(-delta_y*rot_speed_v); // -ve for consistency with Blender
+            if (delta_y != 0)
+                verticalCameraTurn(-delta_y * rot_speed_v); // -ve for consistency with Blender
 
             e_last = e->pos();
             break;
         }
         case btnZOOM: {
             float d = (e->y() - e_last.y()) / float(viewport.height());
-            camera->zoomBy(1+d);
+            camera->zoomBy(1 + d);
             break;
         }
         default:
@@ -181,7 +198,8 @@ void Canvas::mouseMoveEvent(QMouseEvent* e) {
     }
 }
 
-void Canvas::mouseReleaseEvent(QMouseEvent*) {
+void Canvas::mouseReleaseEvent(QMouseEvent*)
+{
     if (camera) {
         camera->endTransform(true);
         update();
@@ -190,16 +208,12 @@ void Canvas::mouseReleaseEvent(QMouseEvent*) {
 
 void Canvas::wheelEvent(QWheelEvent* e)
 {
-    if (camera)
-    {
-        if(e->delta() < 0)
-        {
-            //Zoom in
+    if (camera) {
+        if (e->delta() < 0) {
+            // Zoom in
             camera->zoomBy(zoom_in_scale);
-        }
-        else
-        {
-            //Zoom out
+        } else {
+            // Zoom out
             camera->zoomBy(zoom_out_scale);
         }
         camera->endTransform(true);
@@ -208,21 +222,24 @@ void Canvas::wheelEvent(QWheelEvent* e)
     e->accept(); // disabling the event from propagating further to the parent widgets
 }
 
-void Canvas::releaseBuffer(Geometry const* g) {
+void Canvas::releaseBuffer(Geometry const* g)
+{
     delete buffers.take(g);
 }
 
-void Canvas::releaseBuffers() {
-    for (auto b: buffers.values())
+void Canvas::releaseBuffers()
+{
+    for (auto b : buffers.values())
         delete b;
     buffers.clear();
 }
 
-void Canvas::draw(QColor const& color, QMatrix4x4 const& mat, Geometry const& geo) {
+void Canvas::draw(QColor const& color, QMatrix4x4 const& mat, Geometry const& geo)
+{
     auto it = buffers.find(&geo);
     Buffer* buf;
     if (buffers.end() == it)
-        buffers.insert(&geo, buf = new Buffer(geo));  // created on demand
+        buffers.insert(&geo, buf = new Buffer(geo)); // created on demand
     else
         buf = *it;
 
@@ -234,11 +251,11 @@ void Canvas::draw(QColor const& color, QMatrix4x4 const& mat, Geometry const& ge
 
 void Canvas::defaultView()
 {
-    if (model){
+    if (model) {
         // Default view
-        camera->lookAt(RealSpace::Camera::Position(RealSpace::Vector3D(0, -140, 90),  // eye
-                                                   RealSpace::Vector3D(0, 0, 0),      // center
-                                                   RealSpace::Vector3D::_z));         // up
+        camera->lookAt(RealSpace::Camera::Position(RealSpace::Vector3D(0, -140, 90), // eye
+                                                   RealSpace::Vector3D(0, 0, 0),     // center
+                                                   RealSpace::Vector3D::_z));        // up
         camera->endTransform(true);
         update();
     }
@@ -246,12 +263,11 @@ void Canvas::defaultView()
 
 void Canvas::sideView()
 {
-    if (model){
+    if (model) {
         // Edge view
-        camera->lookAt(RealSpace::Camera::Position(
-                                   RealSpace::Vector3D(0, -140, 0),   // eye
-                                   RealSpace::Vector3D(0, 0, 0),      // center
-                                   RealSpace::Vector3D::_z));         // up
+        camera->lookAt(RealSpace::Camera::Position(RealSpace::Vector3D(0, -140, 0), // eye
+                                                   RealSpace::Vector3D(0, 0, 0),    // center
+                                                   RealSpace::Vector3D::_z));       // up
         camera->endTransform(true);
         update();
     }
@@ -259,13 +275,12 @@ void Canvas::sideView()
 
 void Canvas::topView()
 {
-    if (model){
+    if (model) {
         // Top view
         // Setting a tiny offset in x value of eye such that eye and up vectors are not parallel
-        camera->lookAt(RealSpace::Camera::Position(
-                                   RealSpace::Vector3D(0, -0.5, 140),   // eye
-                                   RealSpace::Vector3D(0, 0, 0),       // center
-                                   RealSpace::Vector3D::_z));          // up
+        camera->lookAt(RealSpace::Camera::Position(RealSpace::Vector3D(0, -0.5, 140), // eye
+                                                   RealSpace::Vector3D(0, 0, 0),      // center
+                                                   RealSpace::Vector3D::_z));         // up
         camera->endTransform(true);
         update();
     }
@@ -273,9 +288,9 @@ void Canvas::topView()
 
 void Canvas::horizontalCameraTurn(float angle)
 {
-    if (model){
+    if (model) {
 
-        float theta = angle*static_cast<float>(M_PI/180.0); // in radians
+        float theta = angle * static_cast<float>(M_PI / 180.0); // in radians
 
         Camera::Position initial_pos = camera->getPos();
 
@@ -286,8 +301,9 @@ void Canvas::horizontalCameraTurn(float angle)
         RealSpace::Vector3D v_axis = v_up.normalized(); // normalized rotation axis
 
         // Rotating camera's position (eye) about up vector
-        RealSpace::Vector3D v_rot_eye = v_up*(1-std::cos(theta))*dot(v_axis,v_eye) +
-                v_eye*std::cos(theta) + cross(v_axis,v_eye)*std::sin(theta);
+        RealSpace::Vector3D v_rot_eye = v_up * (1 - std::cos(theta)) * dot(v_axis, v_eye)
+                                        + v_eye * std::cos(theta)
+                                        + cross(v_axis, v_eye) * std::sin(theta);
 
         Camera::Position rotated_pos(v_rot_eye, v_ctr, v_up);
 
@@ -298,9 +314,9 @@ void Canvas::horizontalCameraTurn(float angle)
 
 void Canvas::verticalCameraTurn(float angle)
 {
-    if (model){
+    if (model) {
 
-        float theta = angle*static_cast<float>(M_PI/180.0); // in radians
+        float theta = angle * static_cast<float>(M_PI / 180.0); // in radians
 
         Camera::Position initial_pos = camera->getPos();
 
@@ -311,8 +327,9 @@ void Canvas::verticalCameraTurn(float angle)
         RealSpace::Vector3D v_axis = cross(v_up, v_eye).normalized(); // normalized rotation axis
 
         // Rotating camera's position (eye) about an axis perpendicular to up and eye vectors
-        RealSpace::Vector3D v_rot_eye = v_up*(1-std::cos(theta))*dot(v_axis,v_eye) +
-                v_eye*std::cos(theta) + cross(v_axis,v_eye)*std::sin(theta);
+        RealSpace::Vector3D v_rot_eye = v_up * (1 - std::cos(theta)) * dot(v_axis, v_eye)
+                                        + v_eye * std::cos(theta)
+                                        + cross(v_axis, v_eye) * std::sin(theta);
 
         Camera::Position rotated_pos(v_rot_eye, v_ctr, v_up);
 
@@ -321,4 +338,4 @@ void Canvas::verticalCameraTurn(float angle)
     }
 }
 
-}  // namespace RealSpace
+} // namespace RealSpace

--- a/GUI/ba3d/ba3d/view/canvas.cpp
+++ b/GUI/ba3d/ba3d/view/canvas.cpp
@@ -21,7 +21,6 @@
 
 #include <QMouseEvent>
 #include <qmath.h>
-#include <QMessageBox>
 #include <math.h>
 
 namespace {
@@ -243,9 +242,6 @@ void Canvas::defaultView()
         camera->endTransform(true);
         update();
     }
-    else{
-        canvasHintMessageBox();
-    }
 }
 
 void Canvas::sideView()
@@ -258,9 +254,6 @@ void Canvas::sideView()
                                    RealSpace::Vector3D::_z));         // up
         camera->endTransform(true);
         update();
-    }
-    else{
-        canvasHintMessageBox();
     }
 }
 
@@ -276,22 +269,6 @@ void Canvas::topView()
         camera->endTransform(true);
         update();
     }
-    else{
-        canvasHintMessageBox();
-    }
-}
-
-// Display message when no Sample is selected and a ToolBar action is clicked
-void Canvas::canvasHintMessageBox()
-{
-    QMessageBox box;
-    box.setIcon(QMessageBox::Information);
-    box.setText("Sample not selected! Nothing to display!");
-    box.setDetailedText("Hint:"
-                        "\n1. Build the sample."
-                        "\n2. Select it from the panel on the right.");
-    box.setWindowFlags(box.windowFlags() & ~Qt::WindowCloseButtonHint); // Hide Close Button
-    box.exec();
 }
 
 void Canvas::horizontalCameraTurn(float angle)

--- a/GUI/ba3d/ba3d/view/canvas.h
+++ b/GUI/ba3d/ba3d/view/canvas.h
@@ -47,8 +47,6 @@ public:
     void sideView();
     void topView();
 
-    void canvasHintMessageBox();
-
     // Flying Camera implementation (similar to Blender's camera system)
     void horizontalCameraTurn(float angle);
     void verticalCameraTurn(float angle);

--- a/GUI/ba3d/ba3d/view/canvas.h
+++ b/GUI/ba3d/ba3d/view/canvas.h
@@ -18,18 +18,25 @@
 #include "../def.h"
 #include <QHash>
 
-#include <QOpenGLWidget>
 #include <QOpenGLFunctions>
 #include <QOpenGLShaderProgram>
+#include <QOpenGLWidget>
 
-namespace RealSpace {
+namespace RealSpace
+{
 
-class Camera; class Program; class Model;
-class Geometry; class Buffer; class Object;
+class Camera;
+class Program;
+class Model;
+class Geometry;
+class Buffer;
+class Object;
 
-class Canvas: public QOpenGLWidget, protected QOpenGLFunctions {
+class Canvas : public QOpenGLWidget, protected QOpenGLFunctions
+{
     Q_OBJECT
     friend class Object;
+
 public:
     Canvas();
     ~Canvas();
@@ -63,17 +70,17 @@ private:
 
     QPoint e_last; // latest mouse event's (x,y) screen coordinates
     QMatrix4x4 matModel, matProj;
-    QVector3D  unproject(QPoint const&);
+    QVector3D unproject(QPoint const&);
 
-    enum {btnNONE, btnTURN, btnZOOM} mouseButton;
+    enum { btnNONE, btnTURN, btnZOOM } mouseButton;
     void mousePressEvent(QMouseEvent*);
     void mouseMoveEvent(QMouseEvent*);
     void mouseReleaseEvent(QMouseEvent*);
     void wheelEvent(QWheelEvent*);
 
-    Camera  *camera;
-    Program *program;
-    Model   *model;
+    Camera* camera;
+    Program* program;
+    Model* model;
 
     QMetaObject::Connection modelUpdated;
 
@@ -84,5 +91,5 @@ private:
     void draw(QColor const&, QMatrix4x4 const&, Geometry const&);
 };
 
-}  // namespace RealSpace
-#endif  // BA3D_CANVAS_H
+} // namespace RealSpace
+#endif // BA3D_CANVAS_H

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.cpp
@@ -20,6 +20,7 @@
 #include <QVBoxLayout>
 #include <FilterPropertyProxy.h>
 #include <QApplication>
+#include "SessionGraphicsItem.h"
 
 RealSpaceCanvas::RealSpaceCanvas(QWidget* parent)
     : QWidget(parent)
@@ -131,6 +132,16 @@ void RealSpaceCanvas::onChangeLayerSizeAction(double layerSizeChangeScale)
     updateScene();
 }
 
+void RealSpaceCanvas::onDataChanged(const QModelIndex &index)
+{
+    auto item = m_sampleModel->itemForIndex(index);
+
+    if(!(item->modelType() == Constants::PropertyType &&
+         (item->displayName() == SessionGraphicsItem::P_XPOS ||
+          item->displayName() == SessionGraphicsItem::P_YPOS)))
+        updateScene();
+}
+
 void RealSpaceCanvas::updateScene()
 {
     QApplication::setOverrideCursor(Qt::WaitCursor);
@@ -203,14 +214,14 @@ void RealSpaceCanvas::setConnected(SampleModel* model, bool makeConnected)
         connect(model, SIGNAL(rowsRemoved(QModelIndex, int, int)),
                 this, SLOT(updateScene()), Qt::UniqueConnection);
         connect(model, SIGNAL(dataChanged(QModelIndex, QModelIndex, QVector<int>)),
-                this, SLOT(updateScene()), Qt::UniqueConnection);
+                this, SLOT(onDataChanged(QModelIndex)), Qt::UniqueConnection);
         connect(model, SIGNAL(modelReset()), this,
                 SLOT(resetScene()), Qt::UniqueConnection);
     } else {
         disconnect(model, SIGNAL(rowsInserted(QModelIndex, int, int)), this, SLOT(updateScene()));
         disconnect(model, SIGNAL(rowsRemoved(QModelIndex, int, int)), this, SLOT(updateScene()));
         disconnect(model, SIGNAL(dataChanged(QModelIndex, QModelIndex, QVector<int>)), this,
-                   SLOT(updateScene()));
+                   SLOT(onDataChanged(QModelIndex)));
         disconnect(model, SIGNAL(modelReset()), this, SLOT(resetScene()));
     }
 }

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.cpp
@@ -18,8 +18,8 @@
 #include "RealSpaceBuilder.h"
 #include "RealSpaceModel.h"
 #include <QVBoxLayout>
-
 #include <FilterPropertyProxy.h>
+#include <QApplication>
 
 RealSpaceCanvas::RealSpaceCanvas(QWidget* parent)
     : QWidget(parent)
@@ -133,6 +133,8 @@ void RealSpaceCanvas::onChangeLayerSizeAction(double layerSizeChangeScale)
 
 void RealSpaceCanvas::updateScene()
 {
+    QApplication::setOverrideCursor(Qt::WaitCursor);
+
     m_realSpaceModel.reset(new RealSpaceModel);
 
     SessionItem* item = m_sampleModel->itemForIndex(m_currentSelection);
@@ -153,6 +155,8 @@ void RealSpaceCanvas::updateScene()
         // ignore exceptions thrown
     }
     m_view->setModel(m_realSpaceModel.get());
+
+    QApplication::restoreOverrideCursor();
 }
 
 void RealSpaceCanvas::resetScene()

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.cpp
@@ -13,21 +13,18 @@
 // ************************************************************************** //
 
 #include "RealSpaceCanvas.h"
-#include "SampleModel.h"
-#include "RealSpaceView.h"
 #include "RealSpaceBuilder.h"
 #include "RealSpaceModel.h"
-#include <QVBoxLayout>
+#include "RealSpaceView.h"
+#include "SampleModel.h"
+#include "SessionGraphicsItem.h"
 #include <FilterPropertyProxy.h>
 #include <QApplication>
-#include "SessionGraphicsItem.h"
+#include <QVBoxLayout>
 
 RealSpaceCanvas::RealSpaceCanvas(QWidget* parent)
-    : QWidget(parent)
-    , m_sampleModel(nullptr)
-    , m_view(new RealSpaceView)
-    , m_view_locked(false)
-    , m_sceneGeometry(new SceneGeometry)
+    : QWidget(parent), m_sampleModel(nullptr), m_view(new RealSpaceView), m_view_locked(false),
+      m_sceneGeometry(new SceneGeometry)
 {
     QVBoxLayout* layout = new QVBoxLayout;
     layout->setMargin(0);
@@ -42,7 +39,6 @@ RealSpaceCanvas::RealSpaceCanvas(QWidget* parent)
 
 RealSpaceCanvas::~RealSpaceCanvas()
 {
-
 }
 
 void RealSpaceCanvas::setModel(SampleModel* sampleModel, QItemSelectionModel* selectionModel)
@@ -58,37 +54,35 @@ void RealSpaceCanvas::setModel(SampleModel* sampleModel, QItemSelectionModel* se
 
         if (m_sampleModel && !isHidden()) {
             setConnected(m_sampleModel, true);
-            if(selectionModel != nullptr)
-            {
+            if (selectionModel != nullptr) {
                 QModelIndexList indices = m_selectionModel->selection().indexes();
-                if(indices.size())
+                if (indices.size())
                     m_currentSelection = FilterPropertyProxy::toSourceIndex(indices.back());
             }
 
-            if(!m_view_locked)
+            if (!m_view_locked)
                 updateScene();
         }
     }
 }
 
-void RealSpaceCanvas::onSelectionChanged(const QItemSelection &selection /* selection */,
-                                         const QItemSelection & /* deselection */)
+void RealSpaceCanvas::onSelectionChanged(const QItemSelection& selection /* selection */,
+                                         const QItemSelection& /* deselection */)
 {
     // propagate selection from selectionChanged() signal to updateToSelection() method
     updateToSelection(selection);
 }
 
-void RealSpaceCanvas::updateToSelection(const QItemSelection &selection)
+void RealSpaceCanvas::updateToSelection(const QItemSelection& selection)
 {
-    if(!m_view_locked)
-    {
+    if (!m_view_locked) {
         QModelIndexList indices = selection.indexes();
 
-        if(indices.size())
+        if (indices.size())
             m_currentSelection = FilterPropertyProxy::toSourceIndex(indices.back());
         else
             m_currentSelection = QModelIndex();
-            // if no object is selected then display nothing on canvas
+        // if no object is selected then display nothing on canvas
 
         updateScene();
     }
@@ -113,32 +107,30 @@ void RealSpaceCanvas::onLockViewAction(bool view_locked)
 {
     // if Lock View box is unchecked i.e. previously it was checked (true) and now it's
     // unchecked (false), then emit a signal to display the current selection on the canvas
-    if(m_view_locked && !view_locked)
-    {
+    if (m_view_locked && !view_locked) {
         m_view_locked = view_locked;
         emit lockViewUnchecked(m_selectionModel->selection());
-    }
-    else
+    } else
         m_view_locked = view_locked;
 }
 
 void RealSpaceCanvas::onChangeLayerSizeAction(double layerSizeChangeScale)
 {
     // when no object is selected --> take no action
-    if(m_currentSelection == QModelIndex())
+    if (m_currentSelection == QModelIndex())
         return;
 
-    m_sceneGeometry->set_layer_size(m_sceneGeometry->layer_size()*layerSizeChangeScale);
+    m_sceneGeometry->set_layer_size(m_sceneGeometry->layer_size() * layerSizeChangeScale);
     updateScene();
 }
 
-void RealSpaceCanvas::onDataChanged(const QModelIndex &index)
+void RealSpaceCanvas::onDataChanged(const QModelIndex& index)
 {
     auto item = m_sampleModel->itemForIndex(index);
 
-    if(!(item->modelType() == Constants::PropertyType &&
-         (item->displayName() == SessionGraphicsItem::P_XPOS ||
-          item->displayName() == SessionGraphicsItem::P_YPOS)))
+    if (!(item->modelType() == Constants::PropertyType
+          && (item->displayName() == SessionGraphicsItem::P_XPOS
+              || item->displayName() == SessionGraphicsItem::P_YPOS)))
         updateScene();
 }
 
@@ -156,7 +148,7 @@ void RealSpaceCanvas::updateScene()
 
     try {
         // if the view is locked, keep the current orientation of the camera
-        if(m_view_locked)
+        if (m_view_locked)
             builder3D.populate(m_realSpaceModel.get(), *item, *m_sceneGeometry,
                                m_view->getCamera().getPos());
         // otherwise use default orientation of camera
@@ -209,14 +201,14 @@ void RealSpaceCanvas::setConnected(SampleModel* model, bool makeConnected)
         return;
 
     if (makeConnected) {
-        connect(model, &SampleModel::rowsInserted,
-                this, &RealSpaceCanvas::updateScene, Qt::UniqueConnection);
-        connect(model, &SampleModel::rowsRemoved,
-                this, &RealSpaceCanvas::updateScene, Qt::UniqueConnection);
-        connect(model, &SampleModel::dataChanged,
-                this, &RealSpaceCanvas::onDataChanged, Qt::UniqueConnection);
-        connect(model, &SampleModel::modelReset,
-                this, &RealSpaceCanvas::resetScene, Qt::UniqueConnection);
+        connect(model, &SampleModel::rowsInserted, this, &RealSpaceCanvas::updateScene,
+                Qt::UniqueConnection);
+        connect(model, &SampleModel::rowsRemoved, this, &RealSpaceCanvas::updateScene,
+                Qt::UniqueConnection);
+        connect(model, &SampleModel::dataChanged, this, &RealSpaceCanvas::onDataChanged,
+                Qt::UniqueConnection);
+        connect(model, &SampleModel::modelReset, this, &RealSpaceCanvas::resetScene,
+                Qt::UniqueConnection);
     } else {
         disconnect(model, &SampleModel::rowsInserted, this, &RealSpaceCanvas::updateScene);
         disconnect(model, &SampleModel::rowsRemoved, this, &RealSpaceCanvas::updateScene);

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.cpp
@@ -209,19 +209,18 @@ void RealSpaceCanvas::setConnected(SampleModel* model, bool makeConnected)
         return;
 
     if (makeConnected) {
-        connect(model, SIGNAL(rowsInserted(QModelIndex, int, int)),
-                this, SLOT(updateScene()), Qt::UniqueConnection);
-        connect(model, SIGNAL(rowsRemoved(QModelIndex, int, int)),
-                this, SLOT(updateScene()), Qt::UniqueConnection);
-        connect(model, SIGNAL(dataChanged(QModelIndex, QModelIndex, QVector<int>)),
-                this, SLOT(onDataChanged(QModelIndex)), Qt::UniqueConnection);
-        connect(model, SIGNAL(modelReset()), this,
-                SLOT(resetScene()), Qt::UniqueConnection);
+        connect(model, &SampleModel::rowsInserted,
+                this, &RealSpaceCanvas::updateScene, Qt::UniqueConnection);
+        connect(model, &SampleModel::rowsRemoved,
+                this, &RealSpaceCanvas::updateScene, Qt::UniqueConnection);
+        connect(model, &SampleModel::dataChanged,
+                this, &RealSpaceCanvas::onDataChanged, Qt::UniqueConnection);
+        connect(model, &SampleModel::modelReset,
+                this, &RealSpaceCanvas::resetScene, Qt::UniqueConnection);
     } else {
-        disconnect(model, SIGNAL(rowsInserted(QModelIndex, int, int)), this, SLOT(updateScene()));
-        disconnect(model, SIGNAL(rowsRemoved(QModelIndex, int, int)), this, SLOT(updateScene()));
-        disconnect(model, SIGNAL(dataChanged(QModelIndex, QModelIndex, QVector<int>)), this,
-                   SLOT(onDataChanged(QModelIndex)));
-        disconnect(model, SIGNAL(modelReset()), this, SLOT(resetScene()));
+        disconnect(model, &SampleModel::rowsInserted, this, &RealSpaceCanvas::updateScene);
+        disconnect(model, &SampleModel::rowsRemoved, this, &RealSpaceCanvas::updateScene);
+        disconnect(model, &SampleModel::dataChanged, this, &RealSpaceCanvas::onDataChanged);
+        disconnect(model, &SampleModel::modelReset, this, &RealSpaceCanvas::resetScene);
     }
 }

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.h
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.h
@@ -16,8 +16,8 @@
 #define REALSPACECANVAS_H
 
 #include "WinDllMacros.h"
-#include <QWidget>
 #include <QModelIndex>
+#include <QWidget>
 #include <memory>
 
 #include <QItemSelectionModel>
@@ -30,23 +30,44 @@ class RealSpaceModel;
 class SceneGeometry
 {
 public:
-    SceneGeometry(double size = 50.0, double top_thickness = 25.0,
-                  double bottom_thickness = 25.0, double min_thickness = 2.0)
+    SceneGeometry(double size = 50.0, double top_thickness = 25.0, double bottom_thickness = 25.0,
+                  double min_thickness = 2.0)
     {
-        l_size = size;                              // layer size
-        l_top_thickness = top_thickness;            // top layer thickness
-        l_bottom_thickness = bottom_thickness;      // bottom layer thickness
-        l_min_thickness = min_thickness;            // minimum layer thickness
+        l_size = size;                         // layer size
+        l_top_thickness = top_thickness;       // top layer thickness
+        l_bottom_thickness = bottom_thickness; // bottom layer thickness
+        l_min_thickness = min_thickness;       // minimum layer thickness
     }
 
-    double layer_size() const {return l_size;}
-    double layer_top_thickness() const {return l_top_thickness;}
-    double layer_bottom_thickness() const {return l_top_thickness;}
-    double layer_min_thickness() const {return l_min_thickness;}
+    double layer_size() const
+    {
+        return l_size;
+    }
+    double layer_top_thickness() const
+    {
+        return l_top_thickness;
+    }
+    double layer_bottom_thickness() const
+    {
+        return l_top_thickness;
+    }
+    double layer_min_thickness() const
+    {
+        return l_min_thickness;
+    }
 
-    void set_layer_size(double size) {l_size = size;}
-    void set_layer_top_thickness(double top_thickness) {l_top_thickness = top_thickness;}
-    void set_layer_bottom_thickness(double bottom_thickness) {l_top_thickness = bottom_thickness;}
+    void set_layer_size(double size)
+    {
+        l_size = size;
+    }
+    void set_layer_top_thickness(double top_thickness)
+    {
+        l_top_thickness = top_thickness;
+    }
+    void set_layer_bottom_thickness(double bottom_thickness)
+    {
+        l_top_thickness = bottom_thickness;
+    }
 
 private:
     double l_size;
@@ -54,7 +75,6 @@ private:
     double l_bottom_thickness;
     double l_min_thickness;
 };
-
 
 //! Provides 3D object generation for RealSpaceWidget.
 class BA_CORE_API_ RealSpaceCanvas : public QWidget
@@ -69,11 +89,11 @@ public:
                   QItemSelectionModel* selectionModel = nullptr);
 
 signals:
-    void lockViewUnchecked(const QItemSelection &);
+    void lockViewUnchecked(const QItemSelection&);
 
 public slots:
-    void onSelectionChanged(const QItemSelection &selection, const QItemSelection &);
-    void updateToSelection(const QItemSelection &selection);
+    void onSelectionChanged(const QItemSelection& selection, const QItemSelection&);
+    void updateToSelection(const QItemSelection& selection);
 
     void onDefaultViewAction();
     void onSideViewAction();

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.h
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.h
@@ -82,6 +82,7 @@ public slots:
     void onChangeLayerSizeAction(double layer_size_scale);
 
 private slots:
+    void onDataChanged(const QModelIndex& index);
     void updateScene();
     void resetScene();
 


### PR DESCRIPTION
Further changes implemented besides the above:

- Display busy cursor symbol during updateScene of 3D view
- Remove old function for displaying message in 3D view when no sample is selected. This was used when 3D view was inside TestView but now it seems unnecessary.