### PR TITLE
Data imported without creating an intermediate file + some bugs corrections.

### DIFF
--- a/Core/InputOutput/OutputDataReadFactory.cpp
+++ b/Core/InputOutput/OutputDataReadFactory.cpp
@@ -28,8 +28,6 @@ IOutputDataReadStrategy* OutputDataReadFactory::getReadStrategy(const std::strin
     IOutputDataReadStrategy* result(nullptr);
     if(DataFormatUtils::isIntFile(file_name))
         result = new OutputDataReadINTStrategy();
-    else if(DataFormatUtils::isTxtFile(file_name))
-        result = new OutputDataReadNumpyTXTStrategy();
 #ifdef BORNAGAIN_TIFF_SUPPORT
     else if(DataFormatUtils::isTiffFile(file_name))
        result = new OutputDataReadTiffStrategy();

--- a/Core/InputOutput/OutputDataReadStrategy.cpp
+++ b/Core/InputOutput/OutputDataReadStrategy.cpp
@@ -37,60 +37,6 @@ OutputData<double>* OutputDataReadINTStrategy::readOutputData(std::istream& inpu
     return result;
 }
 
-
-OutputData<double>* OutputDataReadNumpyTXTStrategy::readOutputData(std::istream& input_stream)
-{
-    std::string line;
-    std::vector<std::vector<double>> data;
-
-    while( std::getline(input_stream, line) ) {
-        if(line.empty() || line[0] == '#')
-            continue;
-        std::vector<double> data_in_row = DataFormatUtils::parse_doubles(line);
-        data.push_back(data_in_row);
-    }
-    // validating
-    size_t nrows = data.size();
-    size_t ncols(0);
-    if(nrows) ncols = data[0].size();
-
-    if (ncols == 0)
-        throw std::runtime_error("OutputDataReadNumpyTXTStrategy::readOutputData() -> Error. "
-                                 "Can't parse file");
-
-    for(size_t row=0; row<nrows; row++) {
-        if(data[row].size() != ncols)
-            throw std::runtime_error("OutputDataReadNumpyTXTStrategy::readOutputData() -> Error. "
-                                     "Number of elements is different from row to row.");
-    }
-
-    std::unique_ptr<OutputData<double>> result, result1d; //= new OutputData<double>;
-    result.reset(new OutputData<double>());
-    result1d.reset(new OutputData<double>());
-    result->addAxis("x", ncols, 0.0, double(ncols));
-    result->addAxis("y", nrows, 0.0, double(nrows));
-    std::vector<unsigned> axes_indices(2);
-    for(unsigned row=0; row<nrows; row++) {
-        for(unsigned col=0; col<ncols; col++) {
-            axes_indices[0] = col;
-            axes_indices[1] = static_cast<unsigned>(nrows) - 1 - row;
-            size_t global_index = result->toGlobalIndex(axes_indices);
-            (*result)[global_index] = data[row][col];
-        }
-    }
-
-
-    if((ncols < 2) || (nrows < 2)){
-            size_t nelem = std::max(ncols,nrows);
-            result1d->addAxis("intensity",nelem, 0.0, double(nelem));
-            result1d->setRawDataVector(result->getRawDataVector());
-            std::swap(result,result1d);
-    }
-
-    return result.release();
-}
-
-
 #ifdef BORNAGAIN_TIFF_SUPPORT
 
 OutputDataReadTiffStrategy::OutputDataReadTiffStrategy()

--- a/Core/InputOutput/OutputDataReadStrategy.h
+++ b/Core/InputOutput/OutputDataReadStrategy.h
@@ -39,16 +39,6 @@ public:
     OutputData<double>* readOutputData(std::istream& input_stream);
 };
 
-//! Strategy to read OutputData from simple ASCII file with the layout as in numpy.savetxt.
-//! @ingroup input_output_internal
-
-class OutputDataReadNumpyTXTStrategy : public IOutputDataReadStrategy
-{
-public:
-    OutputData<double>* readOutputData(std::istream& input_stream);
-};
-
-
 #ifdef BORNAGAIN_TIFF_SUPPORT
 
 class TiffHandler;

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
@@ -280,7 +280,7 @@ std::unique_ptr<OutputData<double>> CsvImportAssistant::getData()
             axes_indices[0] = col;
             axes_indices[1] = static_cast<unsigned>(nDataRows) - 1 - row;
             size_t global_index = result->toGlobalIndex(axes_indices);
-            auto parsed_doubles = DataFormatUtils::parse_doubles(StringVectorVector[row][col]);
+            vector<double> parsed_doubles(DataFormatUtils::parse_doubles(StringVectorVector[row][col]));
             (*result)[global_index] = parsed_doubles[0];
         }
     }

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
@@ -26,6 +26,7 @@
 #include <iostream>     // std::cout
 #include <algorithm>    // std::reverse
 #include <vector>       // std::vector
+#include <string>
 
 namespace
 {

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
@@ -12,7 +12,7 @@
 //
 // ************************************************************************** //
 
-#include "DataFormatUtils.h"
+#include "../Core/InputOutput/DataFormatUtils.h"
 #include "CsvImportAssistant.h"
 #include "mainwindow_constants.h"
 #include "StyleUtils.h"

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
@@ -12,7 +12,7 @@
 //
 // ************************************************************************** //
 
-#include "../Core/InputOutput/DataFormatUtils.h"
+#include "../Core/InputOutput/DataFormatUtils.cpp"
 #include "CsvImportAssistant.h"
 #include "mainwindow_constants.h"
 #include "StyleUtils.h"

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
@@ -280,7 +280,10 @@ std::unique_ptr<OutputData<double>> CsvImportAssistant::getData()
             axes_indices[0] = col;
             axes_indices[1] = static_cast<unsigned>(nDataRows) - 1 - row;
             size_t global_index = result->toGlobalIndex(axes_indices);
-            vector<double> parsed_doubles(DataFormatUtils::parse_doubles(StringVectorVector[row][col]));
+            string string_to_parse;
+            vector<double> parsed_doubles;
+            string_to_parse = StringVectorVector[row][col];
+            parsed_doubles = DataFormatUtils::parse_doubles(string_to_parse);
             (*result)[global_index] = parsed_doubles[0];
         }
     }

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>    // std::reverse
 #include <vector>       // std::vector
 #include <string>
+#include "WinDllMacros.h"
 
 namespace
 {

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
@@ -23,6 +23,9 @@
 #include <QVBoxLayout>
 #include <QFileDialog>
 #include <QMessageBox>
+#include <iostream>     // std::cout
+#include <algorithm>    // std::reverse
+#include <vector>       // std::vector
 
 namespace
 {
@@ -283,10 +286,15 @@ std::unique_ptr<OutputData<double>> CsvImportAssistant::getData()
     }
 
 
-    if((nDataCols < 2) || (nDataRows < 2)){
+    if( (nDataCols < 2) || (nDataRows < 2) ){
         size_t nelem = std::max(nDataCols,nDataRows);
         result1d->addAxis("intensity",nelem, 0.0, double(nelem));
-        result1d->setRawDataVector(result->getRawDataVector());
+        std::vector<double> vector1d(result->getRawDataVector());
+
+        if(nDataRows > nDataCols)
+            std::reverse(vector1d.begin(),vector1d.end());
+
+        result1d->setRawDataVector(vector1d);
         std::swap(result,result1d);
     }
     return result;

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
@@ -29,8 +29,16 @@ namespace
 const QSize default_dialog_size(600, 800);
 }
 
-CsvImportAssistant::CsvImportAssistant(QString dir, QString file, QWidget* parent)
-    : QDialog(parent), m_dirName(dir), m_fileName(file)
+CsvImportAssistant::CsvImportAssistant(QString dir, QString file, QWidget* parent):
+QDialog(parent),
+m_dirName(dir),
+m_fileName(file),
+m_tableWidget(nullptr),
+m_filePathField(nullptr),
+m_separatorField(nullptr),
+m_firstDataRowSpinBox(nullptr),
+m_lastDataRowSpinBox(nullptr),
+m_singleDataColSpinBox(nullptr)
 {
     setWindowTitle("Data Importer");
     setMinimumSize(128, 128);
@@ -223,67 +231,65 @@ void CsvImportAssistant::onRejectButton(){
 void CsvImportAssistant::onImportButton()
 {
     try {
-        importToOutputData();
+        auto data = getData();
+        accept();
     } catch(std::exception& e){
         QString message = QString("Unable to import, check that the table contains only numerical values");
         QMessageBox::warning(nullptr, "Wrong data format", message);
-        m_data = nullptr;
     }
 }
 
 
-void CsvImportAssistant::importToOutputData()
+std::unique_ptr<OutputData<double>> CsvImportAssistant::getData()
 {
     using namespace std;
 
-    int nRows = m_tableWidget->rowCount();
-    int nCols = m_tableWidget->columnCount();
-    vector<vector<string>> A;
-    vector<string> B;
+    int nTableRows = m_tableWidget->rowCount();
+    int nTableCols = m_tableWidget->columnCount();
+    vector<vector<string>> StringVectorVector;
+    vector<string> StringVector;
 
     //save the values of the array
-    std::size_t ncols = 0;
-    std::size_t nrows = 0;
-    for(int i = 0; i < nRows; i++){
-        B.clear();
-        ncols = 0;
-        for(int j = 0; j < nCols; j++){
-            auto b = m_tableWidget->item(i,j);
-            if(b != nullptr){
-                B.push_back(b->text().toStdString());
-                ncols++;
+    std::size_t nDataCols = 0;
+    std::size_t nDataRows = 0;
+    for(int i = 0; i < nTableRows; i++){
+        StringVector.clear();
+        nDataCols = 0;
+        for(int j = 0; j < nTableCols; j++){
+            auto tableElement = m_tableWidget->item(i,j);
+            if(tableElement != nullptr){
+                StringVector.push_back(tableElement->text().toStdString());
+                nDataCols++;
             }
         }
-        A.push_back(B);
-        nrows++;
+        StringVectorVector.push_back(StringVector);
+        nDataRows++;
     }
 
     std::unique_ptr<OutputData<double>> result, result1d; //= new OutputData<double>;
     result.reset(new OutputData<double>());
     result1d.reset(new OutputData<double>());
-    result->addAxis("x", ncols, 0.0, double(ncols));
-    result->addAxis("y", nrows, 0.0, double(nrows));
+    result->addAxis("x", nDataCols, 0.0, double(nDataCols));
+    result->addAxis("y", nDataRows, 0.0, double(nDataRows));
     std::vector<unsigned> axes_indices(2);
-    for(unsigned row=0; row<nrows; row++) {
-        for(unsigned col=0; col<ncols; col++) {
+    for(unsigned row=0; row<nDataRows; row++) {
+        for(unsigned col=0; col<nDataCols; col++) {
             axes_indices[0] = col;
-            axes_indices[1] = static_cast<unsigned>(nrows) - 1 - row;
+            axes_indices[1] = static_cast<unsigned>(nDataRows) - 1 - row;
             size_t global_index = result->toGlobalIndex(axes_indices);
-            (*result)[global_index] = DataFormatUtils::parse_doubles(A[row][col])[0];
-            //std::cout << (*result)[global_index] << std::endl;
+            auto parsed_doubles = DataFormatUtils::parse_doubles(StringVectorVector[row][col]);
+            (*result)[global_index] = parsed_doubles[0];
         }
     }
 
 
-    if((ncols < 2) || (nrows < 2)){
-            size_t nelem = std::max(ncols,nrows);
-            result1d->addAxis("intensity",nelem, 0.0, double(nelem));
-            result1d->setRawDataVector(result->getRawDataVector());
-            std::swap(result,result1d);
+    if((nDataCols < 2) || (nDataRows < 2)){
+        size_t nelem = std::max(nDataCols,nDataRows);
+        result1d->addAxis("intensity",nelem, 0.0, double(nelem));
+        result1d->setRawDataVector(result->getRawDataVector());
+        std::swap(result,result1d);
     }
-
-    m_data = result.release();
-    accept();
+    return result;
 }
 
 
@@ -336,8 +342,8 @@ void CsvImportAssistant::remove_unwanted(){
 
     int nRows = m_tableWidget->rowCount();
     int nCols = m_tableWidget->columnCount();
-    vector<vector<string>> A;
-    vector<string> B;
+    vector<vector<string>> StringVectorVector;
+    vector<string> StringVector;
     vector<int> to_be_removed;
 
     //save the inices of blank cols
@@ -363,24 +369,24 @@ void CsvImportAssistant::remove_unwanted(){
 
     //save the values of the array
     for(int i = 0; i < nRows; i++){
-        B.clear();
+        StringVector.clear();
         for(int j = 0; j < nCols; j++){
             string contents = m_tableWidget->item(i,j) != nullptr ? m_tableWidget->item(i,j)->text().toStdString() : "";
-            B.push_back(contents);
+            StringVector.push_back(contents);
         }
         //Skip last row if it is an empty line:
         if(i == nRows - 1)
-            if(QString::fromStdString(std::accumulate(B.begin(), B.end(), std::string(""))).trimmed() == "")
+            if(QString::fromStdString(std::accumulate(StringVector.begin(), StringVector.end(), std::string(""))).trimmed() == "")
                 continue;
 
-        A.push_back(B);
+        StringVectorVector.push_back(StringVector);
     }
 
     //correct the size of the table
     m_tableWidget->clearContents();
     m_tableWidget->setRowCount(0);
     m_tableWidget->setColumnCount(nCols-int(to_be_removed.size()));
-    nRows = int(A.size());
+    nRows = int(StringVectorVector.size());
 
     //put values into a new table
     for(int i = 0; i < nRows; i++){
@@ -388,8 +394,8 @@ void CsvImportAssistant::remove_unwanted(){
         int J = 0;
         for(int j = 0; j < nCols; j++){
             if( std::find(to_be_removed.begin(), to_be_removed.end(), j) == to_be_removed.end()){
-                std::string a = A[unsigned(i)][unsigned(j)];
-                m_tableWidget->setItem(i,J,new QTableWidgetItem(QString::fromStdString(a)));
+                std::string retrievedString = StringVectorVector[unsigned(i)][unsigned(j)];
+                m_tableWidget->setItem(i,J,new QTableWidgetItem(QString::fromStdString(retrievedString)));
                 J++;
             }
         }
@@ -482,7 +488,7 @@ char CsvImportAssistant::guessSeparator() const{
     char c;
     std::ifstream is(m_fileName.toStdString());
     while (is.get(c))
-      frequencies[int(c)]++;
+        frequencies[int(c)]++;
     is.close();
 
     //set the guessed separator as the most frequent among the
@@ -520,11 +526,4 @@ unsigned CsvImportAssistant::lastLine() const{
 
 unsigned CsvImportAssistant::singleColumnImport() const{
     return unsigned(m_singleDataColSpinBox->value());
-}
-
-OutputData<double> *CsvImportAssistant::getData()
-{    
-     auto x = m_data->clone();
-     delete(m_data);
-     return x;
 }

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.h
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.h
@@ -17,6 +17,7 @@
 
 #include "WinDllMacros.h"
 #include "CsvReader.h"
+#include "OutputData.h"
 #include <QDialog>
 #include <QTableWidget>
 #include <QLineEdit>
@@ -41,6 +42,7 @@ public:
     unsigned firstLine() const;
     unsigned lastLine() const;
     unsigned singleColumnImport() const;
+    OutputData<double>* getData();
 
 
 public slots:
@@ -60,6 +62,7 @@ private:
     void convert_table();
     void remove_unwanted();
     void setRowNumbering();
+    void importToOutputData();
     bool cell_is_blank(int iRow, int jCol);
 
 
@@ -73,9 +76,7 @@ private:
     QSpinBox* m_firstDataRowSpinBox;
     QSpinBox* m_lastDataRowSpinBox;
     QSpinBox* m_singleDataColSpinBox;
-
-
-
+    OutputData<double>* m_data;
 
 };
 

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.h
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.h
@@ -42,8 +42,7 @@ public:
     unsigned firstLine() const;
     unsigned lastLine() const;
     unsigned singleColumnImport() const;
-    OutputData<double>* getData();
-
+    std::unique_ptr<OutputData<double>> getData();
 
 public slots:
     void onImportButton();
@@ -62,8 +61,8 @@ private:
     void convert_table();
     void remove_unwanted();
     void setRowNumbering();
-    void importToOutputData();
     bool cell_is_blank(int iRow, int jCol);
+
 
 
     QString m_dirName;
@@ -76,8 +75,6 @@ private:
     QSpinBox* m_firstDataRowSpinBox;
     QSpinBox* m_lastDataRowSpinBox;
     QSpinBox* m_singleDataColSpinBox;
-    OutputData<double>* m_data;
-
 };
 
 #endif // MATERIALEDITORDIALOG_H

--- a/GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.cpp
@@ -47,55 +47,43 @@ std::unique_ptr<OutputData<double>> ImportDataUtils::ImportData(QString& baseNam
     QString dirname = AppSvc::projectManager()->userImportDir();
     QString fileName = QFileDialog::getOpenFileName(nullptr, QStringLiteral("Open Intensity File"),
                                                     dirname, filter_string);
-
-
-
     std::unique_ptr<OutputData<double>> result;
 
-    bool goodResult = false;
-    while(!goodResult){
-        QString newImportDir = GUIHelpers::fileDir(fileName);
-        if (newImportDir != dirname)
-            AppSvc::projectManager()->setImportDir(newImportDir);
+    QString newImportDir = GUIHelpers::fileDir(fileName);
+    if (newImportDir != dirname)
+        AppSvc::projectManager()->setImportDir(newImportDir);
 
-        if (fileName.isEmpty())
+    if (fileName.isEmpty())
+        return nullptr;
+
+    QFileInfo info(fileName);
+    baseNameOfLoadedFile = info.baseName();
+
+    //Try to use the canonical tools for importing data
+    try {
+        std::unique_ptr<OutputData<double>> data(
+                    IntensityDataIOFactory::readOutputData(fileName.toStdString()));
+        result = CreateSimplifiedOutputData(*data.get());
+
+    } catch(std::exception& e)
+            //Try to import data using the GUI importer
+    {
+        std::unique_ptr<OutputData<double>> data;
+        if(!UseImportAssistant(dirname, fileName, data))
             return nullptr;
 
-        QFileInfo info(fileName);
-        baseNameOfLoadedFile = info.baseName();
-        try {
-            std::unique_ptr<OutputData<double>> data(
-                        IntensityDataIOFactory::readOutputData(fileName.toStdString()));
-            result = CreateSimplifiedOutputData(*data.get());
-            goodResult = true;
-        } catch (std::exception& ex) {
-            goodResult = false;
-            QString message = QString("Automatic load failed for file \n\n'%1'\n\nDo you wish to open the import assistant?\n\n")
-                    .arg(fileName);
-            if(QMessageBox::question(nullptr, "Open import assistant?", message, QMessageBox::No|QMessageBox::Yes, QMessageBox::Yes) != QMessageBox::Yes)
-                break;
-
-            if(!UseImportAssistant(dirname, fileName))
-                break;
-        }
+        result = CreateSimplifiedOutputData(*data.get());
     }
-
     return result;
 }
 
-bool ImportDataUtils::UseImportAssistant(QString& dirname, QString& fileName){
+bool ImportDataUtils::UseImportAssistant(QString& dirname, QString& fileName, std::unique_ptr<OutputData<double>>& result){
     try{
         CsvImportAssistant assistant(dirname,fileName);
         int res = assistant.exec();
         if(res == assistant.Accepted){
-            fileName = assistant.filepath();
-            QString message = QString("New file created:\n\n'%1'\n\nImporting data from it.")
-                    .arg(fileName);
-            QMessageBox::information(nullptr, "New file created", message);
+            result.reset(assistant.getData());
             return true;
-        }
-        else{
-            return false;
         }
     }catch(std::exception& e){
         QString message = QString("Unable to read file:\n\n'%1'\n\n%2\n\nCheck that the file exists and it is not being used by other program.\n\n")
@@ -104,6 +92,7 @@ bool ImportDataUtils::UseImportAssistant(QString& dirname, QString& fileName){
         QMessageBox::warning(nullptr, "IO Problem", message);
         return false;
     }
+    return false;
 }
 
 

--- a/GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.cpp
@@ -45,8 +45,9 @@ int getRank(const InstrumentItem& item) {
 std::unique_ptr<OutputData<double>> ImportDataUtils::ImportData(QString& baseNameOfLoadedFile)
 {
     QString dirname = AppSvc::projectManager()->userImportDir();
-    QString fileName = QFileDialog::getOpenFileName(nullptr, QStringLiteral("Open Intensity File"),
+    QString fileName = QFileDialog::getOpenFileName(Q_NULLPTR, QStringLiteral("Open Intensity File"),
                                                     dirname, filter_string);
+
     std::unique_ptr<OutputData<double>> result;
 
     QString newImportDir = GUIHelpers::fileDir(fileName);
@@ -82,7 +83,7 @@ bool ImportDataUtils::UseImportAssistant(QString& dirname, QString& fileName, st
         CsvImportAssistant assistant(dirname,fileName);
         int res = assistant.exec();
         if(res == assistant.Accepted){
-            result.reset(assistant.getData());
+            result = assistant.getData();
             return true;
         }
     }catch(std::exception& e){

--- a/GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.h
+++ b/GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.h
@@ -31,7 +31,8 @@ namespace ImportDataUtils
 {
 
 BA_CORE_API_ std::unique_ptr<OutputData<double>> ImportData(QString& baseNameOfLoadedFile);
-BA_CORE_API_ bool UseImportAssistant(QString& dirname, QString& fileName);
+BA_CORE_API_ bool UseImportAssistant(QString& dirname, QString& fileName, std::unique_ptr<OutputData<double>>& result);
+
 
 //! Creates OutputData with bin-valued axes.
 BA_CORE_API_ std::unique_ptr<OutputData<double>>


### PR DESCRIPTION
The windows build was fixed by `#include "../Core/InputOutput/DataFormatUtils.cpp"`. This allows for not only the declarations (in the .h) but also the implementations (in the .cpp) of the classes/functions there to be accessible; in particular `std::vector<double> DataFormatUtils::parse_doubles(const std::string& str)`. There are two ways (that I'm aware of) of making these classes and functions accessible to the `CsvImportAssistant`:

1. The neat way: at cmake level
2. The patchy way: adding `#include relative/path/to/file/containing/implementations.cpp` where needed (as I did here)

Mixing the Core functionality and the GUI functionality at cmake level seemed to entangle two worlds that are separated by design (as far as I can tell).

Given that `DataFormatUtils::parse_doubles(const std::string& str)` returns a vector of doubles instead of a single double, and inside it some string to stream conversion takes place, its use at firs seems a bit of an overkill for parsing a single double from a string; thus, parsing single doubles using the `atof`and `strtod` was also tried, however, the parsing was not being done correctly. Additionally, these functions have not been used so far in BornAgain (as far as `grep` can tell), thus, the most reasonable choice is to attach to the already implemented functionality (`DataFormatUtils::parse_doubles(const std::string& str)`) and use it in the `CsvImportAssistant`, even if it is an overkill for our needs. On top of that, `DataFormatUtils::parse_doubles(const std::string& str)` produces trusted results.