### PR TITLE
Redmine issue 2171: fix for switching specular jobs

### DIFF
--- a/GUI/coregui/Views/FitWidgets/FitComparisonWidget1D.cpp
+++ b/GUI/coregui/Views/FitWidgets/FitComparisonWidget1D.cpp
@@ -105,6 +105,7 @@ void FitComparisonWidget1D::subscribeToItem()
 
 void FitComparisonWidget1D::unsubscribeFromItem()
 {
+    m_diff_plot->setItem(nullptr);
     m_comparisonController->clear();
 }
 

--- a/GUI/coregui/Views/SpecularDataWidgets/SpecularPlot.cpp
+++ b/GUI/coregui/Views/SpecularDataWidgets/SpecularPlot.cpp
@@ -246,7 +246,6 @@ SpecularDataItem* SpecularPlot::specularItem()
 const SpecularDataItem* SpecularPlot::specularItem() const
 {
     const auto result = dynamic_cast<const SpecularDataItem*>(currentItem());
-    Q_ASSERT(result);
     return result;
 }
 


### PR DESCRIPTION
This bug shows DataItemView vulnerability against changes in the model. In the future the linking mechanism should be somehow changed to be independent on SessionModel changes.