### PR TITLE
Fix for loading old projects

### DIFF
--- a/GUI/coregui/Models/RealDataItem.cpp
+++ b/GUI/coregui/Models/RealDataItem.cpp
@@ -150,6 +150,6 @@ void RealDataItem::updateIntensityDataFileName()
 
 void RealDataItem::updateToInstrument()
 {
-    DataItem* item = dataItem();
-    JobItemUtils::setIntensityItemAxesUnits(item, m_linkedInstrument);
+    if (DataItem* item = dataItem())
+        JobItemUtils::setIntensityItemAxesUnits(item, m_linkedInstrument);
 }


### PR DESCRIPTION
This issue is solved seemingly easy by skipping update to the instrument if no data item in RealDataItem is available. However, it makes the code more fragile, since now we rely on the integrity of saved data. Still it is required only for old projects.

I would be very grateful for the callback (if this fix is ok or should I find a better way).