### PR TITLE
Redmine issue 2124: fixed program crash on attempt to get axis through SimulationResult.data().getAxis

### DIFF
--- a/Core/Instrument/SimulationResult.cpp
+++ b/Core/Instrument/SimulationResult.cpp
@@ -87,6 +87,18 @@ Histogram2D* SimulationResult::histogram2d(AxesUnits units) const
     return new Histogram2D(*P_data);
 }
 
+IHistogram* SimulationResult::histogram(AxesUnits units) const
+{
+    const std::unique_ptr<OutputData<double>> P_data(data(units));
+    if (mP_data->getRank() == 1 && mP_unit_converter->dimension() == 1)
+        return new Histogram1D(*P_data);
+    else if (mP_data->getRank() == 2 && mP_unit_converter->dimension() == 2)
+        return new Histogram2D(*P_data);
+    else
+        throw std::runtime_error("Error in SimulationResult::histogram: "
+                                 "cannot create output data histogram");
+}
+
 std::vector<AxisInfo> SimulationResult::axisInfo(AxesUnits units) const
 {
     if (!mP_unit_converter) return {};

--- a/Core/Instrument/SimulationResult.h
+++ b/Core/Instrument/SimulationResult.h
@@ -51,7 +51,9 @@ public:
     SimulationResult& operator=(const SimulationResult& other);
     SimulationResult& operator=(SimulationResult&& other);
 
+#ifndef SWIG
     OutputData<double>* data(AxesUnits units = AxesUnits::DEFAULT) const;
+#endif //SWIG
     Histogram1D* histogram1d(AxesUnits units = AxesUnits::DEFAULT) const;
     Histogram2D* histogram2d(AxesUnits units = AxesUnits::DEFAULT) const;
     IHistogram* histogram(AxesUnits units = AxesUnits::DEFAULT) const;

--- a/Core/Instrument/SimulationResult.h
+++ b/Core/Instrument/SimulationResult.h
@@ -23,6 +23,7 @@
 
 class Histogram1D;
 class Histogram2D;
+class IHistogram;
 class IAxis;
 template<class T> class OutputData;
 
@@ -53,6 +54,7 @@ public:
     OutputData<double>* data(AxesUnits units = AxesUnits::DEFAULT) const;
     Histogram1D* histogram1d(AxesUnits units = AxesUnits::DEFAULT) const;
     Histogram2D* histogram2d(AxesUnits units = AxesUnits::DEFAULT) const;
+    IHistogram* histogram(AxesUnits units = AxesUnits::DEFAULT) const;
 
     //! Provide AxisInfo for each axis and the given units
     std::vector<AxisInfo> axisInfo(AxesUnits units = AxesUnits::DEFAULT) const;

--- a/Examples/python/fitting/ex09_FitSpecular/RealLifeReflectometryFitting.py
+++ b/Examples/python/fitting/ex09_FitSpecular/RealLifeReflectometryFitting.py
@@ -191,9 +191,8 @@ def objective_primary(args):
     arg_dict = create_par_dict(*args)
 
     sim_result = run_simulation(arg_dict, bin_start, bin_end)
-    sim_data = sim_result.data().getArray()
     return chi_2(get_real_data_values(bin_start, bin_end),
-                 sim_data, get_weights(bin_start, bin_end))
+                 sim_result.array(), get_weights(bin_start, bin_end))
 
 
 def objective_fine(args, intensity, footprint_factor, divergence):
@@ -206,9 +205,8 @@ def objective_fine(args, intensity, footprint_factor, divergence):
     arg_dict = create_par_dict(intensity, footprint_factor, divergence, *args)
 
     sim_result = run_simulation(arg_dict, bin_start, bin_end)
-    sim_data = sim_result.data().getArray()
     return chi_2(get_real_data_values(bin_start, bin_end),
-                 sim_data, get_weights(bin_start, bin_end))
+                 sim_result.array(), get_weights(bin_start, bin_end))
 
 
 def run_fitting():
@@ -257,13 +255,11 @@ def plot_result(sim_result, ref_result, bin_start=0, bin_end=-1):
     """
     Plots the graphs of obtained simulation data
     """
-    sim_data = sim_result.data()
-    ref_data = ref_result.data()
 
     plt.semilogy(get_real_data_axis(bin_start, bin_end) * 180 / np.pi,
                  get_real_data_values(bin_start, bin_end),
-                 sim_data.getAxis(0).getBinCenters(), sim_data.getArray(),
-                 ref_data.getAxis(0).getBinCenters(), ref_data.getArray())
+                 sim_result.histogram1d().getBinCenters(), sim_result.array(),
+                 ref_result.histogram1d().getBinCenters(), ref_result.array())
 
     xlabel = ba.get_axes_labels(sim_result, ba.AxesUnits.DEFAULT)[0]
     ylabel = "Intensity"

--- a/Tests/Functional/Python/PyPersistence/example_template.py
+++ b/Tests/Functional/Python/PyPersistence/example_template.py
@@ -162,9 +162,9 @@ def check_result(result, example_name):
         raise Exception("Absent reference file")
 
     print("Loading reference file '{}'".format(reffile))
-    reference = ba.IntensityDataIOFactory.readOutputData(reffile)
+    reference = ba.IntensityDataIOFactory.readIntensityData(reffile)
 
-    diff = ba.getRelativeDifference(result.data(), reference)
+    diff = ba.getRelativeDifference(result.histogram(), reference)
 
     if diff > TOLERANCE:
         print("Failure - Difference {0} is above tolerance level {1}".format(diff, TOLERANCE))

--- a/Wrap/python/plot_utils.py
+++ b/Wrap/python/plot_utils.py
@@ -166,9 +166,8 @@ def plot_specular_simulation_result(result, ymin=None, ymax=None, units=ba.AxesU
     :param units: units on the x-axis
     """
 
-    data = result.data(units)
-    intensity = data.getArray()
-    x_axis = data.getAxis(0).getBinCenters()
+    intensity = result.array()
+    x_axis = result.histogram1d(units).getBinCenters()
     ymax = np.amax(intensity) * 2.0 if ymax is None else ymax
     ymin = max(np.amin(intensity) * 0.5, 1e-18 * ymax) if ymin is None else ymin
 
@@ -200,7 +199,7 @@ def plot_simulation_result(result, intensity_min=None, intensity_max=None, units
     :param postpone_show: postpone showing the plot for later tuning (False by default)
     """
     if len(result.array().shape) == 1:  # 1D data, specular simulation assumed
-        plot_specular_simulation_result(result, intensity_min, intensity_max)
+        plot_specular_simulation_result(result, intensity_min, intensity_max, units)
     else:
         plot_colormap(result, intensity_min, intensity_max, units)
     plt.tight_layout()
@@ -389,12 +388,12 @@ class PlotterSpecular(Plotter):
 
     def plot_graph(self, fit_objective):
         # retrieving data from fit suite
-        real_data = fit_objective.experimentalData().data()
-        sim_data = fit_objective.simulationResult().data()
+        real_data = fit_objective.experimentalData()
+        sim_data = fit_objective.simulationResult()
 
         # data values
-        sim_values = sim_data.getArray()
-        real_values = real_data.getArray()
+        sim_values = sim_data.array()
+        real_values = real_data.array()
 
         # default font properties dictionary to use
         font = {'family': 'serif',
@@ -402,11 +401,11 @@ class PlotterSpecular(Plotter):
                 'size': label_fontsize}
 
         plt.subplot(self.gs[0])
-        plt.semilogy(sim_data.getAxis(0).getBinCenters(), sim_values, 'b',
-                     real_data.getAxis(0).getBinCenters(), real_values, 'k--')
-        plt.ylim((0.5 * np.min(real_values), 5 * np.max(real_values)))
+        plt.semilogy(sim_data.histogram1d().getBinCenters(), sim_values, 'b',
+                     real_data.histogram1d().getBinCenters(), real_values, 'k--')
+        plt.ylim((0.5 * real_values.min(), 5 * real_values.max()))
 
-        xlabel = get_axes_labels(fit_objective.experimentalData(), ba.AxesUnits.DEFAULT)[0]
+        xlabel = get_axes_labels(real_data, ba.AxesUnits.DEFAULT)[0]
         plt.legend(['BornAgain', 'Reference'], loc='upper right', prop=font)
         plt.xlabel(xlabel, fontdict=font)
         plt.ylabel("Intensity", fontdict=font)

--- a/Wrap/swig/libBornAgainCore.i
+++ b/Wrap/swig/libBornAgainCore.i
@@ -238,7 +238,9 @@
 // ownership
 
 %newobject SimulationResult::data(AxesUnits units_type = AxesUnits::DEFAULT) const;
+%newobject SimulationResult::histogram1d(AxesUnits units_type = AxesUnits::DEFAULT) const;
 %newobject SimulationResult::histogram2d(AxesUnits units_type = AxesUnits::DEFAULT) const;
+%newobject SimulationResult::histogram(AxesUnits units_type = AxesUnits::DEFAULT) const;
 
 %newobject IntensityDataIOFactory::readOutputData(const std::string& file_name);
 %newobject IntensityDataIOFactory::readIntensityData(const std::string& file_name);

--- a/Wrap/swig/libBornAgainCore.i
+++ b/Wrap/swig/libBornAgainCore.i
@@ -237,7 +237,6 @@
 
 // ownership
 
-%newobject SimulationResult::data(AxesUnits units_type = AxesUnits::DEFAULT) const;
 %newobject SimulationResult::histogram1d(AxesUnits units_type = AxesUnits::DEFAULT) const;
 %newobject SimulationResult::histogram2d(AxesUnits units_type = AxesUnits::DEFAULT) const;
 %newobject SimulationResult::histogram(AxesUnits units_type = AxesUnits::DEFAULT) const;

--- a/auto/Wrap/libBornAgainCore.py
+++ b/auto/Wrap/libBornAgainCore.py
@@ -19086,17 +19086,6 @@ class SimulationResult(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def data(self, *args):
-        """
-        data(SimulationResult self, AxesUnits units) -> IntensityData
-        data(SimulationResult self) -> IntensityData
-
-        OutputData< double > * SimulationResult::data(AxesUnits units=AxesUnits::DEFAULT) const 
-
-        """
-        return _libBornAgainCore.SimulationResult_data(self, *args)
-
-
     def histogram1d(self, *args):
         """
         histogram1d(SimulationResult self, AxesUnits units) -> Histogram1D

--- a/auto/Wrap/libBornAgainCore.py
+++ b/auto/Wrap/libBornAgainCore.py
@@ -19119,6 +19119,14 @@ class SimulationResult(_object):
         return _libBornAgainCore.SimulationResult_histogram2d(self, *args)
 
 
+    def histogram(self, *args):
+        """
+        histogram(SimulationResult self, AxesUnits units) -> IHistogram
+        histogram(SimulationResult self) -> IHistogram
+        """
+        return _libBornAgainCore.SimulationResult_histogram(self, *args)
+
+
     def axisInfo(self, *args):
         """
         axisInfo(SimulationResult self, AxesUnits units) -> swig_dummy_type_axisinfo_vector


### PR DESCRIPTION
The bug was fixed by just removing SimulationResult::data from python scope in favor of SimulationResult::histogram, SimulationResult::histogram1d and SimulationResult::histogram2d.

The bug was because of improper handling of temporary objects by python.
After implementing it, I don't like this solution anymore for these reasons:

1. histogram interface is heavier than underlying OutputData<double>
2. It is not universal (depending on the task one need to call histogram1d or histogram2d, and sometimes it is enough to have just histogram)
3. Histogram functionality is not important in python.
4. The bug caught with SimulationResult::data can re-appear once again with histogram methods. It is necessary to handle it in the future anyway.

Thus it would be better to remove histogram accessors from SimulationResult in the future and replace all of them with one single SimulationResult::data accessor (with carefully handling its lifetime). 