### PR TITLE
GUI3D Remove offset of particles during 3D particle construction

### DIFF
--- a/GUI/ba3d/ba3d/model/geometry.cpp
+++ b/GUI/ba3d/ba3d/model/geometry.cpp
@@ -70,7 +70,8 @@ Geometry::Geometry(GeometricID::Key key_) : m_key(key_) {
         m_mesh = meshBox();
         break;
     case BaseShape::Sphere:
-        m_mesh = meshSphere(m_key.p1);
+//        m_mesh = meshSphere(m_key.p1); // (PREVIOUSLY)
+        m_mesh = meshSphere(m_key.p1, m_key.p2);
         break;
     case BaseShape::Column:
         m_mesh = meshColumn(m_key.p1, m_key.p2);

--- a/GUI/ba3d/ba3d/model/geometry.cpp
+++ b/GUI/ba3d/ba3d/model/geometry.cpp
@@ -86,7 +86,7 @@ Geometry::Geometry(GeometricID::Key key_) : m_key(key_) {
         m_mesh = meshTruncBox(m_key.p1);
         break;
     case BaseShape::Cuboctahedron:
-        m_mesh = meshCuboctahedron(m_key.p1, m_key.p2);
+        m_mesh = meshCuboctahedron(m_key.p1, m_key.p2, m_key.p3);
         break;
     }
 }

--- a/GUI/ba3d/ba3d/model/geometry.cpp
+++ b/GUI/ba3d/ba3d/model/geometry.cpp
@@ -70,7 +70,6 @@ Geometry::Geometry(GeometricID::Key key_) : m_key(key_) {
         m_mesh = meshBox();
         break;
     case BaseShape::Sphere:
-//        m_mesh = meshSphere(m_key.p1); // (PREVIOUSLY)
         m_mesh = meshSphere(m_key.p1, m_key.p2);
         break;
     case BaseShape::Column:

--- a/GUI/ba3d/ba3d/model/geometry.cpp
+++ b/GUI/ba3d/ba3d/model/geometry.cpp
@@ -15,51 +15,62 @@
 #include "geometry.h"
 #include "model.h"
 
-namespace RealSpace {
+namespace RealSpace
+{
 //------------------------------------------------------------------------------
 
-Geometry::Vert_Normal::Vert_Normal(const Vector3D& v_, const Vector3D& n_) : v(v_), n(n_) {}
+Geometry::Vert_Normal::Vert_Normal(const Vector3D& v_, const Vector3D& n_) : v(v_), n(n_)
+{
+}
 
-void Geometry::Vertices::addVertex(const Vector3D& v, int n) {
-    for(int i=0; i<n; ++i)
+void Geometry::Vertices::addVertex(const Vector3D& v, int n)
+{
+    for (int i = 0; i < n; ++i)
         append(v);
 }
 
-void Geometry::Vertices::addTriangle(const Vector3D& v1, const Vector3D& v2, const Vector3D& v3) {
-    append(v1); append(v2); append(v3);
+void Geometry::Vertices::addTriangle(const Vector3D& v1, const Vector3D& v2, const Vector3D& v3)
+{
+    append(v1);
+    append(v2);
+    append(v3);
 }
 
-void Geometry::Vertices::addQuad(const Vector3D& v1, const Vector3D& v2,
-                                 const Vector3D& v3, const Vector3D& v4) {
+void Geometry::Vertices::addQuad(const Vector3D& v1, const Vector3D& v2, const Vector3D& v3,
+                                 const Vector3D& v4)
+{
     addTriangle(v1, v2, v3);
     addTriangle(v3, v4, v1);
 }
 
-void Geometry::Vertices::addQuad(const Vertices& vs,
-                                 unsigned i1, unsigned i2, unsigned i3, unsigned i4) {
+void Geometry::Vertices::addQuad(const Vertices& vs, unsigned i1, unsigned i2, unsigned i3,
+                                 unsigned i4)
+{
     addQuad(vs.at(i1), vs.at(i2), vs.at(i3), vs.at(i4));
 }
 
-void Geometry::Vertices::addStrip(const Vertices& vs, const Indices& is) {
+void Geometry::Vertices::addStrip(const Vertices& vs, const Indices& is)
+{
     Q_ASSERT(is.size() >= 3); // at least one triangle
-    for(unsigned i=0; i+2<is.size(); ++i)
-        if (i%2)
-            addTriangle(vs.at(is.at(i)), vs.at(is.at(1+i)), vs.at(is.at(2+i)));
+    for (unsigned i = 0; i + 2 < is.size(); ++i)
+        if (i % 2)
+            addTriangle(vs.at(is.at(i)), vs.at(is.at(1 + i)), vs.at(is.at(2 + i)));
         else
-            addTriangle(vs.at(is.at(i)), vs.at(is.at(2+i)), vs.at(is.at(1+i)));
+            addTriangle(vs.at(is.at(i)), vs.at(is.at(2 + i)), vs.at(is.at(1 + i)));
 }
 
-void Geometry::Vertices::addFan(const Vertices& vs, const Indices& is) {
+void Geometry::Vertices::addFan(const Vertices& vs, const Indices& is)
+{
     Q_ASSERT(is.size() >= 3); // at least one triangle
-    auto &ctr = vs.at(is.at(0));
-    for(unsigned i=0; i+2<is.size(); ++i)
-        addTriangle(ctr, vs.at(is.at(1+i)),
-                    vs.at(is.at(2+i)));
+    auto& ctr = vs.at(is.at(0));
+    for (unsigned i = 0; i + 2 < is.size(); ++i)
+        addTriangle(ctr, vs.at(is.at(1 + i)), vs.at(is.at(2 + i)));
 }
 
 //------------------------------------------------------------------------------
 
-Geometry::Geometry(GeometricID::Key key_) : m_key(key_) {
+Geometry::Geometry(GeometricID::Key key_) : m_key(key_)
+{
     using namespace GeometricID;
 
     switch (m_key.id) {
@@ -90,45 +101,51 @@ Geometry::Geometry(GeometricID::Key key_) : m_key(key_) {
     }
 }
 
-Geometry::~Geometry() {
+Geometry::~Geometry()
+{
     // remove self from the store
     geometryStore().geometryDeleted(*this);
 }
 
-Geometry::Mesh Geometry::makeMesh(const Vertices& vs, Vertices const* ns) {
+Geometry::Mesh Geometry::makeMesh(const Vertices& vs, Vertices const* ns)
+{
     int nv = vs.count();
-    Q_ASSERT(0 == nv%3);
+    Q_ASSERT(0 == nv % 3);
     Q_ASSERT(!ns || nv == ns->count()); // if normals not given, will be computed
 
     Mesh mesh(nv);
 
-    for (int i=0 ; i<nv; i+=3) {
-        const Vector3D& v0 = vs.at(0+i), v1 = vs.at(1+i), v2 = vs.at(2+i);
+    for (int i = 0; i < nv; i += 3) {
+        const Vector3D &v0 = vs.at(0 + i), v1 = vs.at(1 + i), v2 = vs.at(2 + i);
         const Vector3D *n0, *n1, *n2;
         Vector3D nm;
 
         if (ns) {
-            n0 = &ns->at(0+i); n1 = &ns->at(1+i); n2 = &ns->at(2+i);
+            n0 = &ns->at(0 + i);
+            n1 = &ns->at(1 + i);
+            n2 = &ns->at(2 + i);
         } else {
             nm = cross((v1 - v0), (v2 - v0));
             n0 = n1 = n2 = &nm;
         }
 
-        mesh.append(Vert_Normal(v0,*n0));
-        mesh.append(Vert_Normal(v1,*n1));
-        mesh.append(Vert_Normal(v2,*n2));
+        mesh.append(Vert_Normal(v0, *n0));
+        mesh.append(Vert_Normal(v1, *n1));
+        mesh.append(Vert_Normal(v2, *n2));
     }
 
     return mesh;
 }
 
-Geometry::Mesh Geometry::makeMesh(const Vertices& vs, const Vertices& ns) {
+Geometry::Mesh Geometry::makeMesh(const Vertices& vs, const Vertices& ns)
+{
     return makeMesh(vs, &ns);
 }
 
 //------------------------------------------------------------------------------
 
-GeometryHandle GeometryStore::getGeometry(GeometricID::Key key) {
+GeometryHandle GeometryStore::getGeometry(GeometricID::Key key)
+{
     auto it = m_geometries.find(key);
     if (m_geometries.end() != it) {
         if (auto g = it->second.lock())
@@ -139,12 +156,14 @@ GeometryHandle GeometryStore::getGeometry(GeometricID::Key key) {
     return g;
 }
 
-void GeometryStore::geometryDeleted(Geometry const& g) {
+void GeometryStore::geometryDeleted(Geometry const& g)
+{
     emit deletingGeometry(&g);
     m_geometries.erase(g.m_key);
 }
 
-GeometryStore& geometryStore() {
+GeometryStore& geometryStore()
+{
     static GeometryStore gs;
     return gs;
 }

--- a/GUI/ba3d/ba3d/model/geometry.h
+++ b/GUI/ba3d/ba3d/model/geometry.h
@@ -17,24 +17,27 @@
 
 #include "../def.h"
 #include "geometry_inc.h"
-#include <QVector>
 #include <QObject>
+#include <QVector>
 #include <unordered_map>
 #include <vector>
 
-namespace RealSpace {
+namespace RealSpace
+{
 
 class Buffer;
 class GeometryStore;
 
-class Geometry {
+class Geometry
+{
     friend class Buffer;
     friend class GeometryStore;
+
 public:
     // vertex + normal pair
     struct Vert_Normal {
         Vector3D v, n;
-        Vert_Normal() =default;
+        Vert_Normal() = default;
         Vert_Normal(const Vector3D& v, const Vector3D& n);
     };
 
@@ -42,8 +45,7 @@ public:
     using Indices = std::vector<unsigned>;
 
     // vertices (for GL)
-    struct Vertices : private QVector<Vector3D>
-    {
+    struct Vertices : private QVector<Vector3D> {
         using QVector::QVector;
         using QVector::append;
         using QVector::reserve;
@@ -54,13 +56,13 @@ public:
         using QVector::begin;
         using QVector::end;
 
-        void addVertex(const Vector3D&, int n = 1);     // add a vertex, possibly multiple copies
-        void addTriangle(const Vector3D&, const Vector3D&, const Vector3D&);   // triangle
-        void addQuad(const Vector3D&, const Vector3D&,
-                     const Vector3D&, const Vector3D&); // quad as 2 triangles
+        void addVertex(const Vector3D&, int n = 1); // add a vertex, possibly multiple copies
+        void addTriangle(const Vector3D&, const Vector3D&, const Vector3D&); // triangle
+        void addQuad(const Vector3D&, const Vector3D&, const Vector3D&,
+                     const Vector3D&); // quad as 2 triangles
         void addQuad(const Vertices&, unsigned, unsigned, unsigned, unsigned); // quad by indices
-        void addStrip(const Vertices&, const Indices&); // triangle strip
-        void addFan(const Vertices&, const Indices&);   // triangle fan
+        void addStrip(const Vertices&, const Indices&);                        // triangle strip
+        void addFan(const Vertices&, const Indices&);                          // triangle fan
     };
 
     // vertex/normal mesh
@@ -92,21 +94,23 @@ private:
 
 // a single store keeps existing geometries for sharing
 
-class GeometryStore : public QObject {
-  Q_OBJECT
-  friend class Geometry;
+class GeometryStore : public QObject
+{
+    Q_OBJECT
+    friend class Geometry;
+
 public:
-  GeometryHandle getGeometry(GeometricID::Key);
+    GeometryHandle getGeometry(GeometricID::Key);
 
 signals:
-  void deletingGeometry(Geometry const*); // signal to canvases
+    void deletingGeometry(Geometry const*); // signal to canvases
 
 private:
-  std::unordered_map<GeometricID::Key, GeometryRef, GeometricID::KeyHash> m_geometries;
-  void geometryDeleted(Geometry const&);  // ~Geometry() calls this
+    std::unordered_map<GeometricID::Key, GeometryRef, GeometricID::KeyHash> m_geometries;
+    void geometryDeleted(Geometry const&); // ~Geometry() calls this
 };
 
 GeometryStore& geometryStore(); // simpleton
 
-}  // namespace RealSpace
+} // namespace RealSpace
 #endif

--- a/GUI/ba3d/ba3d/model/geometry.h
+++ b/GUI/ba3d/ba3d/model/geometry.h
@@ -84,7 +84,7 @@ private:
     static Mesh meshIcosahedron();
     static Mesh meshDodecahedron();
     static Mesh meshTruncBox(float tD);
-    static Mesh meshCuboctahedron(float rH, float beta);
+    static Mesh meshCuboctahedron(float rH, float alpha, float H);
 
     // mesh params for round shapes
     static int const RINGS = 12, SLICES = 24;

--- a/GUI/ba3d/ba3d/model/geometry.h
+++ b/GUI/ba3d/ba3d/model/geometry.h
@@ -79,7 +79,7 @@ private:
 
     static Mesh meshPlane();
     static Mesh meshBox();
-    static Mesh meshSphere(float cut);
+    static Mesh meshSphere(float cut, float baseShift = 0.0f);
     static Mesh meshColumn(float ratio_Rt_Rb, float numSides);
     static Mesh meshIcosahedron();
     static Mesh meshDodecahedron();

--- a/GUI/ba3d/ba3d/model/geometry/column.cpp
+++ b/GUI/ba3d/ba3d/model/geometry/column.cpp
@@ -34,12 +34,6 @@ Geometry::Mesh Geometry::meshColumn(float ratio_Rt_Rb, float numSides) {
     for(int s=0; s < slices; ++s) {
         float th = float(2*M_PI*s/slices), st = sinf(th), ct = cosf(th);
 
-        /* This base shape is constructed symmetric about the xy plane, centered at the origin.
-        i.e. xy-plane goes through the center of the shape (object extension: -H/2 to +H/2 in z)
-        Later when the particle is created based upon this shape and scaled to proper dimensions,
-        the offset is kept at H/2 to bring the base of the object to 0 in z (see particles.cpp) */
-
-//        Vector3D vb_(Rb*ct, Rb*st, -H/2), vt_(Rt*ct, Rt*st, +H/2); (PREVIOUSLY)
         Vector3D vb_(Rb*ct, Rb*st, 0), vt_(Rt*ct, Rt*st, H);
         vb[s] = vb_; vt[s] = vt_;
         if (smooth)
@@ -54,12 +48,10 @@ Geometry::Mesh Geometry::meshColumn(float ratio_Rt_Rb, float numSides) {
     for(int s=0; s < slices; ++s) {
         int s1 = s, s2 = (s+1) % slices;
 
-//        vs.addTriangle(vb.at(s1), Vector3D(0,0,-H/2), vb.at(s2));     // bottom (PREVIOUSLY)
         vs.addTriangle(vb.at(s1), Vector3D(0,0,0), vb.at(s2));          // bottom
         if (smooth)
             ns.addVertex(-Vector3D::_z, 3);
 
-//        vs.addTriangle(Vector3D(0,0,+H/2), vt.at(s1), vt.at(s2));     // top (PREVIOUSLY)
         vs.addTriangle(Vector3D(0,0,H), vt.at(s1), vt.at(s2));          // top
         if (smooth)
             ns.addVertex(+Vector3D::_z, 3);

--- a/GUI/ba3d/ba3d/model/geometry/column.cpp
+++ b/GUI/ba3d/ba3d/model/geometry/column.cpp
@@ -39,7 +39,8 @@ Geometry::Mesh Geometry::meshColumn(float ratio_Rt_Rb, float numSides) {
         Later when the particle is created based upon this shape and scaled to proper dimensions,
         the offset is kept at H/2 to bring the base of the object to 0 in z (see particles.cpp) */
 
-        Vector3D vb_(Rb*ct, Rb*st, -H/2), vt_(Rt*ct, Rt*st, +H/2);
+//        Vector3D vb_(Rb*ct, Rb*st, -H/2), vt_(Rt*ct, Rt*st, +H/2); (PREVIOUSLY)
+        Vector3D vb_(Rb*ct, Rb*st, 0), vt_(Rt*ct, Rt*st, H);
         vb[s] = vb_; vt[s] = vt_;
         if (smooth)
             nbt[s] = Vector3D(vb_.x, vb_.y, nz).normalized();
@@ -53,15 +54,17 @@ Geometry::Mesh Geometry::meshColumn(float ratio_Rt_Rb, float numSides) {
     for(int s=0; s < slices; ++s) {
         int s1 = s, s2 = (s+1) % slices;
 
-        vs.addTriangle(vb.at(s1), Vector3D(0,0,-H/2), vb.at(s2));          // bottom
+//        vs.addTriangle(vb.at(s1), Vector3D(0,0,-H/2), vb.at(s2));     // bottom (PREVIOUSLY)
+        vs.addTriangle(vb.at(s1), Vector3D(0,0,0), vb.at(s2));          // bottom
         if (smooth)
             ns.addVertex(-Vector3D::_z, 3);
 
-        vs.addTriangle(Vector3D(0,0,+H/2), vt.at(s1), vt.at(s2));          // top
+//        vs.addTriangle(Vector3D(0,0,+H/2), vt.at(s1), vt.at(s2));     // top (PREVIOUSLY)
+        vs.addTriangle(Vector3D(0,0,H), vt.at(s1), vt.at(s2));          // top
         if (smooth)
             ns.addVertex(+Vector3D::_z, 3);
 
-        vs.addQuad(vb.at(s1), vb.at(s2), vt.at(s2), vt.at(s1)); // side
+        vs.addQuad(vb.at(s1), vb.at(s2), vt.at(s2), vt.at(s1));         // side
         if (smooth) {
             auto &n1 = nbt.at(s1), &n2 = nbt.at(s2);
             ns.addQuad(n1, n2, n2, n1);

--- a/GUI/ba3d/ba3d/model/geometry/column.cpp
+++ b/GUI/ba3d/ba3d/model/geometry/column.cpp
@@ -15,48 +15,54 @@
 #include "../geometry.h"
 #include <qmath.h>
 
-namespace RealSpace {
+namespace RealSpace
+{
 
-Geometry::Mesh Geometry::meshColumn(float ratio_Rt_Rb, float numSides) {
-    int  const sides  = qRound(numSides);
+Geometry::Mesh Geometry::meshColumn(float ratio_Rt_Rb, float numSides)
+{
+    int const sides = qRound(numSides);
     bool const smooth = (0 == sides); // sides = 0 implies smooth -> e.g. cylinder
-    int  const slices = smooth ? SLICES : sides;
+    int const slices = smooth ? SLICES : sides;
 
     // Rt is the top radius, Rb is the bottom radius, H is the height
     // Values are chosen such that diameter and height are 1
     float const R = .5f;
-    float Rb = R, Rt = Rb*ratio_Rt_Rb, H = 2*R;
+    float Rb = R, Rt = Rb * ratio_Rt_Rb, H = 2 * R;
 
     // mesh of vertices (bottom and top) and normals (bottom to top)
     Vertices vb(slices), vt(slices), nbt(slices);
-    float const nz = (1 - Rt/Rb)*H;
+    float const nz = (1 - Rt / Rb) * H;
 
-    for(int s=0; s < slices; ++s) {
-        float th = float(2*M_PI*s/slices), st = sinf(th), ct = cosf(th);
+    for (int s = 0; s < slices; ++s) {
+        float th = float(2 * M_PI * s / slices), st = sinf(th), ct = cosf(th);
 
-        Vector3D vb_(Rb*ct, Rb*st, 0), vt_(Rt*ct, Rt*st, H);
-        vb[s] = vb_; vt[s] = vt_;
+        Vector3D vb_(Rb * ct, Rb * st, 0), vt_(Rt * ct, Rt * st, H);
+        vb[s] = vb_;
+        vt[s] = vt_;
         if (smooth)
             nbt[s] = Vector3D(vb_.x, vb_.y, nz).normalized();
     }
 
     // make into triangles
-    int const nv = 6*2*slices;
-    Vertices vs; vs.reserve(nv);
-    Vertices ns; if (smooth) ns.reserve(nv);
+    int const nv = 6 * 2 * slices;
+    Vertices vs;
+    vs.reserve(nv);
+    Vertices ns;
+    if (smooth)
+        ns.reserve(nv);
 
-    for(int s=0; s < slices; ++s) {
-        int s1 = s, s2 = (s+1) % slices;
+    for (int s = 0; s < slices; ++s) {
+        int s1 = s, s2 = (s + 1) % slices;
 
-        vs.addTriangle(vb.at(s1), Vector3D(0,0,0), vb.at(s2));          // bottom
+        vs.addTriangle(vb.at(s1), Vector3D(0, 0, 0), vb.at(s2)); // bottom
         if (smooth)
             ns.addVertex(-Vector3D::_z, 3);
 
-        vs.addTriangle(Vector3D(0,0,H), vt.at(s1), vt.at(s2));          // top
+        vs.addTriangle(Vector3D(0, 0, H), vt.at(s1), vt.at(s2)); // top
         if (smooth)
             ns.addVertex(+Vector3D::_z, 3);
 
-        vs.addQuad(vb.at(s1), vb.at(s2), vt.at(s2), vt.at(s1));         // side
+        vs.addQuad(vb.at(s1), vb.at(s2), vt.at(s2), vt.at(s1)); // side
         if (smooth) {
             auto &n1 = nbt.at(s1), &n2 = nbt.at(s2);
             ns.addQuad(n1, n2, n2, n1);
@@ -69,4 +75,4 @@ Geometry::Mesh Geometry::meshColumn(float ratio_Rt_Rb, float numSides) {
     return makeMesh(vs, smooth ? &ns : nullptr);
 }
 
-}  // namespace RealSpace
+} // namespace RealSpace

--- a/GUI/ba3d/ba3d/model/geometry/cuboctahedron.cpp
+++ b/GUI/ba3d/ba3d/model/geometry/cuboctahedron.cpp
@@ -17,20 +17,25 @@
 
 namespace RealSpace {
 
-Geometry::Mesh Geometry::meshCuboctahedron(float rH, float beta) { // t/D
+Geometry::Mesh Geometry::meshCuboctahedron(float rH, float alpha, float H) { // t/D
 
-    // beta is the angle between the absolute bottom of the shape (NOT the common square interface)
-    // and a side face. In terms of alpha (angle with common square interface), beta = (PI-alpha)
+    // alpha is the angle between the common square interface and one of the side faces (alpha for
+    // both the two truncated pyramids is the same)
 
-    Q_ASSERT(beta >= float(M_PI_2));
+    // H here is the normalized height of the cuboctahedron i.e. H/L (see particles.cpp)
+
+    Q_ASSERT(alpha <= float(M_PI_2));
     Q_ASSERT(rH >= 0);
 
-    float const D = .5f, H = 2*D / (rH + 1), t = tanf(beta - float(M_PI_2));
-    float const Db = D - t*H, Dt = D - t*(2*D - H);
+//    float const D = .5f, H = 2*D / (rH + 1), t = tanf(float(M_PI_2)-alpha);
+//    float const Db = D - t*H, Dt = D - t*(2*D - H);
+
+    float const D = .5f, t = tanf(float(M_PI_2)-alpha);
+    float const Db = D - t*H, Dt = D - t*rH*H;
 
     Vertices vs_; vs_.reserve(12);
 //    float z[] = {-D, H-D, +D}, d[] = {Db, D, Dt}; // (PREVIOUSLY)
-    float z[] = {0, H, +2*D}, d[] = {Db, D, Dt}; // keep bottom of the cuboctahedron in z=0 plane
+    float z[] = {0, H, H*(rH+1)}, d[] = {Db, D, Dt}; // keep bottom of the cuboctahedron in z=0 plane
     for(int i=0; i<3; ++i)
         for (int x : {-1, +1})
             for (int y : {-1, +1}) {

--- a/GUI/ba3d/ba3d/model/geometry/cuboctahedron.cpp
+++ b/GUI/ba3d/ba3d/model/geometry/cuboctahedron.cpp
@@ -27,14 +27,10 @@ Geometry::Mesh Geometry::meshCuboctahedron(float rH, float alpha, float H) { // 
     Q_ASSERT(alpha <= float(M_PI_2));
     Q_ASSERT(rH >= 0);
 
-//    float const D = .5f, H = 2*D / (rH + 1), t = tanf(float(M_PI_2)-alpha);
-//    float const Db = D - t*H, Dt = D - t*(2*D - H);
-
     float const D = .5f, t = tanf(float(M_PI_2)-alpha);
     float const Db = D - t*H, Dt = D - t*rH*H;
 
     Vertices vs_; vs_.reserve(12);
-//    float z[] = {-D, H-D, +D}, d[] = {Db, D, Dt}; // (PREVIOUSLY)
     float z[] = {0, H, H*(rH+1)}, d[] = {Db, D, Dt}; // keep bottom of the cuboctahedron in z=0 plane
     for(int i=0; i<3; ++i)
         for (int x : {-1, +1})

--- a/GUI/ba3d/ba3d/model/geometry/cuboctahedron.cpp
+++ b/GUI/ba3d/ba3d/model/geometry/cuboctahedron.cpp
@@ -15,9 +15,11 @@
 #include "../geometry.h"
 #include <qmath.h>
 
-namespace RealSpace {
+namespace RealSpace
+{
 
-Geometry::Mesh Geometry::meshCuboctahedron(float rH, float alpha, float H) { // t/D
+Geometry::Mesh Geometry::meshCuboctahedron(float rH, float alpha, float H)
+{ // t/D
 
     // alpha is the angle between the common square interface and one of the side faces (alpha for
     // both the two truncated pyramids is the same)
@@ -27,36 +29,39 @@ Geometry::Mesh Geometry::meshCuboctahedron(float rH, float alpha, float H) { // 
     Q_ASSERT(alpha <= float(M_PI_2));
     Q_ASSERT(rH >= 0);
 
-    float const D = .5f, t = tanf(float(M_PI_2)-alpha);
-    float const Db = D - t*H, Dt = D - t*rH*H;
+    float const D = .5f, t = tanf(float(M_PI_2) - alpha);
+    float const Db = D - t * H, Dt = D - t * rH * H;
 
-    Vertices vs_; vs_.reserve(12);
-    float z[] = {0, H, H*(rH+1)}, d[] = {Db, D, Dt}; // keep bottom of the cuboctahedron in z=0 plane
-    for(int i=0; i<3; ++i)
+    Vertices vs_;
+    vs_.reserve(12);
+    float z[] = {0, H, H * (rH + 1)},
+          d[] = {Db, D, Dt}; // keep bottom of the cuboctahedron in z=0 plane
+    for (int i = 0; i < 3; ++i)
         for (int x : {-1, +1})
             for (int y : {-1, +1}) {
                 float di = d[i];
-                vs_.append(Vector3D(x*di, y*di, z[i]));
+                vs_.append(Vector3D(x * di, y * di, z[i]));
             }
 
     Q_ASSERT(12 == vs_.count());
 
-    Vertices vs; vs.reserve(60);
+    Vertices vs;
+    vs.reserve(60);
 
-    vs.addQuad(vs_, 0,  1,  3, 2);
+    vs.addQuad(vs_, 0, 1, 3, 2);
     vs.addQuad(vs_, 8, 10, 11, 9);
-    vs.addQuad(vs_, 0,  4,  5, 1);
-    vs.addQuad(vs_, 1,  5,  7, 3);
-    vs.addQuad(vs_, 3,  7,  6, 2);
-    vs.addQuad(vs_, 2,  6,  4, 0);
-    vs.addQuad(vs_, 4,  8,  9, 5);
-    vs.addQuad(vs_, 5,  9, 11, 7);
+    vs.addQuad(vs_, 0, 4, 5, 1);
+    vs.addQuad(vs_, 1, 5, 7, 3);
+    vs.addQuad(vs_, 3, 7, 6, 2);
+    vs.addQuad(vs_, 2, 6, 4, 0);
+    vs.addQuad(vs_, 4, 8, 9, 5);
+    vs.addQuad(vs_, 5, 9, 11, 7);
     vs.addQuad(vs_, 7, 11, 10, 6);
-    vs.addQuad(vs_, 6, 10,  8, 4);
+    vs.addQuad(vs_, 6, 10, 8, 4);
 
     Q_ASSERT(60 == vs.count());
 
     return makeMesh(vs);
 }
 
-}  // namespace RealSpace
+} // namespace RealSpace

--- a/GUI/ba3d/ba3d/model/geometry/cuboctahedron.cpp
+++ b/GUI/ba3d/ba3d/model/geometry/cuboctahedron.cpp
@@ -19,8 +19,8 @@ namespace RealSpace {
 
 Geometry::Mesh Geometry::meshCuboctahedron(float rH, float beta) { // t/D
 
-    // beta is the angle between the absolute base of the shape (NOT the common square base)
-    // and a side face. In terms of alpha (angle with common square base), it is (PI-alpha) radians
+    // beta is the angle between the absolute bottom of the shape (NOT the common square interface)
+    // and a side face. In terms of alpha (angle with common square interface), beta = (PI-alpha)
 
     Q_ASSERT(beta >= float(M_PI_2));
     Q_ASSERT(rH >= 0);
@@ -29,7 +29,8 @@ Geometry::Mesh Geometry::meshCuboctahedron(float rH, float beta) { // t/D
     float const Db = D - t*H, Dt = D - t*(2*D - H);
 
     Vertices vs_; vs_.reserve(12);
-    float z[] = {-D, H-D, +D}, d[] = {Db, D, Dt};
+//    float z[] = {-D, H-D, +D}, d[] = {Db, D, Dt}; // (PREVIOUSLY)
+    float z[] = {0, H, +2*D}, d[] = {Db, D, Dt}; // keep bottom of the cuboctahedron in z=0 plane
     for(int i=0; i<3; ++i)
         for (int x : {-1, +1})
             for (int y : {-1, +1}) {

--- a/GUI/ba3d/ba3d/model/geometry/dodecahedron.cpp
+++ b/GUI/ba3d/ba3d/model/geometry/dodecahedron.cpp
@@ -13,20 +13,22 @@
 // ************************************************************************** //
 
 #include "../geometry.h"
-#include <qmath.h>
 #include <QQuaternion>
+#include <qmath.h>
 
-namespace RealSpace {
+namespace RealSpace
+{
 
-Geometry::Mesh Geometry::meshDodecahedron() {
-    const float GR  = GoldenRatio,
-            G1 = 1/GR;
+Geometry::Mesh Geometry::meshDodecahedron()
+{
+    const float GR = GoldenRatio, G1 = 1 / GR;
 
-    Vertices vs_; vs_.reserve(20);
+    Vertices vs_;
+    vs_.reserve(20);
     for (float x : {-1, +1})
         for (float y : {-1, +1})
             for (float z : {-1, +1})
-                vs_.append(Vector3D(x,y,z));
+                vs_.append(Vector3D(x, y, z));
 
     for (float g1 : {-G1, +G1})
         for (float g : {-GR, +GR}) {
@@ -40,39 +42,40 @@ Geometry::Mesh Geometry::meshDodecahedron() {
     // scale to circumscribed sphere
     float const F = .5f / vs_.at(0).length();
     for (auto& v : vs_)
-        v = v*F;
+        v = v * F;
 
-    //face down
+    // face down
     auto q = QQuaternion::rotationTo(-Vector3D::_z,
-                                     cross(vs_.at(8)-vs_.at(0), vs_.at(10)-vs_.at(0)));
-    for(int i=0; i<20; ++i) {
+                                     cross(vs_.at(8) - vs_.at(0), vs_.at(10) - vs_.at(0)));
+    for (int i = 0; i < 20; ++i) {
         vs_[i] = q.rotatedVector(vs_.at(i));
-        vs_[i].z += 0.5f*std::sqrt(G1); // shift the bottom of the dodecahedron to z=0 plane
+        vs_[i].z += 0.5f * std::sqrt(G1); // shift the bottom of the dodecahedron to z=0 plane
     }
 
-    Vertices vs; vs.reserve(180);
+    Vertices vs;
+    vs.reserve(180);
 
     auto add5 = [&](unsigned i1, unsigned i2, unsigned i3, unsigned i4, unsigned i5) {
         vs.addFan(vs_, {i1, i2, i3, i4, i5, i1});
     };
 
-    add5( 1, 11, 17,  3, 16); // bottom
-    add5( 1, 16, 10,  0, 9 );
-    add5(16,  3, 12,  2, 10);
-    add5( 3, 17,  7, 18, 12);
-    add5(17, 11,  5, 19,  7);
-    add5(11,  1,  9, 15,  5);
+    add5(1, 11, 17, 3, 16); // bottom
+    add5(1, 16, 10, 0, 9);
+    add5(16, 3, 12, 2, 10);
+    add5(3, 17, 7, 18, 12);
+    add5(17, 11, 5, 19, 7);
+    add5(11, 1, 9, 15, 5);
 
-    add5( 8,  4, 15,  9,  0);
-    add5(14,  8,  0, 10,  2);
-    add5( 6, 14,  2, 12, 18);
-    add5(13,  6, 18,  7, 19);
-    add5( 4, 13, 19,  5, 15);
-    add5( 4,  8, 14,  6, 13);  // top
+    add5(8, 4, 15, 9, 0);
+    add5(14, 8, 0, 10, 2);
+    add5(6, 14, 2, 12, 18);
+    add5(13, 6, 18, 7, 19);
+    add5(4, 13, 19, 5, 15);
+    add5(4, 8, 14, 6, 13); // top
 
     Q_ASSERT(144 == vs.count());
 
     return makeMesh(vs);
 }
 
-}  // namespace RealSpace
+} // namespace RealSpace

--- a/GUI/ba3d/ba3d/model/geometry/dodecahedron.cpp
+++ b/GUI/ba3d/ba3d/model/geometry/dodecahedron.cpp
@@ -45,8 +45,10 @@ Geometry::Mesh Geometry::meshDodecahedron() {
     //face down
     auto q = QQuaternion::rotationTo(-Vector3D::_z,
                                      cross(vs_.at(8)-vs_.at(0), vs_.at(10)-vs_.at(0)));
-    for(int i=0; i<20; ++i)
+    for(int i=0; i<20; ++i) {
         vs_[i] = q.rotatedVector(vs_.at(i));
+        vs_[i].z += 0.5f*std::sqrt(G1); // shift the bottom of the dodecahedron to z=0 plane
+    }
 
     Vertices vs; vs.reserve(180);
 

--- a/GUI/ba3d/ba3d/model/geometry/icosahedron.cpp
+++ b/GUI/ba3d/ba3d/model/geometry/icosahedron.cpp
@@ -13,17 +13,20 @@
 // ************************************************************************** //
 
 #include "../geometry.h"
-#include <qmath.h>
 #include <QQuaternion>
+#include <qmath.h>
 
-namespace RealSpace {
+namespace RealSpace
+{
 
-Geometry::Mesh Geometry::meshIcosahedron() {
+Geometry::Mesh Geometry::meshIcosahedron()
+{
     const float GR = GoldenRatio;
 
-    auto q = QQuaternion::rotationTo(-Vector3D::_z, Vector3D(0,1,-GR));
+    auto q = QQuaternion::rotationTo(-Vector3D::_z, Vector3D(0, 1, -GR));
 
-    Vertices vs_; vs_.reserve(12);
+    Vertices vs_;
+    vs_.reserve(12);
     for (float _1 : {-1, +1})
         for (float g : {-GR, +GR}) {
             vs_.append(q.rotatedVector(Vector3D(0, _1, g)));
@@ -36,11 +39,12 @@ Geometry::Mesh Geometry::meshIcosahedron() {
     // scale to circumscribed sphere
     float const F = .5f / vs_.at(0).length();
     for (auto& v : vs_) {
-        v = v*F;
+        v = v * F;
         v.z += 0.5; // shift the bottom of the icosahedron to z=0 plane
     }
 
-    Vertices vs; vs.reserve(60);
+    Vertices vs;
+    vs.reserve(60);
 
     vs.addFan(vs_, {0, 1, 2, 6, 5, 7, 1});
     vs.addFan(vs_, {9, 3, 11, 10, 4, 8, 3});
@@ -51,4 +55,4 @@ Geometry::Mesh Geometry::meshIcosahedron() {
     return makeMesh(vs);
 }
 
-}  // namespace RealSpace
+} // namespace RealSpace

--- a/GUI/ba3d/ba3d/model/geometry/icosahedron.cpp
+++ b/GUI/ba3d/ba3d/model/geometry/icosahedron.cpp
@@ -35,8 +35,10 @@ Geometry::Mesh Geometry::meshIcosahedron() {
 
     // scale to circumscribed sphere
     float const F = .5f / vs_.at(0).length();
-    for (auto& v : vs_)
+    for (auto& v : vs_) {
         v = v*F;
+        v.z += 0.5; // shift the bottom of the icosahedron to z=0 plane
+    }
 
     Vertices vs; vs.reserve(60);
 

--- a/GUI/ba3d/ba3d/model/geometry/sphere.cpp
+++ b/GUI/ba3d/ba3d/model/geometry/sphere.cpp
@@ -18,7 +18,7 @@
 namespace RealSpace {
 
 // cut: 0..1 - how much is cut off off the bottom
-Geometry::Mesh Geometry::meshSphere(float cut) {
+Geometry::Mesh Geometry::meshSphere(float cut, float baseShift) {
     if (1 <= cut)
         return Mesh();
     cut = qMax(0.f, cut);
@@ -57,6 +57,8 @@ Geometry::Mesh Geometry::meshSphere(float cut) {
         for(int s=0; s < slices; ++s) {
             float th = float(2*M_PI*s/slices);
             Vector3D v(R*cp*cosf(th), R*cp*sinf(th), R*sp);
+            v.z += baseShift; // baseShift is used for shifting the bottom of the spherical shape
+                              // to z=0 plane
             vs_[r][s] = v;
             ns_[r][s] = v.normalized();
         }
@@ -82,7 +84,8 @@ Geometry::Mesh Geometry::meshSphere(float cut) {
                     vp = Vector3D(0, 0, v0.z);
                     n0 = n1 = np;
                 } else {
-                    vp = Vector3D(0,0,-R);
+                    //vp = Vector3D(0,0,-R); // (PREVIOUSLY)
+                    vp = Vector3D(0,0,-R+baseShift);
                     n0 = nr.at(s0); n1 = nr.at(s1);
                 }
                 vs.addTriangle(v0, vp, v1);
@@ -90,7 +93,8 @@ Geometry::Mesh Geometry::meshSphere(float cut) {
             }
 
             if (r+1 == rings) {  // north pole
-                Vector3D vp(0, 0, +R), np(Vector3D::_z);
+//                Vector3D vp(0, 0, +R), np(Vector3D::_z); // (PREVIOUSLY)
+                Vector3D vp(0, 0, +R+baseShift), np(Vector3D::_z);
                 vs.addTriangle(v0, v1, vp);
                 ns.addTriangle(n0, n1, np);
             } else if (1 < rings) { // in between poles

--- a/GUI/ba3d/ba3d/model/geometry/sphere.cpp
+++ b/GUI/ba3d/ba3d/model/geometry/sphere.cpp
@@ -84,7 +84,6 @@ Geometry::Mesh Geometry::meshSphere(float cut, float baseShift) {
                     vp = Vector3D(0, 0, v0.z);
                     n0 = n1 = np;
                 } else {
-                    //vp = Vector3D(0,0,-R); // (PREVIOUSLY)
                     vp = Vector3D(0,0,-R+baseShift);
                     n0 = nr.at(s0); n1 = nr.at(s1);
                 }
@@ -93,7 +92,6 @@ Geometry::Mesh Geometry::meshSphere(float cut, float baseShift) {
             }
 
             if (r+1 == rings) {  // north pole
-//                Vector3D vp(0, 0, +R), np(Vector3D::_z); // (PREVIOUSLY)
                 Vector3D vp(0, 0, +R+baseShift), np(Vector3D::_z);
                 vs.addTriangle(v0, v1, vp);
                 ns.addTriangle(n0, n1, np);

--- a/GUI/ba3d/ba3d/model/geometry/sphere.cpp
+++ b/GUI/ba3d/ba3d/model/geometry/sphere.cpp
@@ -15,10 +15,12 @@
 #include "../geometry.h"
 #include <qmath.h>
 
-namespace RealSpace {
+namespace RealSpace
+{
 
 // cut: 0..1 - how much is cut off off the bottom
-Geometry::Mesh Geometry::meshSphere(float cut, float baseShift) {
+Geometry::Mesh Geometry::meshSphere(float cut, float baseShift)
+{
     if (1 <= cut)
         return Mesh();
     cut = qMax(0.f, cut);
@@ -29,7 +31,7 @@ Geometry::Mesh Geometry::meshSphere(float cut, float baseShift) {
     float minPh, phRge;
 
     if (cut > 0) {
-        minPh = asinf(2*cut - 1);
+        minPh = asinf(2 * cut - 1);
         phRge = float(M_PI_2) - minPh;
         rings = qMax(1, qCeil(qreal(RINGS * phRge) / M_PI));
     } else {
@@ -43,20 +45,20 @@ Geometry::Mesh Geometry::meshSphere(float cut, float baseShift) {
 
     // meshes of vertices and normals, without poles, _[ring][slice]
     QVector<Vertices> vs_(rings), ns_(rings);
-    for (auto& ring: vs_)
+    for (auto& ring : vs_)
         ring.resize(slices);
-    for (auto& ring: ns_)
+    for (auto& ring : ns_)
         ring.resize(slices);
 
     float const R = .5f;
 
-    for(int r=0; r < rings; ++r) {
-        float ph = minPh + phRge * r/rings;
+    for (int r = 0; r < rings; ++r) {
+        float ph = minPh + phRge * r / rings;
         float cp = cosf(ph), sp = sinf(ph);
 
-        for(int s=0; s < slices; ++s) {
-            float th = float(2*M_PI*s/slices);
-            Vector3D v(R*cp*cosf(th), R*cp*sinf(th), R*sp);
+        for (int s = 0; s < slices; ++s) {
+            float th = float(2 * M_PI * s / slices);
+            Vector3D v(R * cp * cosf(th), R * cp * sinf(th), R * sp);
             v.z += baseShift; // baseShift is used for shifting the bottom of the spherical shape
                               // to z=0 plane
             vs_[r][s] = v;
@@ -65,15 +67,17 @@ Geometry::Mesh Geometry::meshSphere(float cut, float baseShift) {
     }
 
     // make into triangles
-    int const nv = 6*(rings)*slices;
-    Vertices vs; vs.reserve(nv);
-    Vertices ns; ns.reserve(nv);
+    int const nv = 6 * (rings)*slices;
+    Vertices vs;
+    vs.reserve(nv);
+    Vertices ns;
+    ns.reserve(nv);
 
-    for(int r=0; r < rings; ++r) {
+    for (int r = 0; r < rings; ++r) {
         auto &vr = vs_.at(r), &nr = ns_.at(r);
 
-        for(int s=0; s < slices; ++s) {
-            int s0 = s, s1 = (s+1) % slices;
+        for (int s = 0; s < slices; ++s) {
+            int s0 = s, s1 = (s + 1) % slices;
 
             auto &v0 = vr.at(s0), &v1 = vr.at(s1);
             auto &n0 = nr.at(s0), &n1 = nr.at(s1);
@@ -84,19 +88,20 @@ Geometry::Mesh Geometry::meshSphere(float cut, float baseShift) {
                     vp = Vector3D(0, 0, v0.z);
                     n0 = n1 = np;
                 } else {
-                    vp = Vector3D(0,0,-R+baseShift);
-                    n0 = nr.at(s0); n1 = nr.at(s1);
+                    vp = Vector3D(0, 0, -R + baseShift);
+                    n0 = nr.at(s0);
+                    n1 = nr.at(s1);
                 }
                 vs.addTriangle(v0, vp, v1);
                 ns.addTriangle(n0, np, n1);
             }
 
-            if (r+1 == rings) {  // north pole
-                Vector3D vp(0, 0, +R+baseShift), np(Vector3D::_z);
+            if (r + 1 == rings) { // north pole
+                Vector3D vp(0, 0, +R + baseShift), np(Vector3D::_z);
                 vs.addTriangle(v0, v1, vp);
                 ns.addTriangle(n0, n1, np);
             } else if (1 < rings) { // in between poles
-                auto &vr1 = vs_.at(r+1), &nr1 = ns_.at(r+1);
+                auto &vr1 = vs_.at(r + 1), &nr1 = ns_.at(r + 1);
                 auto &n2 = nr1.at(s1), &n3 = nr1.at(s0);
                 vs.addQuad(v0, v1, vr1.at(s1), vr1.at(s0));
                 ns.addQuad(n0, n1, n2, n3);
@@ -107,4 +112,4 @@ Geometry::Mesh Geometry::meshSphere(float cut, float baseShift) {
     return makeMesh(vs, ns);
 }
 
-}  // namespace RealSpace
+} // namespace RealSpace

--- a/GUI/ba3d/ba3d/model/geometry/truncbox.cpp
+++ b/GUI/ba3d/ba3d/model/geometry/truncbox.cpp
@@ -14,45 +14,49 @@
 
 #include "../geometry.h"
 
-namespace RealSpace {
+namespace RealSpace
+{
 
-Geometry::Mesh Geometry::meshTruncBox(float tD) { // t/D
+Geometry::Mesh Geometry::meshTruncBox(float tD)
+{ // t/D
     if (tD <= 0)
         return meshBox();
 
     float const D = .5f, t = D * (1 - qMin(tD, 1.f));
-    Vertices vs; vs.reserve(150);
+    Vertices vs;
+    vs.reserve(150);
 
     QVector<float> as({+D, +t, -t, -D, -D, -t, +t, +D});
     QVector<float> bs({+t, +D, +D, +t, -t, -D, -D, -t});
 
-    auto side = [&](int ax, int ay, int az, int bx, int by, int bz,
-                const Vector3D& d, bool rev) {
+    auto side = [&](int ax, int ay, int az, int bx, int by, int bz, const Vector3D& d, bool rev) {
         Vertices vs_(8);
-        for(int i=0; i<8; ++i)
-            vs_[rev ? 7-i : i] =
-                    Vector3D(ax*as.at(i) + bx*bs.at(i),
-                             ay*as.at(i) + by*bs.at(i),
-                             az*as.at(i) + bz*bs.at(i)) + d;
-        vs.addFan(vs_, {0,1,2,3,4,5,6,7,0});
+        for (int i = 0; i < 8; ++i)
+            vs_[rev ? 7 - i : i]
+                = Vector3D(ax * as.at(i) + bx * bs.at(i), ay * as.at(i) + by * bs.at(i),
+                           az * as.at(i) + bz * bs.at(i))
+                  + d;
+        vs.addFan(vs_, {0, 1, 2, 3, 4, 5, 6, 7, 0});
     };
 
     // +0.5f is required to shift the bottom of the Truncated Box to the z=0 plane
 
     auto corner = [&](int x, int y, int z) {
-        Vertices vs_({{D*x,D*y,t*z+0.5f},{D*x,t*y,D*z+0.5f},{t*x,D*y,D*z+0.5f}});
-        if (x*y*z > 0)
+        Vertices vs_({{D * x, D * y, t * z + 0.5f},
+                      {D * x, t * y, D * z + 0.5f},
+                      {t * x, D * y, D * z + 0.5f}});
+        if (x * y * z > 0)
             vs.addTriangle(vs_.at(0), vs_.at(2), vs_.at(1));
         else
             vs.addTriangle(vs_.at(0), vs_.at(1), vs_.at(2));
     };
 
-    side(0,1,0, 0,0,1, Vector3D(+D,0,+0.5f), false);
-    side(0,1,0, 0,0,1, Vector3D(-D,0,+0.5f), true);
-    side(1,0,0, 0,0,1, Vector3D(0,+D,+0.5f), true);
-    side(1,0,0, 0,0,1, Vector3D(0,-D,+0.5f), false);
-    side(1,0,0, 0,1,0, Vector3D(0,0,+D+0.5f), false);
-    side(1,0,0, 0,1,0, Vector3D(0,0,-D+0.5f), true);
+    side(0, 1, 0, 0, 0, 1, Vector3D(+D, 0, +0.5f), false);
+    side(0, 1, 0, 0, 0, 1, Vector3D(-D, 0, +0.5f), true);
+    side(1, 0, 0, 0, 0, 1, Vector3D(0, +D, +0.5f), true);
+    side(1, 0, 0, 0, 0, 1, Vector3D(0, -D, +0.5f), false);
+    side(1, 0, 0, 0, 1, 0, Vector3D(0, 0, +D + 0.5f), false);
+    side(1, 0, 0, 0, 1, 0, Vector3D(0, 0, -D + 0.5f), true);
 
     for (int x : {-1, +1})
         for (int y : {-1, +1})
@@ -64,4 +68,4 @@ Geometry::Mesh Geometry::meshTruncBox(float tD) { // t/D
     return makeMesh(vs);
 }
 
-}  // namespace RealSpace
+} // namespace RealSpace

--- a/GUI/ba3d/ba3d/model/geometry/truncbox.cpp
+++ b/GUI/ba3d/ba3d/model/geometry/truncbox.cpp
@@ -37,20 +37,22 @@ Geometry::Mesh Geometry::meshTruncBox(float tD) { // t/D
         vs.addFan(vs_, {0,1,2,3,4,5,6,7,0});
     };
 
+    // +0.5f is required to shift the bottom of the Truncated Box to the z=0 plane
+
     auto corner = [&](int x, int y, int z) {
-        Vertices vs_({{D*x,D*y,t*z},{D*x,t*y,D*z},{t*x,D*y,D*z}});
+        Vertices vs_({{D*x,D*y,t*z+0.5f},{D*x,t*y,D*z+0.5f},{t*x,D*y,D*z+0.5f}});
         if (x*y*z > 0)
             vs.addTriangle(vs_.at(0), vs_.at(2), vs_.at(1));
         else
             vs.addTriangle(vs_.at(0), vs_.at(1), vs_.at(2));
     };
 
-    side(0,1,0, 0,0,1, Vector3D(+D,0,0), false);
-    side(0,1,0, 0,0,1, Vector3D(-D,0,0), true);
-    side(1,0,0, 0,0,1, Vector3D(0,+D,0), true);
-    side(1,0,0, 0,0,1, Vector3D(0,-D,0), false);
-    side(1,0,0, 0,1,0, Vector3D(0,0,+D), false);
-    side(1,0,0, 0,1,0, Vector3D(0,0,-D), true);
+    side(0,1,0, 0,0,1, Vector3D(+D,0,+0.5f), false);
+    side(0,1,0, 0,0,1, Vector3D(-D,0,+0.5f), true);
+    side(1,0,0, 0,0,1, Vector3D(0,+D,+0.5f), true);
+    side(1,0,0, 0,0,1, Vector3D(0,-D,+0.5f), false);
+    side(1,0,0, 0,1,0, Vector3D(0,0,+D+0.5f), false);
+    side(1,0,0, 0,1,0, Vector3D(0,0,-D+0.5f), true);
 
     for (int x : {-1, +1})
         for (int y : {-1, +1})

--- a/GUI/ba3d/ba3d/model/geometry_inc.cpp
+++ b/GUI/ba3d/ba3d/model/geometry_inc.cpp
@@ -24,8 +24,8 @@ const float IcosahedronL2R  = 4.f / (10.f + 2.f*std::sqrt(5.f));
 const float DodecahedronL2R = 4.f / std::sqrt(3.f) / (1.f+std::sqrt(5.f));
 
 // Keys and hash:
-GeometricID::Key::Key(BaseShape id_, float p1_, float p2_)
-    : id(id_), p1(p1_), p2(p2_) {
+GeometricID::Key::Key(BaseShape id_, float p1_, float p2_, float p3_)
+    : id(id_), p1(p1_), p2(p2_), p3(p3_)  {
 }
 
 bool GeometricID::Key::operator==(Key const& other) const {
@@ -38,7 +38,8 @@ std::size_t GeometricID::KeyHash::operator()(const GeometricID::Key& key) const 
         size_t h1 = std::hash<int>{}(static_cast<int>(key.id));
         size_t h2 = std::hash<float>{}(key.p1);
         size_t h3 = std::hash<float>{}(key.p2);
-        return h1 ^ (h2 ^ h3);
+        size_t h4 = std::hash<float>{}(key.p3);
+        return h1 ^ (h2 ^ (h3 ^ h4));
     }
 }
 }  // namespace RealSpace

--- a/GUI/ba3d/ba3d/model/geometry_inc.cpp
+++ b/GUI/ba3d/ba3d/model/geometry_inc.cpp
@@ -16,19 +16,22 @@
 #include <cmath>
 #include <functional>
 
-namespace RealSpace {
+namespace RealSpace
+{
 
 // Useful constants:
-const float GoldenRatio     = (1.f + std::sqrt(5.f)) / 2.f;
-const float IcosahedronL2R  = 4.f / (10.f + 2.f*std::sqrt(5.f));
-const float DodecahedronL2R = 4.f / std::sqrt(3.f) / (1.f+std::sqrt(5.f));
+const float GoldenRatio = (1.f + std::sqrt(5.f)) / 2.f;
+const float IcosahedronL2R = 4.f / (10.f + 2.f * std::sqrt(5.f));
+const float DodecahedronL2R = 4.f / std::sqrt(3.f) / (1.f + std::sqrt(5.f));
 
 // Keys and hash:
 GeometricID::Key::Key(BaseShape id_, float p1_, float p2_, float p3_)
-    : id(id_), p1(p1_), p2(p2_), p3(p3_)  {
+    : id(id_), p1(p1_), p2(p2_), p3(p3_)
+{
 }
 
-bool GeometricID::Key::operator==(Key const& other) const {
+bool GeometricID::Key::operator==(Key const& other) const
+{
     return id == other.id && p1 == other.p1 && p2 == other.p2;
 }
 
@@ -42,4 +45,4 @@ std::size_t GeometricID::KeyHash::operator()(const GeometricID::Key& key) const 
         return h1 ^ (h2 ^ (h3 ^ h4));
     }
 }
-}  // namespace RealSpace
+} // namespace RealSpace

--- a/GUI/ba3d/ba3d/model/geometry_inc.h
+++ b/GUI/ba3d/ba3d/model/geometry_inc.h
@@ -43,12 +43,12 @@ enum class BaseShape { Plane, Box, Sphere, Column,
 
 // Real shapes will be parameterized by BaseShape enum and possibly two floats
 struct Key {
-    Key(BaseShape, float=0.0f, float=0.0f);
+    Key(BaseShape, float=0.0f, float=0.0f, float=0.0f);
 
     bool operator==(Key const&) const;
 
     BaseShape id;
-    float p1, p2;
+    float p1, p2, p3;
 };
 
 // Hash functor for Key objects

--- a/GUI/ba3d/ba3d/model/geometry_inc.h
+++ b/GUI/ba3d/ba3d/model/geometry_inc.h
@@ -20,30 +20,38 @@
 
 // include to use geometry basics, without details
 
-namespace RealSpace {
+namespace RealSpace
+{
 //------------------------------------------------------------------------------
 
 class Geometry;
 
 typedef std::shared_ptr<Geometry> GeometryHandle;
-typedef std::weak_ptr<Geometry>   GeometryRef;
+typedef std::weak_ptr<Geometry> GeometryRef;
 
 // some useful constants:
 extern const float GoldenRatio;
-extern const float IcosahedronL2R;  // L/R conversion
+extern const float IcosahedronL2R; // L/R conversion
 extern const float DodecahedronL2R;
 
-namespace GeometricID {
+namespace GeometricID
+{
 
 // Enum id for basic shapes
-enum class BaseShape { Plane, Box, Sphere, Column,
-                 Icosahedron, Dodecahedron, TruncatedBox,
-                 Cuboctahedron };
-
+enum class BaseShape {
+    Plane,
+    Box,
+    Sphere,
+    Column,
+    Icosahedron,
+    Dodecahedron,
+    TruncatedBox,
+    Cuboctahedron
+};
 
 // Real shapes will be parameterized by BaseShape enum and possibly two floats
 struct Key {
-    Key(BaseShape, float=0.0f, float=0.0f, float=0.0f);
+    Key(BaseShape, float = 0.0f, float = 0.0f, float = 0.0f);
 
     bool operator==(Key const&) const;
 
@@ -52,8 +60,7 @@ struct Key {
 };
 
 // Hash functor for Key objects
-struct KeyHash
-{
+struct KeyHash {
     std::size_t operator()(const Key& key) const noexcept;
 };
 

--- a/GUI/ba3d/ba3d/model/particles.cpp
+++ b/GUI/ba3d/ba3d/model/particles.cpp
@@ -86,7 +86,6 @@ AnisoPyramid::AnisoPyramid(float L, float W, float H, float alpha)
     isNull = (L <= 0 || W <= 0  || H <= 0 || alpha <= 0);
     turn = Vector3D(0,0,45*pi/180.0f);
     scale  = Vector3D(L*sqrt2f, W*sqrt2f, H);
-//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
     offset = Vector3D(0, 0, 0);
     set();
 }
@@ -97,7 +96,6 @@ Box::Box(float L, float W, float H)
     isNull = (L < 0 || W < 0 || H < 0) || (L <= 0 && W <= 0 && H <= 0);
     turn = Vector3D(0,0,45*pi/180.0f);
     scale  = Vector3D(L*sqrt2f, W*sqrt2f, H);
-//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
     offset = Vector3D(0, 0, 0);
     set();
 }
@@ -107,7 +105,6 @@ Cone::Cone(float R, float H, float alpha)
 {
     isNull = (R <= 0 || H <= 0 || alpha <= 0);
     scale  = Vector3D(R*2, R*2, H);
-//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
     offset = Vector3D(0, 0, 0);
     set();
 }
@@ -117,7 +114,6 @@ Cone6::Cone6(float R, float H, float alpha)
 {
     isNull = (R <= 0 || H <= 0 || alpha <= 0);
     scale  = Vector3D(R*2, R*2, H);
-//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
     offset = Vector3D(0, 0, 0);
     set();
 }
@@ -127,7 +123,6 @@ Cuboctahedron::Cuboctahedron(float L, float H, float rH, float alpha)
 {
     isNull = (L <= 0 || H <= 0 || rH <= 0 || alpha >= pi2f);
     scale  = Vector3D(L, L, L);
-    //offset = Vector3D(0, 0, L/2); // (PREVIOUSLY)
     offset = Vector3D(0, 0, 0);
     set();
 }
@@ -137,7 +132,6 @@ Cylinder::Cylinder(float R, float H)
 {
     isNull = (R <= 0 || H <= 0);
     scale  = Vector3D(R*2, R*2, H);
-//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
     offset = Vector3D(0, 0, 0);
     set();
 }
@@ -148,7 +142,6 @@ Dodecahedron::Dodecahedron(float L)
     isNull = (L <= 0);
     float R = L / DodecahedronL2R;
     scale  = Vector3D(R*2, R*2, R*2);
-//    offset = Vector3D(0, 0, R/std::sqrt(GoldenRatio)); // (PREVIOUSLY)
     offset = Vector3D(0, 0, 0);
     set();
 }
@@ -158,7 +151,6 @@ EllipsoidalCylinder::EllipsoidalCylinder(float Ra, float Rb, float H)
 {
     isNull = (Ra <= 0 || Rb <= 0 || H <= 0);
     scale  = Vector3D(Ra*2, Rb*2, H);
-//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
     offset = Vector3D(0, 0, 0);
     set();
 }
@@ -168,7 +160,6 @@ FullSphere::FullSphere(float R)
 {
     isNull = (R <= 0);
     scale  = Vector3D(R*2);
-//    offset = Vector3D(0, 0, R); // (PREVIOUSLY)
     offset = Vector3D(0, 0, 0);
     set();
 }
@@ -178,7 +169,6 @@ FullSpheroid::FullSpheroid(float R, float H)
 {
     isNull = (R <= 0 || H <= 0);
     scale  = Vector3D(R*2, R*2, H);
-//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
     offset = Vector3D(0, 0, 0);
     set();
 }
@@ -198,7 +188,6 @@ Icosahedron::Icosahedron(float L)
     isNull = (L <= 0);
     float R = L / IcosahedronL2R;
     scale  = Vector3D(R/GoldenRatio, R/GoldenRatio, R/GoldenRatio);
-//    offset = Vector3D(0, 0, R/(2*GoldenRatio)); // (PREVIOUSLY)
     offset = Vector3D(0, 0, 0);
     set();
 }
@@ -209,7 +198,6 @@ Prism3::Prism3(float L, float H)
     isNull = (L <= 0 || H <= 0);
     float D = L*2 / sqrt3f;
     scale = Vector3D(D*2, D*2, H);
-//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
     offset = Vector3D(0, 0, 0);
     set();
 }
@@ -219,7 +207,6 @@ Prism6::Prism6(float R, float H)
 {
     isNull = (R <= 0 || H <= 0);
     scale  = Vector3D(R*2, R*2, H);
-//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
     offset = Vector3D(0, 0, 0);
     set();
 }
@@ -231,7 +218,6 @@ Pyramid::Pyramid(float L, float H, float alpha)
     float L2 = L * sqrt2f;
     turn = Vector3D(0,0,45*pi/180.0f);
     scale  = Vector3D(L2, L2, H);
-//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
     offset = Vector3D(0, 0, 0);
     set();
 }
@@ -242,7 +228,6 @@ Tetrahedron::Tetrahedron(float L, float H, float alpha)
     isNull = (L <= 0 || H <= 0 || alpha <= 0);
     float D = L / sqrt3f;
     scale = Vector3D(D*2, D*2, H);
-//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
     offset = Vector3D(0, 0, 0);
     set();
 }
@@ -252,7 +237,6 @@ TruncatedCube::TruncatedCube(float L, float t)
 {
     isNull = (L <= 0);
     scale  = Vector3D(L,L,L);
-//    offset = Vector3D(0, 0, L/2); // (PREVIOUSLY)
     offset = Vector3D(0, 0, 0);
     set();
 }
@@ -262,7 +246,6 @@ TruncatedSphere::TruncatedSphere(float R, float H)
 {
     isNull = (R <= 0 || H <= 0);
     scale  = Vector3D(R*2);
-//    offset = Vector3D(0, 0, H-R); // (PREVIOUSLY)
     offset = Vector3D(0, 0, 0);
     set();
 }
@@ -272,7 +255,6 @@ TruncatedSpheroid::TruncatedSpheroid(float R, float H, float fp)
 {
     isNull = (R <= 0 || H <= 0 || fp <= 0);
     scale  = Vector3D(R*2, R*2, fp*R*2);
-//    offset = Vector3D(0, 0, H-fp*R); // (PREVIOUSLY)
     offset = Vector3D(0, 0, 0);
     set();
 }

--- a/GUI/ba3d/ba3d/model/particles.cpp
+++ b/GUI/ba3d/ba3d/model/particles.cpp
@@ -15,15 +15,34 @@
 #include "particles.h"
 #include <cmath>
 
-namespace RealSpace { namespace Particles {
+namespace RealSpace
+{
+namespace Particles
+{
 
 QString const& name(EShape k)
 {
     static QString names[] = {
-        "", "FullSphere", "FullSpheroid", "Cylinder", "TruncatedSphere",
-        "TruncatedSpheroid", "Cone", "Icosahedron", "Dodecahedron", "TruncatedCube",
-        "Prism6", "Cone6", "Pyramid", "Cuboctahedron", "Prism3", "Tetrahedron",
-        "EllipsoidalCylinder", "Box", "HemiEllipsoid", "AnisoPyramid",
+        "",
+        "FullSphere",
+        "FullSpheroid",
+        "Cylinder",
+        "TruncatedSphere",
+        "TruncatedSpheroid",
+        "Cone",
+        "Icosahedron",
+        "Dodecahedron",
+        "TruncatedCube",
+        "Prism6",
+        "Cone6",
+        "Pyramid",
+        "Cuboctahedron",
+        "Prism3",
+        "Tetrahedron",
+        "EllipsoidalCylinder",
+        "Box",
+        "HemiEllipsoid",
+        "AnisoPyramid",
     };
     return names[uint(k)];
 }
@@ -32,10 +51,9 @@ QString const& name(EShape k)
 
 using namespace GeometricID;
 
-Particle::Particle(Key key)
-    : Object(key)
-    , scale(Vector3D::_1)
-{}
+Particle::Particle(Key key) : Object(key), scale(Vector3D::_1)
+{
+}
 
 void Particle::set()
 {
@@ -49,12 +67,13 @@ void Particle::transform(Vector3D rotate_, Vector3D translate_)
 
 void Particle::fancy(Vector3D rotate, float r)
 {
-    Object::transform(turn, scale*r, rotate, offset + translate);
+    Object::transform(turn, scale * r, rotate, offset + translate);
 }
 
 void Particle::addTransform(Vector3D rotate_, Vector3D translate_)
 {
-    Object::transform(turn, scale, (rotate = rotate + rotate_), offset + (translate = translate + translate_));
+    Object::transform(turn, scale, (rotate = rotate + rotate_),
+                      offset + (translate = translate + translate_));
 }
 
 void Particle::addTranslation(Vector3D translate_)
@@ -64,8 +83,8 @@ void Particle::addTranslation(Vector3D translate_)
 
 //------------------------------------------------------------------------------
 
-static float const pi   = float(M_PI);
-static float const pi2f   = float(M_PI_2);
+static float const pi = float(M_PI);
+static float const pi2f = float(M_PI_2);
 static float const sqrt2f = std::sqrt(2.f);
 static float const sqrt3f = std::sqrt(3.f);
 
@@ -81,67 +100,65 @@ of the particle is already in the z=0 plane and there is no need for specifying 
 in other words, offset = Vector3D(0,0,0) */
 
 AnisoPyramid::AnisoPyramid(float L, float W, float H, float alpha)
-    : Particle(Key(BaseShape::Column, (1.0f - H/(std::sqrt((L*L/4)+(W*W/4))*std::tan(alpha))), 4))
+    : Particle(Key(BaseShape::Column,
+                   (1.0f - H / (std::sqrt((L * L / 4) + (W * W / 4)) * std::tan(alpha))), 4))
 {
-    isNull = (L <= 0 || W <= 0  || H <= 0 || alpha <= 0);
-    turn = Vector3D(0,0,45*pi/180.0f);
-    scale  = Vector3D(L*sqrt2f, W*sqrt2f, H);
+    isNull = (L <= 0 || W <= 0 || H <= 0 || alpha <= 0);
+    turn = Vector3D(0, 0, 45 * pi / 180.0f);
+    scale = Vector3D(L * sqrt2f, W * sqrt2f, H);
     offset = Vector3D(0, 0, 0);
     set();
 }
 
-Box::Box(float L, float W, float H)
-    : Particle(Key(BaseShape::Column, 1.0f, 4))
+Box::Box(float L, float W, float H) : Particle(Key(BaseShape::Column, 1.0f, 4))
 {
     isNull = (L < 0 || W < 0 || H < 0) || (L <= 0 && W <= 0 && H <= 0);
-    turn = Vector3D(0,0,45*pi/180.0f);
-    scale  = Vector3D(L*sqrt2f, W*sqrt2f, H);
+    turn = Vector3D(0, 0, 45 * pi / 180.0f);
+    scale = Vector3D(L * sqrt2f, W * sqrt2f, H);
     offset = Vector3D(0, 0, 0);
     set();
 }
 
 Cone::Cone(float R, float H, float alpha)
-    : Particle(Key(BaseShape::Column, (1.0f - H/(R*std::tan(alpha))), 0))
+    : Particle(Key(BaseShape::Column, (1.0f - H / (R * std::tan(alpha))), 0))
 {
     isNull = (R <= 0 || H <= 0 || alpha <= 0);
-    scale  = Vector3D(R*2, R*2, H);
+    scale = Vector3D(R * 2, R * 2, H);
     offset = Vector3D(0, 0, 0);
     set();
 }
 
 Cone6::Cone6(float R, float H, float alpha)
-    : Particle(Key(BaseShape::Column, (1.0f - H/(R*std::tan(alpha))), 6))
+    : Particle(Key(BaseShape::Column, (1.0f - H / (R * std::tan(alpha))), 6))
 {
     isNull = (R <= 0 || H <= 0 || alpha <= 0);
-    scale  = Vector3D(R*2, R*2, H);
+    scale = Vector3D(R * 2, R * 2, H);
     offset = Vector3D(0, 0, 0);
     set();
 }
 
 Cuboctahedron::Cuboctahedron(float L, float H, float rH, float alpha)
-    : Particle(Key(BaseShape::Cuboctahedron, rH, alpha, H/L))
+    : Particle(Key(BaseShape::Cuboctahedron, rH, alpha, H / L))
 {
     isNull = (L <= 0 || H <= 0 || rH <= 0 || alpha >= pi2f);
-    scale  = Vector3D(L, L, L);
+    scale = Vector3D(L, L, L);
     offset = Vector3D(0, 0, 0);
     set();
 }
 
-Cylinder::Cylinder(float R, float H)
-    : Particle(Key(BaseShape::Column, 1.0f, 0))
+Cylinder::Cylinder(float R, float H) : Particle(Key(BaseShape::Column, 1.0f, 0))
 {
     isNull = (R <= 0 || H <= 0);
-    scale  = Vector3D(R*2, R*2, H);
+    scale = Vector3D(R * 2, R * 2, H);
     offset = Vector3D(0, 0, 0);
     set();
 }
 
-Dodecahedron::Dodecahedron(float L)
-    : Particle(Key(BaseShape::Dodecahedron))
+Dodecahedron::Dodecahedron(float L) : Particle(Key(BaseShape::Dodecahedron))
 {
     isNull = (L <= 0);
     float R = L / DodecahedronL2R;
-    scale  = Vector3D(R*2, R*2, R*2);
+    scale = Vector3D(R * 2, R * 2, R * 2);
     offset = Vector3D(0, 0, 0);
     set();
 }
@@ -150,25 +167,23 @@ EllipsoidalCylinder::EllipsoidalCylinder(float Ra, float Rb, float H)
     : Particle(Key(BaseShape::Column, 1.0f, 0))
 {
     isNull = (Ra <= 0 || Rb <= 0 || H <= 0);
-    scale  = Vector3D(Ra*2, Rb*2, H);
+    scale = Vector3D(Ra * 2, Rb * 2, H);
     offset = Vector3D(0, 0, 0);
     set();
 }
 
-FullSphere::FullSphere(float R)
-    : Particle(Key(BaseShape::Sphere, 0, 0.5f))
+FullSphere::FullSphere(float R) : Particle(Key(BaseShape::Sphere, 0, 0.5f))
 {
     isNull = (R <= 0);
-    scale  = Vector3D(R*2);
+    scale = Vector3D(R * 2);
     offset = Vector3D(0, 0, 0);
     set();
 }
 
-FullSpheroid::FullSpheroid(float R, float H)
-    : Particle(Key(BaseShape::Sphere, 0, 0.5f))
+FullSpheroid::FullSpheroid(float R, float H) : Particle(Key(BaseShape::Sphere, 0, 0.5f))
 {
     isNull = (R <= 0 || H <= 0);
-    scale  = Vector3D(R*2, R*2, H);
+    scale = Vector3D(R * 2, R * 2, H);
     offset = Vector3D(0, 0, 0);
     set();
 }
@@ -177,86 +192,82 @@ HemiEllipsoid::HemiEllipsoid(float Ra, float Rb, float H)
     : Particle(Key(BaseShape::Sphere, .5f, 0.0f))
 {
     isNull = (Ra <= 0 || Rb <= 0 || H <= 0);
-    scale  = Vector3D(Ra*2, Rb*2, H*2);
+    scale = Vector3D(Ra * 2, Rb * 2, H * 2);
     offset = Vector3D(0, 0, 0);
     set();
 }
 
-Icosahedron::Icosahedron(float L)
-    : Particle(Key(BaseShape::Icosahedron))
+Icosahedron::Icosahedron(float L) : Particle(Key(BaseShape::Icosahedron))
 {
     isNull = (L <= 0);
     float R = L / IcosahedronL2R;
-    scale  = Vector3D(R/GoldenRatio, R/GoldenRatio, R/GoldenRatio);
+    scale = Vector3D(R / GoldenRatio, R / GoldenRatio, R / GoldenRatio);
     offset = Vector3D(0, 0, 0);
     set();
 }
 
-Prism3::Prism3(float L, float H)
-    : Particle(Key(BaseShape::Column, 1.0f, 3))
+Prism3::Prism3(float L, float H) : Particle(Key(BaseShape::Column, 1.0f, 3))
 {
     isNull = (L <= 0 || H <= 0);
-    float D = L*2 / sqrt3f;
-    scale = Vector3D(D*2, D*2, H);
+    float D = L * 2 / sqrt3f;
+    scale = Vector3D(D * 2, D * 2, H);
     offset = Vector3D(0, 0, 0);
     set();
 }
 
-Prism6::Prism6(float R, float H)
-    : Particle(Key(BaseShape::Column, 1.0f, 6))
+Prism6::Prism6(float R, float H) : Particle(Key(BaseShape::Column, 1.0f, 6))
 {
     isNull = (R <= 0 || H <= 0);
-    scale  = Vector3D(R*2, R*2, H);
+    scale = Vector3D(R * 2, R * 2, H);
     offset = Vector3D(0, 0, 0);
     set();
 }
 
 Pyramid::Pyramid(float L, float H, float alpha)
-    : Particle(Key(BaseShape::Column, (1.0f - H/(std::sqrt(L*L/2)*std::tan(alpha))), 4))
+    : Particle(Key(BaseShape::Column, (1.0f - H / (std::sqrt(L * L / 2) * std::tan(alpha))), 4))
 {
     isNull = (L <= 0 || H <= 0 || alpha <= 0);
     float L2 = L * sqrt2f;
-    turn = Vector3D(0,0,45*pi/180.0f);
-    scale  = Vector3D(L2, L2, H);
+    turn = Vector3D(0, 0, 45 * pi / 180.0f);
+    scale = Vector3D(L2, L2, H);
     offset = Vector3D(0, 0, 0);
     set();
 }
 
 Tetrahedron::Tetrahedron(float L, float H, float alpha)
-    : Particle(Key(BaseShape::Column, (1.0f - H/(L/sqrt3f*std::tan(alpha))), 3))
+    : Particle(Key(BaseShape::Column, (1.0f - H / (L / sqrt3f * std::tan(alpha))), 3))
 {
     isNull = (L <= 0 || H <= 0 || alpha <= 0);
     float D = L / sqrt3f;
-    scale = Vector3D(D*2, D*2, H);
+    scale = Vector3D(D * 2, D * 2, H);
     offset = Vector3D(0, 0, 0);
     set();
 }
 
-TruncatedCube::TruncatedCube(float L, float t)
-    : Particle(Key(BaseShape::TruncatedBox, 2*t/L))
+TruncatedCube::TruncatedCube(float L, float t) : Particle(Key(BaseShape::TruncatedBox, 2 * t / L))
 {
     isNull = (L <= 0);
-    scale  = Vector3D(L,L,L);
+    scale = Vector3D(L, L, L);
     offset = Vector3D(0, 0, 0);
     set();
 }
 
 TruncatedSphere::TruncatedSphere(float R, float H)
-    : Particle(Key(BaseShape::Sphere, 1 - H/R/2, (H-R)/R/2))
+    : Particle(Key(BaseShape::Sphere, 1 - H / R / 2, (H - R) / R / 2))
 {
     isNull = (R <= 0 || H <= 0);
-    scale  = Vector3D(R*2);
+    scale = Vector3D(R * 2);
     offset = Vector3D(0, 0, 0);
     set();
 }
 
 TruncatedSpheroid::TruncatedSpheroid(float R, float H, float fp)
-    : Particle(Key(BaseShape::Sphere, 1 - H/fp/R/2, (H-fp*R)/fp/R/2))
+    : Particle(Key(BaseShape::Sphere, 1 - H / fp / R / 2, (H - fp * R) / fp / R / 2))
 {
     isNull = (R <= 0 || H <= 0 || fp <= 0);
-    scale  = Vector3D(R*2, R*2, fp*R*2);
+    scale = Vector3D(R * 2, R * 2, fp * R * 2);
     offset = Vector3D(0, 0, 0);
     set();
 }
-
-}}  // namespace RealSpace::Particles
+}
+} // namespace RealSpace::Particles

--- a/GUI/ba3d/ba3d/model/particles.cpp
+++ b/GUI/ba3d/ba3d/model/particles.cpp
@@ -123,7 +123,7 @@ Cone6::Cone6(float R, float H, float alpha)
 }
 
 Cuboctahedron::Cuboctahedron(float L, float H, float rH, float alpha)
-    : Particle(Key(BaseShape::Cuboctahedron, rH, (pi - alpha)))
+    : Particle(Key(BaseShape::Cuboctahedron, rH, alpha, H/L))
 {
     isNull = (L <= 0 || H <= 0 || rH <= 0 || alpha >= pi2f);
     scale  = Vector3D(L, L, L);

--- a/GUI/ba3d/ba3d/model/particles.cpp
+++ b/GUI/ba3d/ba3d/model/particles.cpp
@@ -70,6 +70,15 @@ static float const sqrt2f = std::sqrt(2.f);
 static float const sqrt3f = std::sqrt(3.f);
 
 // see ~/BornAgain/GUI/ba3d/ba3d/model/geometry/ for BaseShape construction
+// e.g. column.cpp, sphere.cpp etc.
+
+/* PREVIOUSLY, the base shapes were constructed symmetric about the xy plane, centered at the
+origin. E.g. for column base shape (see column.cpp), the xy-plane went through the center of the
+shape (object extension: -H/2 to +H/2 in z). When a 3D particle was created (see the following code)
+using this column base shape and scaled to proper dimensions, the offset  was kept at z=H/2 to bring
+the bottom of the particle to z=0 plane. NOW, the base shapes are all created such that the bottom
+of the particle is already in the z=0 plane and there is no need for specifying the bottom offset -
+in other words, offset = Vector3D(0,0,0) */
 
 AnisoPyramid::AnisoPyramid(float L, float W, float H, float alpha)
     : Particle(Key(BaseShape::Column, (1.0f - H/(std::sqrt((L*L/4)+(W*W/4))*std::tan(alpha))), 4))
@@ -77,7 +86,8 @@ AnisoPyramid::AnisoPyramid(float L, float W, float H, float alpha)
     isNull = (L <= 0 || W <= 0  || H <= 0 || alpha <= 0);
     turn = Vector3D(0,0,45*pi/180.0f);
     scale  = Vector3D(L*sqrt2f, W*sqrt2f, H);
-    offset = Vector3D(0, 0, H/2);
+//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
+    offset = Vector3D(0, 0, 0);
     set();
 }
 
@@ -87,7 +97,8 @@ Box::Box(float L, float W, float H)
     isNull = (L < 0 || W < 0 || H < 0) || (L <= 0 && W <= 0 && H <= 0);
     turn = Vector3D(0,0,45*pi/180.0f);
     scale  = Vector3D(L*sqrt2f, W*sqrt2f, H);
-    offset = Vector3D(0, 0, H/2);
+//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
+    offset = Vector3D(0, 0, 0);
     set();
 }
 
@@ -96,7 +107,8 @@ Cone::Cone(float R, float H, float alpha)
 {
     isNull = (R <= 0 || H <= 0 || alpha <= 0);
     scale  = Vector3D(R*2, R*2, H);
-    offset = Vector3D(0, 0, H/2);
+//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
+    offset = Vector3D(0, 0, 0);
     set();
 }
 
@@ -105,7 +117,8 @@ Cone6::Cone6(float R, float H, float alpha)
 {
     isNull = (R <= 0 || H <= 0 || alpha <= 0);
     scale  = Vector3D(R*2, R*2, H);
-    offset = Vector3D(0, 0, H/2);
+//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
+    offset = Vector3D(0, 0, 0);
     set();
 }
 
@@ -114,7 +127,8 @@ Cuboctahedron::Cuboctahedron(float L, float H, float rH, float alpha)
 {
     isNull = (L <= 0 || H <= 0 || rH <= 0 || alpha >= pi2f);
     scale  = Vector3D(L, L, L);
-    offset = Vector3D(0, 0, L/2);
+    //offset = Vector3D(0, 0, L/2); // (PREVIOUSLY)
+    offset = Vector3D(0, 0, 0);
     set();
 }
 
@@ -123,7 +137,8 @@ Cylinder::Cylinder(float R, float H)
 {
     isNull = (R <= 0 || H <= 0);
     scale  = Vector3D(R*2, R*2, H);
-    offset = Vector3D(0, 0, H/2);
+//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
+    offset = Vector3D(0, 0, 0);
     set();
 }
 
@@ -133,7 +148,8 @@ Dodecahedron::Dodecahedron(float L)
     isNull = (L <= 0);
     float R = L / DodecahedronL2R;
     scale  = Vector3D(R*2, R*2, R*2);
-    offset = Vector3D(0, 0, R/std::sqrt(GoldenRatio));
+//    offset = Vector3D(0, 0, R/std::sqrt(GoldenRatio)); // (PREVIOUSLY)
+    offset = Vector3D(0, 0, 0);
     set();
 }
 
@@ -142,33 +158,37 @@ EllipsoidalCylinder::EllipsoidalCylinder(float Ra, float Rb, float H)
 {
     isNull = (Ra <= 0 || Rb <= 0 || H <= 0);
     scale  = Vector3D(Ra*2, Rb*2, H);
-    offset = Vector3D(0, 0, H/2);
+//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
+    offset = Vector3D(0, 0, 0);
     set();
 }
 
 FullSphere::FullSphere(float R)
-    : Particle(Key(BaseShape::Sphere, 0))
+    : Particle(Key(BaseShape::Sphere, 0, 0.5f))
 {
     isNull = (R <= 0);
     scale  = Vector3D(R*2);
-    offset = Vector3D(0, 0, R);
+//    offset = Vector3D(0, 0, R); // (PREVIOUSLY)
+    offset = Vector3D(0, 0, 0);
     set();
 }
 
 FullSpheroid::FullSpheroid(float R, float H)
-    : Particle(Key(BaseShape::Sphere, 0))
+    : Particle(Key(BaseShape::Sphere, 0, 0.5f))
 {
     isNull = (R <= 0 || H <= 0);
     scale  = Vector3D(R*2, R*2, H);
-    offset = Vector3D(0, 0, H/2);
+//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
+    offset = Vector3D(0, 0, 0);
     set();
 }
 
 HemiEllipsoid::HemiEllipsoid(float Ra, float Rb, float H)
-    : Particle(Key(BaseShape::Sphere, .5f))
+    : Particle(Key(BaseShape::Sphere, .5f, 0.0f))
 {
     isNull = (Ra <= 0 || Rb <= 0 || H <= 0);
     scale  = Vector3D(Ra*2, Rb*2, H*2);
+    offset = Vector3D(0, 0, 0);
     set();
 }
 
@@ -178,7 +198,8 @@ Icosahedron::Icosahedron(float L)
     isNull = (L <= 0);
     float R = L / IcosahedronL2R;
     scale  = Vector3D(R/GoldenRatio, R/GoldenRatio, R/GoldenRatio);
-    offset = Vector3D(0, 0, R/(2*GoldenRatio));
+//    offset = Vector3D(0, 0, R/(2*GoldenRatio)); // (PREVIOUSLY)
+    offset = Vector3D(0, 0, 0);
     set();
 }
 
@@ -188,7 +209,8 @@ Prism3::Prism3(float L, float H)
     isNull = (L <= 0 || H <= 0);
     float D = L*2 / sqrt3f;
     scale = Vector3D(D*2, D*2, H);
-    offset = Vector3D(0, 0, H/2);
+//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
+    offset = Vector3D(0, 0, 0);
     set();
 }
 
@@ -197,7 +219,8 @@ Prism6::Prism6(float R, float H)
 {
     isNull = (R <= 0 || H <= 0);
     scale  = Vector3D(R*2, R*2, H);
-    offset = Vector3D(0, 0, H/2);
+//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
+    offset = Vector3D(0, 0, 0);
     set();
 }
 
@@ -208,7 +231,8 @@ Pyramid::Pyramid(float L, float H, float alpha)
     float L2 = L * sqrt2f;
     turn = Vector3D(0,0,45*pi/180.0f);
     scale  = Vector3D(L2, L2, H);
-    offset = Vector3D(0, 0, H/2);
+//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
+    offset = Vector3D(0, 0, 0);
     set();
 }
 
@@ -218,7 +242,8 @@ Tetrahedron::Tetrahedron(float L, float H, float alpha)
     isNull = (L <= 0 || H <= 0 || alpha <= 0);
     float D = L / sqrt3f;
     scale = Vector3D(D*2, D*2, H);
-    offset = Vector3D(0, 0, H/2);
+//    offset = Vector3D(0, 0, H/2); // (PREVIOUSLY)
+    offset = Vector3D(0, 0, 0);
     set();
 }
 
@@ -227,25 +252,28 @@ TruncatedCube::TruncatedCube(float L, float t)
 {
     isNull = (L <= 0);
     scale  = Vector3D(L,L,L);
-    offset = Vector3D(0, 0, L/2);
+//    offset = Vector3D(0, 0, L/2); // (PREVIOUSLY)
+    offset = Vector3D(0, 0, 0);
     set();
 }
 
 TruncatedSphere::TruncatedSphere(float R, float H)
-    : Particle(Key(BaseShape::Sphere, 1 - H/R/2))
+    : Particle(Key(BaseShape::Sphere, 1 - H/R/2, (H-R)/R/2))
 {
     isNull = (R <= 0 || H <= 0);
     scale  = Vector3D(R*2);
-    offset = Vector3D(0, 0, H-R);
+//    offset = Vector3D(0, 0, H-R); // (PREVIOUSLY)
+    offset = Vector3D(0, 0, 0);
     set();
 }
 
 TruncatedSpheroid::TruncatedSpheroid(float R, float H, float fp)
-    : Particle(Key(BaseShape::Sphere, 1 - H/fp/R/2))
+    : Particle(Key(BaseShape::Sphere, 1 - H/fp/R/2, (H-fp*R)/fp/R/2))
 {
     isNull = (R <= 0 || H <= 0 || fp <= 0);
     scale  = Vector3D(R*2, R*2, fp*R*2);
-    offset = Vector3D(0, 0, H-fp*R);
+//    offset = Vector3D(0, 0, H-fp*R); // (PREVIOUSLY)
+    offset = Vector3D(0, 0, 0);
     set();
 }
 

--- a/GUI/ba3d/ba3d/model/particles.h
+++ b/GUI/ba3d/ba3d/model/particles.h
@@ -17,14 +17,32 @@
 
 #include "object.h"
 
-namespace RealSpace { namespace Particles {
+namespace RealSpace
+{
+namespace Particles
+{
 
 enum class EShape {
     None,
-    FullSphere, FullSpheroid, Cylinder, TruncatedSphere, TruncatedSpheroid,
-    Cone, Icosahedron, Dodecahedron, TruncatedCube, Prism6, Cone6, Pyramid,
-    Cuboctahedron, Prism3, Tetrahedron, EllipsoidalCylinder, Box,
-    HemiEllipsoid, AnisoPyramid,
+    FullSphere,
+    FullSpheroid,
+    Cylinder,
+    TruncatedSphere,
+    TruncatedSpheroid,
+    Cone,
+    Icosahedron,
+    Dodecahedron,
+    TruncatedCube,
+    Prism6,
+    Cone6,
+    Pyramid,
+    Cuboctahedron,
+    Prism3,
+    Tetrahedron,
+    EllipsoidalCylinder,
+    Box,
+    HemiEllipsoid,
+    AnisoPyramid,
 };
 
 QString const& name(EShape);
@@ -35,10 +53,10 @@ class Particle : public Object
 {
 protected:
     Particle(GeometricID::Key);
-    Vector3D turn;   // turn before scale
-    Vector3D scale;  // geometries are of 1-size (box 1x1x1, sphere D=1), need scaling
-    Vector3D offset; // geometries centered around origin; particles stand on z=0 plane
-    Vector3D rotate, translate;  // remembered
+    Vector3D turn;              // turn before scale
+    Vector3D scale;             // geometries are of 1-size (box 1x1x1, sphere D=1), need scaling
+    Vector3D offset;            // geometries centered around origin; particles stand on z=0 plane
+    Vector3D rotate, translate; // remembered
 
     void set();
 
@@ -169,6 +187,6 @@ class AnisoPyramid : public Particle
 public:
     AnisoPyramid(float L, float W, float H, float alpha);
 };
-
-}}  // namespace RealSpace::Particles
-#endif  // BA3D_PARTICLES_H
+}
+} // namespace RealSpace::Particles
+#endif // BA3D_PARTICLES_H


### PR DESCRIPTION
- The BaseShapes have been refactored such that the bottom of the objects lie in the z=0 plane during object creation and there remains no need for separately specifying the offset of the 3D particles (as done previously).

- This also fixes the error in the rotation of the 3D particle due to the non-zero offset parameter which was being specified previously.