### PR TITLE
Csv import assistant added

### DIFF
--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.cpp
@@ -95,7 +95,7 @@ QBoxLayout* CsvImportAssistant::createLayout()
     m_separatorField = new QLineEdit(QString(""));
     m_separatorField->setMaxLength(1);
     m_separatorField->setMaximumWidth(50);
-    connect(m_separatorField, &QLineEdit::editingFinished, this, &CsvImportAssistant::Reload);
+    connect(m_separatorField, &QLineEdit::editingFinished, this, &CsvImportAssistant::reloadCsvFile);
 
     //First Row SpinBox
     m_firstDataRowSpinBox = new QSpinBox();
@@ -133,7 +133,7 @@ QBoxLayout* CsvImportAssistant::createLayout()
     auto tableLayout = new QVBoxLayout;
     tableLayout->setMargin(10);
     tableLayout->addWidget(new QLabel("Right click on the table or use the controls below to modify what will be imported"));
-    tableLayout->addWidget(m_columnTypeSelector);
+    //tableLayout->addWidget(m_columnTypeSelector);
     tableLayout->addWidget(m_tableWidget);
 
     //place separator_field, single_column_spinbox and first_row:
@@ -177,6 +177,19 @@ void CsvImportAssistant::Reload()
     }
 }
 
+void CsvImportAssistant::reloadCsvFile(){
+    reset();
+    try {
+        if(!m_fileName.isEmpty())
+            m_csvFile = std::make_unique<CSVFile>(m_fileName.toStdString(), separator());
+    }
+    catch (...) {
+        showErrorMessage("There was a problem opening the file \"" + m_fileName.toStdString() + "\"");
+        return;
+    }
+    Reload();
+}
+
 void CsvImportAssistant::onRejectButton(){
     reject();
 }
@@ -188,7 +201,7 @@ void CsvImportAssistant::onImportButton()
         auto data = getData();
         accept();
     } catch(std::exception& e){
-        QString message = QString("Unable to import, check the following error message may help:\n") + QString::fromStdString(e.what());
+        QString message = QString("Unable to import, the following exception was thrown:\n") + QString::fromStdString(e.what());
         QMessageBox::warning(nullptr, "Wrong data format", message);
     }
 }

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.h
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.h
@@ -57,6 +57,7 @@ private:
     QBoxLayout* createFileDetailsLayout();
 
     char guessSeparator() const;
+    void reloadCsvFile();
     void generate_table();
     void set_table_data(std::vector<std::vector<std::string>> dataArray);
     void removeBlankColumns(std::vector<std::vector<std::string>> &dataArray);

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.h
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant.h
@@ -18,11 +18,13 @@
 #include "WinDllMacros.h"
 #include "CsvReader.h"
 #include "OutputData.h"
+#include <QAction>
 #include <QDialog>
 #include <QTableWidget>
 #include <QLineEdit>
 #include <QLabel>
 #include <QSpinBox>
+#include <QComboBox>
 #include <memory>
 
 class QBoxLayout;
@@ -34,7 +36,7 @@ class BA_CORE_API_ CsvImportAssistant : public QDialog
     Q_OBJECT
 
 public:
-    CsvImportAssistant(QString& dir, QString& file, QWidget* parent = nullptr);
+    CsvImportAssistant(QString& file, QWidget* parent = nullptr);
     char separator() const;
     void setHeaders();
     unsigned firstLine() const;
@@ -61,10 +63,15 @@ private:
     void extractDesiredColumns(std::vector<std::vector<std::string>> &dataArray);
     bool hasEqualLengthLines(std::vector<std::vector<std::string> > &dataArray);
     void setRowNumbering();
+    void showErrorMessage(std::string message);
+    void setColumnAsCoordinate(int coord);
+    void setColumnAsIntensity();
+    void setColumnAsBinValues();
+    void setColumnAsBinValues(int col);
+    void setFirstRow();
+    void reset();
 
 
-
-    QString m_dirName;
     QString m_fileName;
     unsigned m_lastDataRow;
     unsigned m_intensityCol;
@@ -77,7 +84,13 @@ private:
     QSpinBox* m_firstDataRowSpinBox;
     QSpinBox* m_singleDataColSpinBox;
     QPushButton* m_importButton;
-
+    std::unique_ptr<CSVFile> m_csvFile;
+    QComboBox* m_columnTypeSelector;
+    QAction* m_setAsTheta;
+    QAction* m_setAs2Theta;
+    QAction* m_setAsQ;
+    QAction* m_setAsIntensity;
+    QAction* m_setAsIntensityBins;
 };
 
 #endif // CSVIMPORTASSISTANT_H

--- a/GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.cpp
@@ -21,6 +21,7 @@
 #include "IntensityDataIOFactory.h"
 #include "IntensityDataItem.h"
 #include "RealDataItem.h"
+#include "CsvImportAssistant.h"
 #include "projectmanager.h"
 #include <QFileDialog>
 #include <QFileInfo>
@@ -28,7 +29,7 @@
 
 namespace
 {
-const QString filter_string = "Intensity File (*.int *.gz *.tif *.tiff *.txt);;"
+const QString filter_string = "Intensity File (*.int *.gz *.tif *.tiff *.txt *.csv);;"
                               "Other (*)";
 
 int getRank(const RealDataItem& item)
@@ -44,8 +45,14 @@ int getRank(const InstrumentItem& item) {
 std::unique_ptr<OutputData<double>> ImportDataUtils::ImportData(QString& baseNameOfLoadedFile)
 {
     QString dirname = AppSvc::projectManager()->userImportDir();
-    QString fileName = QFileDialog::getOpenFileName(0, QStringLiteral("Open Intensity File"),
+    QString fileName = QFileDialog::getOpenFileName(Q_NULLPTR, QStringLiteral("Open Intensity File"),
                                                     dirname, filter_string);
+
+    std::unique_ptr<OutputData<double>> result;
+
+    QString newImportDir = GUIHelpers::fileDir(fileName);
+    if (newImportDir != dirname)
+        AppSvc::projectManager()->setImportDir(newImportDir);
 
     if (fileName.isEmpty())
         return nullptr;
@@ -53,25 +60,42 @@ std::unique_ptr<OutputData<double>> ImportDataUtils::ImportData(QString& baseNam
     QFileInfo info(fileName);
     baseNameOfLoadedFile = info.baseName();
 
-    QString newImportDir = GUIHelpers::fileDir(fileName);
-    if (newImportDir != dirname)
-        AppSvc::projectManager()->setImportDir(newImportDir);
-
-    std::unique_ptr<OutputData<double>> result;
-
+    //Try to use the canonical tools for importing data
     try {
         std::unique_ptr<OutputData<double>> data(
-            IntensityDataIOFactory::readOutputData(fileName.toStdString()));
+                    IntensityDataIOFactory::readOutputData(fileName.toStdString()));
         result = CreateSimplifiedOutputData(*data.get());
-    } catch (std::exception& ex) {
-        QString message = QString("Error while trying to read file\n\n'%1'\n\n%2")
-                              .arg(fileName)
-                              .arg(QString::fromStdString(std::string(ex.what())));
-        QMessageBox::warning(0, "IO Problem", message);
-    }
 
+    } catch(std::exception& e)
+            //Try to import data using the GUI importer
+    {
+        std::unique_ptr<OutputData<double>> data;
+        if(!UseImportAssistant(fileName, data))
+            return nullptr;
+
+        result = CreateSimplifiedOutputData(*data.get());
+    }
     return result;
 }
+
+bool ImportDataUtils::UseImportAssistant(QString& fileName, std::unique_ptr<OutputData<double>>& result){
+    try{
+        CsvImportAssistant assistant(fileName);
+        int res = assistant.exec();
+        if(res == assistant.Accepted){
+            result = assistant.getData();
+            return true;
+        }
+    }catch(std::exception& e){
+        QString message = QString("Unable to read file:\n\n'%1'\n\n%2\n\nCheck that the file exists and it is not being used by other program.\n\n")
+                .arg(fileName)
+                .arg(QString::fromStdString(std::string(e.what())));
+        QMessageBox::warning(nullptr, "IO Problem", message);
+        return false;
+    }
+    return false;
+}
+
 
 bool ImportDataUtils::Compatible(const InstrumentItem& instrumentItem,
                                  const RealDataItem& realDataItem)

--- a/GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.h
+++ b/GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.h
@@ -31,6 +31,8 @@ namespace ImportDataUtils
 {
 
 BA_CORE_API_ std::unique_ptr<OutputData<double>> ImportData(QString& baseNameOfLoadedFile);
+BA_CORE_API_ bool UseImportAssistant(QString& fileName, std::unique_ptr<OutputData<double>>& result);
+
 
 //! Creates OutputData with bin-valued axes.
 BA_CORE_API_ std::unique_ptr<OutputData<double>>


### PR DESCRIPTION
## Tests made:
 - Import of a 150x150 number array  
  - Automatically guess separator without crashing
  - "Separator" field updates table as expected.
  - "Column" field updates table as expected.
  - "From row" field updates table as expected.
 - Does not crash when reading empty file.
- Does not crash when reading corrupted / binary file (shows rubbish on the table)
- *Read* 1200 x 1200 string array in 3 seconds
- *Import* 1200 x 1200 number array in 6 seconds (bad implementation, must be revisited)
- When hitting import an error message is shown if the data is not "good" (does not crash).
- Context menu works as expected (updates headers, updates table and updates controls in the bottom of the dialog).
- Import 1D works in two possible ways: a) setting 1 column as coordinate and 1 as intensity and then hitting the import button, or 2) setting one column as "intensity bins".

## Desired:
- Do not make columns/rows disappear from the table but instead grey them out.
- Let the user choose between importing 1d or 2d BEFORE opening the dialog
- If the 2d array can be imported automatically (e.g. with the machinery for importing numpy arrays saved as txt), do it without opening the dialog.