### PR TITLE
GUI3D Modification to zoom level for Top and Side View

### DIFF
--- a/GUI/ba3d/ba3d/view/canvas.cpp
+++ b/GUI/ba3d/ba3d/view/canvas.cpp
@@ -44,7 +44,7 @@ const float rot_speed_v = 0.4f; // camera rotation speed in vertical direction
 
 // Default camera position in accordance with RealSpaceBuilder.h
 const float cameraDefaultPosY = -200.0f; // default camera position on Y axis
-const float cameraDefaultPosZ = 120.0f; // default camera position on Z axis
+const float cameraDefaultPosZ = 120.0f;  // default camera position on Z axis
 }
 
 namespace RealSpace
@@ -271,9 +271,9 @@ void Canvas::defaultView()
     if (model) {
         // Default view
         camera->lookAt(RealSpace::Camera::Position(
-                           RealSpace::Vector3D(0, cameraDefaultPosY, cameraDefaultPosZ), // eye
-                           RealSpace::Vector3D(0, 0, 0),                                 // center
-                           RealSpace::Vector3D::_z));                                    // up
+            RealSpace::Vector3D(0, cameraDefaultPosY, cameraDefaultPosZ), // eye
+            RealSpace::Vector3D(0, 0, 0),                                 // center
+            RealSpace::Vector3D::_z));                                    // up
         camera->endTransform(true);
 
         currentZoomLevel = 0; // reset zoom level to default value

--- a/GUI/ba3d/ba3d/view/canvas.cpp
+++ b/GUI/ba3d/ba3d/view/canvas.cpp
@@ -277,7 +277,7 @@ void Canvas::defaultView()
 void Canvas::sideView()
 {
     if (model) {
-        // Side view
+        // Side view at current zoom level
         RealSpace::Vector3D eye(0, -140, 0);
 
         if (currentZoomLevel >= 0)
@@ -297,7 +297,7 @@ void Canvas::sideView()
 void Canvas::topView()
 {
     if (model) {
-        // Top view
+        // Top view at current zoom level
         // Setting a tiny offset in y value of eye such that eye and up vectors are not parallel
         RealSpace::Vector3D eye(0, -0.5, 140);
 

--- a/GUI/ba3d/ba3d/view/canvas.cpp
+++ b/GUI/ba3d/ba3d/view/canvas.cpp
@@ -45,8 +45,8 @@ namespace RealSpace
 {
 
 Canvas::Canvas()
-    : aspectRatio(1), colorBgR(1), colorBgG(1), colorBgB(1), camera(nullptr), program(nullptr),
-      model(nullptr)
+    : aspectRatio(1), colorBgR(1), colorBgG(1), colorBgB(1), currentZoomLevel(0),
+      camera(nullptr), program(nullptr), model(nullptr)
 {
     connect(&geometryStore(), &GeometryStore::deletingGeometry, this, &Canvas::releaseBuffer);
 }
@@ -221,9 +221,11 @@ void Canvas::wheelEvent(QWheelEvent* e)
         if (e->delta() < 0) {
             // Zoom in
             camera->zoomBy(ZoomInScale());
+            currentZoomLevel += 1;
         } else {
             // Zoom out
             camera->zoomBy(ZoomOutScale());
+            currentZoomLevel -= 1;
         }
         camera->endTransform(true);
         update();
@@ -266,6 +268,8 @@ void Canvas::defaultView()
                                                    RealSpace::Vector3D(0, 0, 0),     // center
                                                    RealSpace::Vector3D::_z));        // up
         camera->endTransform(true);
+
+        currentZoomLevel = 0; // reset zoom level to default value
         update();
     }
 }
@@ -273,10 +277,18 @@ void Canvas::defaultView()
 void Canvas::sideView()
 {
     if (model) {
-        // Edge view
-        camera->lookAt(RealSpace::Camera::Position(RealSpace::Vector3D(0, -140, 0), // eye
-                                                   RealSpace::Vector3D(0, 0, 0),    // center
-                                                   RealSpace::Vector3D::_z));       // up
+        // Side view
+        RealSpace::Vector3D eye(0, -140, 0);
+
+        if (currentZoomLevel >= 0)
+            eye.y *= std::pow(ZoomInScale(), std::abs(currentZoomLevel));
+        else
+            eye.y *= std::pow(ZoomOutScale(), std::abs(currentZoomLevel));
+
+        camera->lookAt(RealSpace::Camera::Position(eye,                               // eye
+                                                   RealSpace::Vector3D(0, 0, 0),      // center
+                                                   RealSpace::Vector3D::_z));         // up
+
         camera->endTransform(true);
         update();
     }
@@ -286,10 +298,18 @@ void Canvas::topView()
 {
     if (model) {
         // Top view
-        // Setting a tiny offset in x value of eye such that eye and up vectors are not parallel
-        camera->lookAt(RealSpace::Camera::Position(RealSpace::Vector3D(0, -0.5, 140), // eye
+        // Setting a tiny offset in y value of eye such that eye and up vectors are not parallel
+        RealSpace::Vector3D eye(0, -0.5, 140);
+
+        if (currentZoomLevel >= 0)
+            eye.z *= std::pow(ZoomInScale(), std::abs(currentZoomLevel));
+        else
+            eye.z *= std::pow(ZoomOutScale(), std::abs(currentZoomLevel));
+
+        camera->lookAt(RealSpace::Camera::Position(eye,                               // eye
                                                    RealSpace::Vector3D(0, 0, 0),      // center
                                                    RealSpace::Vector3D::_z));         // up
+
         camera->endTransform(true);
         update();
     }

--- a/GUI/ba3d/ba3d/view/canvas.cpp
+++ b/GUI/ba3d/ba3d/view/canvas.cpp
@@ -26,13 +26,15 @@
 
 namespace
 {
-float ZoomInScale() {
-    if (QSysInfo::productType()=="osx")
+float ZoomInScale()
+{
+    if (QSysInfo::productType() == "osx")
         return 1.02f;
     return 1.25f;
 }
-float ZoomOutScale() {
-    if (QSysInfo::productType()=="osx")
+float ZoomOutScale()
+{
+    if (QSysInfo::productType() == "osx")
         return 0.98f;
     return 0.8f;
 }
@@ -45,8 +47,8 @@ namespace RealSpace
 {
 
 Canvas::Canvas()
-    : aspectRatio(1), colorBgR(1), colorBgG(1), colorBgB(1), currentZoomLevel(0),
-      camera(nullptr), program(nullptr), model(nullptr)
+    : aspectRatio(1), colorBgR(1), colorBgG(1), colorBgB(1), currentZoomLevel(0), camera(nullptr),
+      program(nullptr), model(nullptr)
 {
     connect(&geometryStore(), &GeometryStore::deletingGeometry, this, &Canvas::releaseBuffer);
 }
@@ -285,9 +287,9 @@ void Canvas::sideView()
         else
             eye.y *= std::pow(ZoomOutScale(), std::abs(currentZoomLevel));
 
-        camera->lookAt(RealSpace::Camera::Position(eye,                               // eye
-                                                   RealSpace::Vector3D(0, 0, 0),      // center
-                                                   RealSpace::Vector3D::_z));         // up
+        camera->lookAt(RealSpace::Camera::Position(eye,                          // eye
+                                                   RealSpace::Vector3D(0, 0, 0), // center
+                                                   RealSpace::Vector3D::_z));    // up
 
         camera->endTransform(true);
         update();
@@ -306,9 +308,9 @@ void Canvas::topView()
         else
             eye.z *= std::pow(ZoomOutScale(), std::abs(currentZoomLevel));
 
-        camera->lookAt(RealSpace::Camera::Position(eye,                               // eye
-                                                   RealSpace::Vector3D(0, 0, 0),      // center
-                                                   RealSpace::Vector3D::_z));         // up
+        camera->lookAt(RealSpace::Camera::Position(eye,                          // eye
+                                                   RealSpace::Vector3D(0, 0, 0), // center
+                                                   RealSpace::Vector3D::_z));    // up
 
         camera->endTransform(true);
         update();

--- a/GUI/ba3d/ba3d/view/canvas.cpp
+++ b/GUI/ba3d/ba3d/view/canvas.cpp
@@ -41,6 +41,10 @@ float ZoomOutScale()
 
 const float rot_speed_h = 0.4f; // camera rotation speed in horizontal direction
 const float rot_speed_v = 0.4f; // camera rotation speed in vertical direction
+
+// Default camera position in accordance with RealSpaceBuilder.h
+const float cameraDefaultPosY = -200.0f; // default camera position on Y axis
+const float cameraDefaultPosZ = 120.0f; // default camera position on Z axis
 }
 
 namespace RealSpace
@@ -266,9 +270,10 @@ void Canvas::defaultView()
 {
     if (model) {
         // Default view
-        camera->lookAt(RealSpace::Camera::Position(RealSpace::Vector3D(0, -140, 90), // eye
-                                                   RealSpace::Vector3D(0, 0, 0),     // center
-                                                   RealSpace::Vector3D::_z));        // up
+        camera->lookAt(RealSpace::Camera::Position(
+                           RealSpace::Vector3D(0, cameraDefaultPosY, cameraDefaultPosZ), // eye
+                           RealSpace::Vector3D(0, 0, 0),                                 // center
+                           RealSpace::Vector3D::_z));                                    // up
         camera->endTransform(true);
 
         currentZoomLevel = 0; // reset zoom level to default value
@@ -280,7 +285,7 @@ void Canvas::sideView()
 {
     if (model) {
         // Side view at current zoom level
-        RealSpace::Vector3D eye(0, -140, 0);
+        RealSpace::Vector3D eye(0, cameraDefaultPosY, 0);
 
         if (currentZoomLevel >= 0)
             eye.y *= std::pow(ZoomInScale(), std::abs(currentZoomLevel));
@@ -301,7 +306,7 @@ void Canvas::topView()
     if (model) {
         // Top view at current zoom level
         // Setting a tiny offset in y value of eye such that eye and up vectors are not parallel
-        RealSpace::Vector3D eye(0, -0.5, 140);
+        RealSpace::Vector3D eye(0, -0.5, -cameraDefaultPosY);
 
         if (currentZoomLevel >= 0)
             eye.z *= std::pow(ZoomInScale(), std::abs(currentZoomLevel));

--- a/GUI/ba3d/ba3d/view/canvas.h
+++ b/GUI/ba3d/ba3d/view/canvas.h
@@ -61,6 +61,7 @@ public:
 private:
     QRect viewport;
     float aspectRatio, colorBgR, colorBgG, colorBgB;
+    int currentZoomLevel; // current configuration of mousewheel w.r.t to default (0) configuration
 
     void setCamera(bool full = true);
 

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.h
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.h
@@ -39,8 +39,8 @@ public:
                   const SceneGeometry& sceneGeometry,
                   const RealSpace::Camera::Position& cameraPosition
                   = RealSpace::Camera::Position(RealSpace::Vector3D(0, -200, 120), // eye
-                                                RealSpace::Vector3D(0, 0, 0),     // center
-                                                RealSpace::Vector3D::_z));        // up
+                                                RealSpace::Vector3D(0, 0, 0),      // center
+                                                RealSpace::Vector3D::_z));         // up
 
     void populateMultiLayer(RealSpaceModel* model, const SessionItem& item,
                             const SceneGeometry& sceneGeometry,

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.h
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceBuilder.h
@@ -38,7 +38,7 @@ public:
     void populate(RealSpaceModel* model, const SessionItem& item,
                   const SceneGeometry& sceneGeometry,
                   const RealSpace::Camera::Position& cameraPosition
-                  = RealSpace::Camera::Position(RealSpace::Vector3D(0, -140, 90), // eye
+                  = RealSpace::Camera::Position(RealSpace::Vector3D(0, -200, 120), // eye
                                                 RealSpace::Vector3D(0, 0, 0),     // center
                                                 RealSpace::Vector3D::_z));        // up
 

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.cpp
@@ -154,8 +154,10 @@ void RealSpaceCanvas::updateScene()
             builder3D.populate(m_realSpaceModel.get(), *item, *m_sceneGeometry,
                                m_view->getCamera().getPos());
         // otherwise use default orientation of camera
-        else
+        else {
             builder3D.populate(m_realSpaceModel.get(), *item, *m_sceneGeometry);
+            defaultView(); // Enforces default view and also sets the zoomLevel to default i.e. 0
+        }
     } catch (const std::exception& ex) {
         m_warningSign->setWarningMessage(ex.what());
     } catch (...) {

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.h
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.h
@@ -30,7 +30,7 @@ class WarningSign;
 class SceneGeometry
 {
 public:
-    SceneGeometry(double size = 50.0, double top_thickness = 25.0, double bottom_thickness = 25.0,
+    SceneGeometry(double size = 100.0, double top_thickness = 25.0, double bottom_thickness = 25.0,
                   double min_thickness = 2.0)
     {
         l_size = size;                         // layer size

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceToolBar.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceToolBar.cpp
@@ -15,29 +15,26 @@
 #include "RealSpaceToolBar.h"
 #include "mainwindow_constants.h"
 
-#include <QToolButton>
 #include <QCheckBox>
+#include <QToolButton>
 
 namespace
 {
-    const double increaseLayerSizeScale = 1.25;
-    const double decreaseLayerSizeScale = 0.8;
+const double increaseLayerSizeScale = 1.25;
+const double decreaseLayerSizeScale = 0.8;
 }
 
 RealSpaceToolBar::RealSpaceToolBar(QWidget* parent)
-    : StyledToolBar(parent)
-    , m_defaultViewButton(new QToolButton)
-    , m_sideViewButton(new QToolButton)
-    , m_topViewButton(new QToolButton)
-    , m_lockViewCheckBox(new QCheckBox)
-    , m_increaseLayerSizeButton(new QToolButton)
-    , m_decreaseLayerSizeButton(new QToolButton)
+    : StyledToolBar(parent), m_defaultViewButton(new QToolButton),
+      m_sideViewButton(new QToolButton), m_topViewButton(new QToolButton),
+      m_lockViewCheckBox(new QCheckBox), m_increaseLayerSizeButton(new QToolButton),
+      m_decreaseLayerSizeButton(new QToolButton)
 {
     setMinimumSize(Constants::styled_toolbar_height, Constants::styled_toolbar_height);
 
     // Default View
     m_defaultViewButton->setText("Default View");
-    //m_defaultViewButton->setIcon(QIcon(":/SampleDesigner/images/toolbar_recycle.png"));
+    // m_defaultViewButton->setIcon(QIcon(":/SampleDesigner/images/toolbar_recycle.png"));
     m_defaultViewButton->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
     m_defaultViewButton->setToolTip("Reset view and zoom level to default");
     connect(m_defaultViewButton, &QToolButton::clicked, this, &RealSpaceToolBar::defaultViewAction);
@@ -47,7 +44,7 @@ RealSpaceToolBar::RealSpaceToolBar(QWidget* parent)
 
     // Side View
     m_sideViewButton->setText("Side View");
-    //m_sideViewButton->setIcon(QIcon(":/SampleDesigner/images/toolbar_recycle.png"));
+    // m_sideViewButton->setIcon(QIcon(":/SampleDesigner/images/toolbar_recycle.png"));
     m_sideViewButton->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
     m_sideViewButton->setToolTip("View sample from the side at current zoom level");
     connect(m_sideViewButton, &QToolButton::clicked, this, &RealSpaceToolBar::sideViewAction);
@@ -57,7 +54,7 @@ RealSpaceToolBar::RealSpaceToolBar(QWidget* parent)
 
     // Top View
     m_topViewButton->setText("Top View");
-    //m_topViewButton->setIcon(QIcon(":/SampleDesigner/images/toolbar_recycle.png"));
+    // m_topViewButton->setIcon(QIcon(":/SampleDesigner/images/toolbar_recycle.png"));
     m_topViewButton->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
     m_topViewButton->setToolTip("View sample from the top at current zoom level");
     connect(m_topViewButton, &QToolButton::clicked, this, &RealSpaceToolBar::topViewAction);
@@ -69,32 +66,31 @@ RealSpaceToolBar::RealSpaceToolBar(QWidget* parent)
     m_lockViewCheckBox->setText("Lock View");
     m_lockViewCheckBox->setToolTip("Lock/unlock current sample selection");
     m_lockViewCheckBox->setCheckable(true);
-    connect(m_lockViewCheckBox, &QCheckBox::clicked,
-            this, [&](){emit RealSpaceToolBar::lockViewAction(m_lockViewCheckBox->isChecked());});
+    connect(m_lockViewCheckBox, &QCheckBox::clicked, this,
+            [&]() { emit RealSpaceToolBar::lockViewAction(m_lockViewCheckBox->isChecked()); });
     addWidget(m_lockViewCheckBox);
 
     addSeparator();
 
     // Increase layer size
     m_increaseLayerSizeButton->setText("Enlarge");
-    //m_increaseLayerSizeButton->setIcon(QIcon(":/SampleDesigner/images/toolbar_recycle.png"));
+    // m_increaseLayerSizeButton->setIcon(QIcon(":/SampleDesigner/images/toolbar_recycle.png"));
     m_increaseLayerSizeButton->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
     m_increaseLayerSizeButton->setToolTip("Increase layer size");
-    connect(m_increaseLayerSizeButton, &QToolButton::clicked,
-            this, [&](){emit RealSpaceToolBar::changeLayerSizeAction(increaseLayerSizeScale);});
+    connect(m_increaseLayerSizeButton, &QToolButton::clicked, this,
+            [&]() { emit RealSpaceToolBar::changeLayerSizeAction(increaseLayerSizeScale); });
     addWidget(m_increaseLayerSizeButton);
 
     addSeparator();
 
     // Decrease layer size
     m_decreaseLayerSizeButton->setText("Reduce");
-    //m_decreaseLayerSizeButton->setIcon(QIcon(":/SampleDesigner/images/toolbar_recycle.png"));
+    // m_decreaseLayerSizeButton->setIcon(QIcon(":/SampleDesigner/images/toolbar_recycle.png"));
     m_decreaseLayerSizeButton->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
     m_decreaseLayerSizeButton->setToolTip("Decrease layer size");
-    connect(m_decreaseLayerSizeButton, &QToolButton::clicked,
-            this, [&](){emit RealSpaceToolBar::changeLayerSizeAction(decreaseLayerSizeScale);});
+    connect(m_decreaseLayerSizeButton, &QToolButton::clicked, this,
+            [&]() { emit RealSpaceToolBar::changeLayerSizeAction(decreaseLayerSizeScale); });
     addWidget(m_decreaseLayerSizeButton);
 
     addSeparator();
-
 }

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceToolBar.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceToolBar.cpp
@@ -39,7 +39,7 @@ RealSpaceToolBar::RealSpaceToolBar(QWidget* parent)
     m_defaultViewButton->setText("Default View");
     //m_defaultViewButton->setIcon(QIcon(":/SampleDesigner/images/toolbar_recycle.png"));
     m_defaultViewButton->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
-    m_defaultViewButton->setToolTip("Default view of the sample");
+    m_defaultViewButton->setToolTip("Reset view and zoom level to default");
     connect(m_defaultViewButton, &QToolButton::clicked, this, &RealSpaceToolBar::defaultViewAction);
     addWidget(m_defaultViewButton);
 
@@ -49,7 +49,7 @@ RealSpaceToolBar::RealSpaceToolBar(QWidget* parent)
     m_sideViewButton->setText("Side View");
     //m_sideViewButton->setIcon(QIcon(":/SampleDesigner/images/toolbar_recycle.png"));
     m_sideViewButton->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
-    m_sideViewButton->setToolTip("View the sample from the side");
+    m_sideViewButton->setToolTip("View sample from the side at current zoom level");
     connect(m_sideViewButton, &QToolButton::clicked, this, &RealSpaceToolBar::sideViewAction);
     addWidget(m_sideViewButton);
 
@@ -59,7 +59,7 @@ RealSpaceToolBar::RealSpaceToolBar(QWidget* parent)
     m_topViewButton->setText("Top View");
     //m_topViewButton->setIcon(QIcon(":/SampleDesigner/images/toolbar_recycle.png"));
     m_topViewButton->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
-    m_topViewButton->setToolTip("View the sample from the top");
+    m_topViewButton->setToolTip("View sample from the top at current zoom level");
     connect(m_topViewButton, &QToolButton::clicked, this, &RealSpaceToolBar::topViewAction);
     addWidget(m_topViewButton);
 


### PR DESCRIPTION
- Allows the zoomLevel to be remembered when switching from side to top view or vice versa (reset on default view)
- Increase default layer display size in 3D view
- Change default camera position