### PR TITLE
GUI3D Set border width for population of particles on a layer

### DIFF
--- a/GUI/ba3d/ba3d/model/particles.cpp
+++ b/GUI/ba3d/ba3d/model/particles.cpp
@@ -89,15 +89,6 @@ static float const sqrt2f = std::sqrt(2.f);
 static float const sqrt3f = std::sqrt(3.f);
 
 // see ~/BornAgain/GUI/ba3d/ba3d/model/geometry/ for BaseShape construction
-// e.g. column.cpp, sphere.cpp etc.
-
-/* PREVIOUSLY, the base shapes were constructed symmetric about the xy plane, centered at the
-origin. E.g. for column base shape (see column.cpp), the xy-plane went through the center of the
-shape (object extension: -H/2 to +H/2 in z). When a 3D particle was created (see the following code)
-using this column base shape and scaled to proper dimensions, the offset  was kept at z=H/2 to bring
-the bottom of the particle to z=0 plane. NOW, the base shapes are all created such that the bottom
-of the particle is already in the z=0 plane and there is no need for specifying the bottom offset -
-in other words, offset = Vector3D(0,0,0) */
 
 AnisoPyramid::AnisoPyramid(float L, float W, float H, float alpha)
     : Particle(Key(BaseShape::Column,

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.cpp
@@ -80,7 +80,7 @@ void RealSpaceBuilder::populateMultiLayer(RealSpaceModel* model, const SessionIt
 {
     double total_height(0.0);
     int index(0);
-    bool isTopLayer(true); // for not displaying colour of the top layer in Multilayer
+    bool isTopLayer(true); // for not displaying colour of the top layer in MultiLayer
     for (auto layer : item.getItems(MultiLayerItem::T_LAYERS)) {
 
         if (index != 0) {
@@ -97,7 +97,7 @@ void RealSpaceBuilder::populateMultiLayer(RealSpaceModel* model, const SessionIt
 void RealSpaceBuilder::populateLayer(RealSpaceModel* model, const SessionItem& layerItem,
                                      const SceneGeometry& sceneGeometry, const QVector3D& origin,
                                      const bool isTopLayer)
-{   
+{
     auto layer = TransformTo3D::createLayer(layerItem, sceneGeometry, origin);
     if (layer && !isTopLayer)
         model->addBlend(layer.release());

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.cpp
@@ -80,22 +80,26 @@ void RealSpaceBuilder::populateMultiLayer(RealSpaceModel* model, const SessionIt
 {
     double total_height(0.0);
     int index(0);
+    bool isTopLayer(true); // for not displaying colour of the top layer in Multilayer
     for (auto layer : item.getItems(MultiLayerItem::T_LAYERS)) {
 
-        if (index != 0)
+        if (index != 0) {
             total_height += TransformTo3D::visualLayerThickness(*layer, sceneGeometry);
+            isTopLayer = false;
+        }
 
         populateLayer(model, *layer, sceneGeometry,
-                      QVector3D(0, 0, static_cast<float>(-total_height)));
+                      QVector3D(0, 0, static_cast<float>(-total_height)), isTopLayer);
         ++index;
     }
 }
 
 void RealSpaceBuilder::populateLayer(RealSpaceModel* model, const SessionItem& layerItem,
-                                     const SceneGeometry& sceneGeometry, const QVector3D& origin)
-{
+                                     const SceneGeometry& sceneGeometry, const QVector3D& origin,
+                                     const bool isTopLayer)
+{   
     auto layer = TransformTo3D::createLayer(layerItem, sceneGeometry, origin);
-    if (layer)
+    if (layer && !isTopLayer)
         model->addBlend(layer.release());
 
     for (auto layout : layerItem.getItems(LayerItem::T_LAYOUTS))

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.h
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.h
@@ -47,7 +47,8 @@ public:
                             const QVector3D& origin = QVector3D());
 
     void populateLayer(RealSpaceModel* model, const SessionItem& layerItem,
-                       const SceneGeometry& sceneGeometry, const QVector3D& origin = QVector3D());
+                       const SceneGeometry& sceneGeometry, const QVector3D& origin = QVector3D(),
+                       const bool isTopLayer = false);
 
     void populateLayout(RealSpaceModel* model, const SessionItem& layoutItem,
                         const SceneGeometry& sceneGeometry, const QVector3D& origin = QVector3D());

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilderUtils.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilderUtils.cpp
@@ -45,6 +45,8 @@
 
 namespace
 {
+const double layerBorderWidth = 10.0;
+
 const IFormFactor* getUnderlyingFormFactor(const IFormFactor* ff)
 {
     // TRUE as long as ff is of IFormFactorDecorator (or its derived) type
@@ -93,8 +95,9 @@ void RealSpaceBuilderUtils::populateParticlesAtLatticePositions(
                 double pos_y = position[1];
                 double pos_z = 0;
 
-                if (std::abs(pos_x) <= layer_size && std::abs(pos_y) <= layer_size
-                    && std::abs(pos_z) <= layer_thickness) {
+                if (std::abs(pos_x) <= layer_size - layerBorderWidth && std::abs(pos_y) <=
+                        layer_size - layerBorderWidth  && std::abs(pos_z) <= layer_thickness) {
+
                     builder3D->populateParticleFromParticle3DContainer(
                         model, particle3DContainer,
                         QVector3D(static_cast<float>(position[0]), static_cast<float>(position[1]),

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilderUtils.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilderUtils.cpp
@@ -95,8 +95,9 @@ void RealSpaceBuilderUtils::populateParticlesAtLatticePositions(
                 double pos_y = position[1];
                 double pos_z = 0;
 
-                if (std::abs(pos_x) <= layer_size - layerBorderWidth && std::abs(pos_y) <=
-                        layer_size - layerBorderWidth  && std::abs(pos_z) <= layer_thickness) {
+                if (std::abs(pos_x) <= layer_size - layerBorderWidth
+                    && std::abs(pos_y) <= layer_size - layerBorderWidth
+                    && std::abs(pos_z) <= layer_thickness) {
 
                     builder3D->populateParticleFromParticle3DContainer(
                         model, particle3DContainer,


### PR DESCRIPTION
- Remove unnecessary comment from particles.cpp (was not removed previously).
- Do not display colour of the top layer when MultiLayer is selected in 3D view.
- Add a border width of 10 nm during calculation of lattice positions so that most of the particles are populated inside the layer boundaries.