### PR TITLE
Corrections to CsvImportAssistant (http://apps.jcns.fz-juelich.de/redmine/issues/2137)

### DIFF
--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
@@ -2,7 +2,7 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/MaterialEditor/CsvImportAssistant.cpp
+//! @file      GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
 //! @brief     Implements class CsvImportAssistant
 //!
 //! @homepage  http://www.bornagainproject.org
@@ -43,7 +43,7 @@ CsvImportAssistant::CsvImportAssistant(QString dir, QString file, QWidget* paren
     setLayout(layout);
 
     StyleUtils::setResizable(this);
-    m_filePathField->setText(m_fileName);
+
     if(!m_fileName.isEmpty())
         CsvImportAssistant::onReloadButton();
 }
@@ -55,8 +55,8 @@ QBoxLayout* CsvImportAssistant::createLayout()
     auto result = new QVBoxLayout;
     auto preresult = new QHBoxLayout;
 
-    auto exportButton = new QPushButton("Export");
-    connect(exportButton, &QPushButton::clicked, this, &CsvImportAssistant::onExportButton);
+    auto importButton = new QPushButton("Import");
+    connect(importButton, &QPushButton::clicked, this, &CsvImportAssistant::onImportButton);
 
     auto rejectButton = new QPushButton("Cancel");
     connect(rejectButton, &QPushButton::clicked, this, &CsvImportAssistant::onRejectButton);
@@ -69,7 +69,7 @@ QBoxLayout* CsvImportAssistant::createLayout()
     //preresult->addStretch(1);
 
     preresult->addWidget(rejectButton);
-    preresult->addWidget(exportButton);
+    preresult->addWidget(importButton);
 
 
     result->setMargin(10);
@@ -92,7 +92,7 @@ QBoxLayout* CsvImportAssistant::createFileDetailsLayout(){
     //result->addStretch(1);
 
     auto labelFilepath = new QLabel("File to import: ");
-    m_filePathField = new QLineEdit("",this);
+    m_filePathField = new QLineEdit(m_fileName,this);
     auto browseButton = new QPushButton("browse");
     connect(browseButton, &QPushButton::clicked, this, &CsvImportAssistant::onBrowseButton);
     auto lay1 = new QHBoxLayout;
@@ -106,7 +106,7 @@ QBoxLayout* CsvImportAssistant::createFileDetailsLayout(){
     result->addLayout(lay1);
 
     auto labelSeparator = new QLabel("Separator: ");
-    m_separatorField = new QLineEdit(",");
+    m_separatorField = new QLineEdit(QString(guessSeparator()));
     m_separatorField->setMaxLength(1);
     auto lay2 = new QHBoxLayout;
     //lay2->setMargin(10);
@@ -116,18 +116,18 @@ QBoxLayout* CsvImportAssistant::createFileDetailsLayout(){
     lay2->addWidget(m_separatorField);
     result->addLayout(lay2);
 
-    auto labelHeaderRow = new QLabel("Headers row (zero for no headers): ");
-    m_headersRowSpinBox = new QSpinBox();
-    m_headersRowSpinBox->setMinimum(0);
-    m_headersRowSpinBox->setMaximum(0);
-    m_headersRowSpinBox->setValue(0);
-    auto lay3 = new QHBoxLayout;
-    //lay3->setMargin(10);
-    //lay3->setSpacing(5);
-    //lay3->addStretch(1);
-    lay3->addWidget(labelHeaderRow);
-    lay3->addWidget(m_headersRowSpinBox);
-    result->addLayout(lay3);
+    //    auto labelHeaderRow = new QLabel("Headers row (zero for no headers): ");
+    //    m_headersRowSpinBox = new QSpinBox();
+    //    m_headersRowSpinBox->setMinimum(0);
+    //    m_headersRowSpinBox->setMaximum(0);
+    //    m_headersRowSpinBox->setValue(0);
+    //    auto lay3 = new QHBoxLayout;
+    //    //lay3->setMargin(10);
+    //    //lay3->setSpacing(5);
+    //    //lay3->addStretch(1);
+    //    lay3->addWidget(labelHeaderRow);
+    //    lay3->addWidget(m_headersRowSpinBox);
+    //    result->addLayout(lay3);
 
     auto labelFirstDataRow = new QLabel("First data row: ");
     m_firstDataRowSpinBox = new QSpinBox();
@@ -164,7 +164,7 @@ QBoxLayout* CsvImportAssistant::createFileDetailsLayout(){
 
     result->addLayout(lay1);
     result->addLayout(lay2);
-    result->addLayout(lay3);
+    //result->addLayout(lay3);
     result->addLayout(lay4);
     result->addLayout(lay5);
     result->addLayout(lay6);
@@ -174,14 +174,14 @@ QBoxLayout* CsvImportAssistant::createFileDetailsLayout(){
 
 void CsvImportAssistant::onBrowseButton()
 {
-        const QString filter_string = "Intensity File (*.txt *.dat *.ascii *.int *.gz *.tif *.tiff *.csv);;All files (*.*)";
-        QString fileName = QFileDialog::getOpenFileName(nullptr, QStringLiteral("Open Intensity File"),
-                                                        this->m_dirName, filter_string);
-        if(fileName != nullptr){
-            m_filePathField->setText(fileName);
-            m_fileName = fileName;
-            CsvImportAssistant::onReloadButton();
-        }
+    const QString filter_string = "Intensity File (*.txt *.dat *.ascii *.int *.gz *.tif *.tiff *.csv);;All files (*.*)";
+    QString fileName = QFileDialog::getOpenFileName(nullptr, QStringLiteral("Open Intensity File"),
+                                                    this->m_dirName, filter_string);
+    if(fileName != nullptr){
+        m_filePathField->setText(fileName);
+        m_fileName = fileName;
+        CsvImportAssistant::onReloadButton();
+    }
 
 }
 
@@ -205,7 +205,7 @@ void CsvImportAssistant::onRejectButton(){
 }
 
 
-void CsvImportAssistant::onExportButton()
+void CsvImportAssistant::onImportButton()
 {
     using namespace std;
 
@@ -218,19 +218,19 @@ void CsvImportAssistant::onExportButton()
     for(int i = 0; i < nRows; i++){
         B.clear();
         for(int j = 0; j < nCols; j++){
-           B.push_back( m_tableWidget->item(i,j) != nullptr ? m_tableWidget->item(i,j)->text().toStdString() : "");
+            B.push_back( m_tableWidget->item(i,j) != nullptr ? m_tableWidget->item(i,j)->text().toStdString() : "");
         }
         A.push_back(B);
     }
 
-    setFilepath(filepath()+"-ba-exported.txt");
+    setFilepath(filepath()+"-ba-imported.txt");
     ofstream output_file(filepath().toStdString());
     for(int i = 0; i < nRows; i++){
         for(int j = 0; j < nCols - 1; j++){
-            std::string a = A[i][j];
+            std::string a = A[unsigned(i)][unsigned(j)];
             output_file << a << " ";
         }
-        std::string a = A[i][nCols - 1];
+        std::string a = A[unsigned(i)][unsigned(nCols) - 1];
         output_file << a << '\n';
     }
     accept();
@@ -253,15 +253,16 @@ void CsvImportAssistant::generate_table()
     }
 
     m_tableWidget->clearContents();
-    m_tableWidget->setColumnCount(csvFile->NumberOfColumns());
+    m_tableWidget->setColumnCount(int(csvFile->NumberOfColumns()));
     m_tableWidget->setRowCount(0);
-    m_lastDataRowSpinBox->setMaximum(csvFile->NumberOfRows());
-    m_firstDataRowSpinBox->setMaximum(csvFile->NumberOfRows());
-    m_headersRowSpinBox->setMaximum(csvFile->NumberOfRows());
+    m_lastDataRowSpinBox->setMaximum(int(csvFile->NumberOfRows()));
+    m_firstDataRowSpinBox->setMaximum(int(csvFile->NumberOfRows()));
+    //m_headersRowSpinBox->setMaximum(csvFile->NumberOfRows());
 
     set_table_headers(csvFile);
     set_table_data(csvFile);
     remove_blanks();
+    setRowNumbering();
 
     return;
 }
@@ -276,6 +277,7 @@ void CsvImportAssistant::set_table_headers(CSVFile* csvFile){
         titulos << QString::fromStdString(header);
     }
     m_tableWidget->setHorizontalHeaderLabels(titulos);
+
     return;
 }
 
@@ -283,14 +285,15 @@ void CsvImportAssistant::set_table_headers(CSVFile* csvFile){
 void CsvImportAssistant::set_table_data(CSVFile* csvFile){
 
     unsigned firstDataLine = firstLine() - 1;
-    unsigned lastDataLine = lastLine() == 0 ? csvFile->NumberOfRows() : lastLine();
+    unsigned lastDataLine = lastLine() == 0 ? unsigned(m_lastDataRowSpinBox->maximum()) : lastLine();
+
 
     for(unsigned i = firstDataLine; i < lastDataLine; i++){
         m_tableWidget->insertRow(m_tableWidget->rowCount());
-        unsigned I = m_tableWidget->rowCount() - 1;
+        unsigned I = unsigned(m_tableWidget->rowCount()) - 1;
         for(unsigned j = 0; j < csvFile->NumberOfColumns(); j++){
-           std::string aasdf = csvFile->operator [](i)[j];
-           m_tableWidget->setItem(I,j,new QTableWidgetItem(QString::fromStdString(aasdf)));
+            std::string aasdf = csvFile->operator [](i)[j];
+            m_tableWidget->setItem(int(I),int(j),new QTableWidgetItem(QString::fromStdString(aasdf)));
         }
     }
 }
@@ -321,28 +324,50 @@ void CsvImportAssistant::remove_blanks(){
     for(int i = 0; i < nRows; i++){
         B.clear();
         for(int j = 0; j < nCols; j++){
-           B.push_back( m_tableWidget->item(i,j) != nullptr ? m_tableWidget->item(i,j)->text().toStdString() : "");
+            string contents = m_tableWidget->item(i,j) != nullptr ? m_tableWidget->item(i,j)->text().toStdString() : "";
+            B.push_back(contents);
         }
+        //Skip last row if it is an empty line:
+        if(i == nRows - 1)
+            if(QString::fromStdString(std::accumulate(B.begin(), B.end(), std::string(""))).trimmed() == "")
+                continue;
+
         A.push_back(B);
     }
 
-    //put them into a new table
+    //correct the size of the table
     m_tableWidget->clearContents();
     m_tableWidget->setRowCount(0);
-    m_tableWidget->setColumnCount(nCols-blank_cols.size());
+    m_tableWidget->setColumnCount(nCols-int(blank_cols.size()));
+    nRows = int(A.size());
+
+    //put values into a new table
     for(int i = 0; i < nRows; i++){
         m_tableWidget->insertRow(m_tableWidget->rowCount());
         int J = 0;
         for(int j = 0; j < nCols; j++){
-               if( std::find(blank_cols.begin(), blank_cols.end(), j) == blank_cols.end()){
-                    std::string a = A[i][j];
-                    m_tableWidget->setItem(i,J,new QTableWidgetItem(QString::fromStdString(a)));
-                    J++;
-               }
-         }
-
+            if( std::find(blank_cols.begin(), blank_cols.end(), j) == blank_cols.end()){
+                std::string a = A[unsigned(i)][unsigned(j)];
+                m_tableWidget->setItem(i,J,new QTableWidgetItem(QString::fromStdString(a)));
+                J++;
+            }
+        }
     }
 }
+
+void CsvImportAssistant::setRowNumbering(){
+
+    unsigned firstDataLine = firstLine();
+    unsigned lastDataLine = lastLine() == 0 ? unsigned(m_lastDataRowSpinBox->maximum()) : lastLine();
+
+
+    QStringList displayRowNumbers;
+    for(unsigned i = firstDataLine; i <= lastDataLine; i++)
+        displayRowNumbers << QString::number(i);
+
+    m_tableWidget->setVerticalHeaderLabels(displayRowNumbers);
+}
+
 
 bool CsvImportAssistant::cell_is_blank(int iRow, int jCol){
 
@@ -359,7 +384,7 @@ bool CsvImportAssistant::cell_is_blank(int iRow, int jCol){
 }
 
 QString CsvImportAssistant::filepath() const{
-        return m_filePathField->text().trimmed();
+    return m_filePathField->text().trimmed();
 }
 
 void CsvImportAssistant::setFilepath(QString fpath){
@@ -368,30 +393,79 @@ void CsvImportAssistant::setFilepath(QString fpath){
 }
 
 char CsvImportAssistant::separator() const{
-        char separator;
-        QString tmpstr = m_separatorField->text();
-        if(tmpstr.size() < 1){
-                separator = ' ';
-                QMessageBox msgBox;
-                msgBox.setText("There was a problem with the separator given.\n Replacing it by ' ' [space]");
-                msgBox.setIcon(msgBox.Information);
-                msgBox.exec();
-                m_separatorField->setText(QString(QChar::fromLatin1(separator)));
-        }
-        else{
-                separator = tmpstr.at(0).toLatin1();
-        }
-        return separator;
+    char separator;
+    QString tmpstr = m_separatorField->text();
+    if(tmpstr.size() < 1){
+        separator = guessSeparator();
+        QMessageBox msgBox;
+        msgBox.setText("There was a problem with the separator given.\n Replacing it by ' ' [space]");
+        msgBox.setIcon(msgBox.Information);
+        msgBox.exec();
+        m_separatorField->setText(QString(QChar::fromLatin1(separator)));
+    }
+    else{
+        separator = tmpstr.at(0).toLatin1();
+    }
+    return separator;
+}
+
+char CsvImportAssistant::guessSeparator() const{
+    using namespace std;
+    int frequencies[127] = {0};
+
+    //The actual characters that may be realistically
+    //used as separators are only a handfull...
+    //And this list seems already exagerated.
+    vector<char> preferredSeparators;
+    preferredSeparators.push_back(' ');
+    preferredSeparators.push_back(',');
+    preferredSeparators.push_back(';');
+    preferredSeparators.push_back('|');
+    preferredSeparators.push_back(':');
+    preferredSeparators.push_back('\t');
+    preferredSeparators.push_back('/');
+    preferredSeparators.push_back('\\');
+    preferredSeparators.push_back('_');
+    preferredSeparators.push_back('\'');
+    preferredSeparators.push_back('\"');
+
+
+    //count number of occurences of each char in the file:
+    char c;
+    std::ifstream is(m_fileName.toStdString());
+    while (is.get(c))
+      frequencies[int(c)]++;
+    is.close();
+
+    //set the guessed separator as the most frequent among the
+    //preferred separators. -- Some unavoidable hieararchy is
+    //present: characters with lower ascii code are preferred.
+    char guessedSep = ' ';
+    int freq = 0;
+    for(char i = 0; i< 127 ; i++){
+        if( std::find(preferredSeparators.begin(), preferredSeparators.end(), i) != preferredSeparators.end())
+            if(frequencies[int(i)] > freq){
+                freq = frequencies[int(i)];
+                guessedSep = i;
+            }
+    }
+
+    //We don't like tabs, as we cannot write them in the GUI.
+    //The rest of the CsvImportAssistant and CsvReader should be already aware of this.
+    if(guessedSep == '\t')
+        guessedSep = ' ';
+
+    return guessedSep;
 }
 
 unsigned CsvImportAssistant::headersLine() const{
-       return m_headersRowSpinBox->value();
+    return 0;//m_headersRowSpinBox->value();
 }
 
 unsigned CsvImportAssistant::firstLine() const{
-        return m_firstDataRowSpinBox->value();
+    return unsigned(m_firstDataRowSpinBox->value());
 }
 
 unsigned CsvImportAssistant::lastLine() const{
-        return m_lastDataRowSpinBox->value();
+    return unsigned(m_lastDataRowSpinBox->value());
 }

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.h
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.h
@@ -2,7 +2,7 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/MaterialEditor/CsvImportAssistant.h
+//! @file      GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.h
 //! @brief     Defines class CsvImportAssistant
 //!
 //! @homepage  http://www.bornagainproject.org
@@ -26,9 +26,7 @@
 
 class QBoxLayout;
 
-//! Dialog to hold MaterialEditor.
-//! It's main function is to return MaterialModel to original state, if user decided to cancel
-//! changes.
+//! Dialog to hold ImportAssistant.
 
 class BA_CORE_API_ CsvImportAssistant : public QDialog
 {
@@ -45,22 +43,24 @@ public:
 
 
 public slots:
-    void onExportButton();
+    void onImportButton();
     void onReloadButton();
     void onRejectButton();
     void onBrowseButton();
+
 
 private:
     QBoxLayout* createLayout();
     QBoxLayout* createFileDetailsLayout();
 
+    char guessSeparator() const;
     void generate_table();
     void set_table_headers(CSVFile *csvFile);
     void set_table_data(CSVFile *csvFile);
     void convert_table();
     void remove_blanks();
+    void setRowNumbering();
     bool cell_is_blank(int iRow, int jCol);
-
 
 
     QString m_dirName;
@@ -69,9 +69,11 @@ private:
     QTableWidget* m_tableWidget;
     QLineEdit* m_filePathField;
     QLineEdit* m_separatorField;
-    QSpinBox* m_headersRowSpinBox;
+    //QSpinBox* m_headersRowSpinBox;
     QSpinBox* m_firstDataRowSpinBox;
     QSpinBox* m_lastDataRowSpinBox;
+
+
 
 
 };

--- a/GUI/coregui/Views/ImportDataWidgets/CsvReader.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvReader.cpp
@@ -59,7 +59,7 @@ void CSVFile::Read()
     if(!file.is_open()){throw std::ios_base::failure("Unable to open file \"" + filepath + "\"");}
     for(CSVIterator loop(file, separator); loop != CSVIterator(); ++loop){
         rows.push_back((*loop));
-        numberOfColumns = (*loop).size() > numberOfColumns ? (*loop).size() : numberOfColumns;
+        numberOfColumns = (*loop).size() > numberOfColumns ? unsigned((*loop).size()) : numberOfColumns;
     }
 }
 

--- a/GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.h
+++ b/GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.h
@@ -31,6 +31,7 @@ namespace ImportDataUtils
 {
 
 BA_CORE_API_ std::unique_ptr<OutputData<double>> ImportData(QString& baseNameOfLoadedFile);
+BA_CORE_API_ bool UseImportAssistant(QString& dirname, QString& fileName);
 
 //! Creates OutputData with bin-valued axes.
 BA_CORE_API_ std::unique_ptr<OutputData<double>>


### PR DESCRIPTION
 - Before opening the ImportAssistant, a MessageBox asks: 'Data format not recognized, do you want to open the Import Assitant?'

 - 'Export' button changed to 'Import'.

 - 'Headers Row Number' removed from the GUI (The relevant code was only commented in case it turns out comfortable to have headers added in the future).

 - Line numbers in the table widget match the line numbers in the file.

 - If the last line is blank, it is ignored. If there are errors in the middle of files, users should pay more attention to the data they are trying to import. In addition, ignoring lines in the middle of the file would mess up the line numbering.

 - Separators are automatically deduced from the file provided (Only from a subset of ascii characters: <SPACE> ; , : | <TAB> / _ \ ' " ).