### PR TITLE
Redmine issue 2177: PointwiseAxisItem and associated save/load mashinery

### DIFF
--- a/GUI/coregui/Models/ApplicationModels.cpp
+++ b/GUI/coregui/Models/ApplicationModels.cpp
@@ -231,8 +231,9 @@ QList<SessionModel*> ApplicationModels::modelList()
 
 QVector<SessionItem*> ApplicationModels::nonXMLData() const
 {
-    Q_ASSERT(m_realDataModel && m_jobModel);
-    return QVector<SessionItem*>() << m_realDataModel->nonXMLData() << m_jobModel->nonXMLData();
+    Q_ASSERT(m_realDataModel && m_jobModel && m_instrumentModel);
+    return QVector<SessionItem*>() << m_realDataModel->nonXMLData() << m_jobModel->nonXMLData()
+                                   << m_instrumentModel->nonXMLData();
 }
 
 void ApplicationModels::disconnectModel(SessionModel* model)

--- a/GUI/coregui/Models/AxesItems.h
+++ b/GUI/coregui/Models/AxesItems.h
@@ -33,7 +33,7 @@ public:
     explicit BasicAxisItem(const QString& type = Constants::BasicAxisType);
     virtual ~BasicAxisItem();
 
-    std::unique_ptr<IAxis> createAxis(double scale = 1.0) const;
+    std::unique_ptr<IAxis> createAxis(double scale) const;
 
 protected:
     void register_basic_properties();

--- a/GUI/coregui/Models/AxesItems.h
+++ b/GUI/coregui/Models/AxesItems.h
@@ -33,7 +33,7 @@ public:
     explicit BasicAxisItem(const QString& type = Constants::BasicAxisType);
     virtual ~BasicAxisItem();
 
-    std::unique_ptr<IAxis> createAxis(double scale) const;
+    virtual std::unique_ptr<IAxis> createAxis(double scale) const;
 
 protected:
     void register_basic_properties();

--- a/GUI/coregui/Models/BeamItems.cpp
+++ b/GUI/coregui/Models/BeamItems.cpp
@@ -153,10 +153,15 @@ void SpecularBeamItem::setInclinationAngle(double value)
     BeamItem::setInclinationAngle(value);
 }
 
-BasicAxisItem& SpecularBeamItem::getInclinationAngleAxis()
+SessionItem* SpecularBeamItem::inclinationAxisGroup()
 {
-    return getItem(BeamItem::P_INCLINATION_ANGLE)
-        ->item<BasicAxisItem>(SpecularBeamInclinationItem::P_ALPHA_AXIS);
+    return getItem(P_INCLINATION_ANGLE)->getItem(SpecularBeamInclinationItem::P_ALPHA_AXIS);
+}
+
+BasicAxisItem* SpecularBeamItem::currentInclinationAxisItem()
+{
+    return &getItem(BeamItem::P_INCLINATION_ANGLE)
+        ->groupItem<BasicAxisItem>(SpecularBeamInclinationItem::P_ALPHA_AXIS);
 }
 
 FootprintItem* SpecularBeamItem::currentFootprintItem() const

--- a/GUI/coregui/Models/BeamItems.cpp
+++ b/GUI/coregui/Models/BeamItems.cpp
@@ -169,6 +169,11 @@ FootprintItem* SpecularBeamItem::currentFootprintItem() const
     return &groupItem<FootprintItem>(P_FOOPTPRINT);
 }
 
+void SpecularBeamItem::updateFileName(const QString& filename)
+{
+    item<SpecularBeamInclinationItem>(BeamItem::P_INCLINATION_ANGLE).updateFileName(filename);
+}
+
 // GISAS beam item
 /* ------------------------------------------------------------------------- */
 

--- a/GUI/coregui/Models/BeamItems.h
+++ b/GUI/coregui/Models/BeamItems.h
@@ -63,7 +63,8 @@ public:
     double getInclinationAngle() const override;
     void setInclinationAngle(double value) override;
 
-    BasicAxisItem& getInclinationAngleAxis();
+    SessionItem* inclinationAxisGroup();
+    BasicAxisItem* currentInclinationAxisItem();
     FootprintItem* currentFootprintItem() const;
 };
 

--- a/GUI/coregui/Models/BeamItems.h
+++ b/GUI/coregui/Models/BeamItems.h
@@ -66,6 +66,8 @@ public:
     SessionItem* inclinationAxisGroup();
     BasicAxisItem* currentInclinationAxisItem();
     FootprintItem* currentFootprintItem() const;
+
+    void updateFileName(const QString& filename);
 };
 
 class BA_CORE_API_ GISASBeamItem : public BeamItem

--- a/GUI/coregui/Models/DomainObjectBuilder.cpp
+++ b/GUI/coregui/Models/DomainObjectBuilder.cpp
@@ -140,12 +140,9 @@ DomainObjectBuilder::createUnitConverter(const InstrumentItem* instrumentItem)
     if (instrumentItem->modelType() == Constants::GISASInstrumentType)
         return UnitConverterUtils::createConverterForGISAS(*instrument);
 
-    if (instrumentItem->modelType() == Constants::SpecularInstrumentType)
+    if (auto specular_instrument = dynamic_cast<const SpecularInstrumentItem*>(instrumentItem))
     {
-        auto axis_item = dynamic_cast<BasicAxisItem*>(
-            instrumentItem->beamItem()
-                ->getItem(SpecularBeamItem::P_INCLINATION_ANGLE)
-                ->getItem(SpecularBeamInclinationItem::P_ALPHA_AXIS));
+        auto axis_item = specular_instrument->beamItem()->currentInclinationAxisItem();
         return std::make_unique<UnitConverter1D>(instrument->getBeam(),
                                                  *axis_item->createAxis(Units::degree));
     }

--- a/GUI/coregui/Models/DomainSimulationBuilder.cpp
+++ b/GUI/coregui/Models/DomainSimulationBuilder.cpp
@@ -141,9 +141,7 @@ createSpecularSimulation(std::unique_ptr<MultiLayer> P_multilayer,
         = std::make_unique<SpecularSimulation>(*P_multilayer);
 
     auto beam_item = specular_instrument->beamItem();
-    const auto axis_item
-        = dynamic_cast<BasicAxisItem*>(beam_item->getItem(SpecularBeamItem::P_INCLINATION_ANGLE)
-                                           ->getItem(SpecularBeamInclinationItem::P_ALPHA_AXIS));
+    const auto axis_item = beam_item->currentInclinationAxisItem();
     const auto footprint = beam_item->currentFootprintItem();
 
     specular_simulation->setBeamIntensity(beam_item->getIntensity());

--- a/GUI/coregui/Models/GroupInfoCatalogue.cpp
+++ b/GUI/coregui/Models/GroupInfoCatalogue.cpp
@@ -179,6 +179,12 @@ GroupInfoCatalogue::GroupInfoCatalogue()
     info.add(Constants::FootprintSquareType, "Square footprint");
     info.setDefaultType(Constants::FootprintNoneType);
     addInfo(info);
+
+    info = GroupInfo(Constants::AxesGroup);
+    info.add(Constants::BasicAxisType, "Uniform axis");
+    info.add(Constants::PointwiseAxisType, "Non-uniform axis");
+    info.setDefaultType(Constants::BasicAxisType);
+    addInfo(info);
 }
 
 GroupInfo GroupInfoCatalogue::groupInfo(const QString& groupType) const

--- a/GUI/coregui/Models/InstrumentItems.cpp
+++ b/GUI/coregui/Models/InstrumentItems.cpp
@@ -21,6 +21,7 @@
 #include "GUIHelpers.h"
 #include "IDetector2D.h"
 #include "Instrument.h"
+#include "ItemFileNameUtils.h"
 #include "MaskItems.h"
 #include "SessionModel.h"
 
@@ -95,6 +96,7 @@ SpecularInstrumentItem::SpecularInstrumentItem()
     : InstrumentItem(Constants::SpecularInstrumentType)
 {
     initBeamGroup(Constants::SpecularBeamType);
+    item<SpecularBeamItem>(P_BEAM).updateFileName(ItemFileNameUtils::instrumentDataFileName(*this));
 }
 
 SpecularBeamItem* SpecularInstrumentItem::beamItem() const

--- a/GUI/coregui/Models/InstrumentItems.cpp
+++ b/GUI/coregui/Models/InstrumentItems.cpp
@@ -111,8 +111,8 @@ std::unique_ptr<Instrument> SpecularInstrumentItem::createInstrument() const
 
 std::vector<int> SpecularInstrumentItem::shape() const
 {
-    const auto& axis_item = beamItem()->getInclinationAngleAxis();
-    return {axis_item.getItemValue(BasicAxisItem::P_NBINS).toInt()};
+    const auto axis_item = beamItem()->currentInclinationAxisItem();
+    return {axis_item->getItemValue(BasicAxisItem::P_NBINS).toInt()};
 }
 
 void SpecularInstrumentItem::setShape(const std::vector<int>& data_shape)
@@ -120,8 +120,8 @@ void SpecularInstrumentItem::setShape(const std::vector<int>& data_shape)
     if (shape().size() != data_shape.size())
         throw GUIHelpers::Error("Error in SpecularInstrumentItem::setShape: The type of "
                                 "instrument is incompatible with passed data shape.");
-    auto& axis_item = beamItem()->getInclinationAngleAxis();
-    axis_item.setItemValue(BasicAxisItem::P_NBINS, data_shape[0]);
+    auto axis_item = beamItem()->currentInclinationAxisItem();
+    axis_item->setItemValue(BasicAxisItem::P_NBINS, data_shape[0]);
 }
 
 const QString Instrument2DItem::P_DETECTOR = "Detector";

--- a/GUI/coregui/Models/InstrumentModel.cpp
+++ b/GUI/coregui/Models/InstrumentModel.cpp
@@ -14,6 +14,7 @@
 
 #include "InstrumentModel.h"
 #include "InstrumentItems.h"
+#include "SpecularBeamInclinationItem.h"
 
 InstrumentModel::InstrumentModel(QObject *parent)
     : SessionModel(SessionXML::InstrumentModelTag, parent)
@@ -21,11 +22,28 @@ InstrumentModel::InstrumentModel(QObject *parent)
     setObjectName(SessionXML::InstrumentModelTag);
 }
 
+InstrumentModel::~InstrumentModel() = default;
 
 InstrumentModel *InstrumentModel::createCopy(SessionItem *parent)
 {
     InstrumentModel *result = new InstrumentModel();
     result->initFrom(this, parent);
+    return result;
+}
+
+QVector<SessionItem *> InstrumentModel::nonXMLData() const
+{
+    QVector<SessionItem*> result;
+
+    for (auto instrument_item : topItems<SpecularInstrumentItem>()) {
+        auto axis_group = instrument_item->beamItem()
+                              ->getItem(BeamItem::P_INCLINATION_ANGLE)
+                              ->getItem(SpecularBeamInclinationItem::P_ALPHA_AXIS);
+
+        if (auto pointwise_axis = axis_group->getChildOfType(Constants::PointwiseAxisType))
+            result.push_back(pointwise_axis);
+    }
+
     return result;
 }
 

--- a/GUI/coregui/Models/InstrumentModel.h
+++ b/GUI/coregui/Models/InstrumentModel.h
@@ -24,10 +24,11 @@ class BA_CORE_API_ InstrumentModel : public SessionModel
     Q_OBJECT
 
 public:
-    explicit InstrumentModel(QObject *parent = 0);
-    virtual ~InstrumentModel(){}
+    explicit InstrumentModel(QObject *parent = nullptr);
+    ~InstrumentModel() override;
 
-    virtual InstrumentModel *createCopy(SessionItem *parent=0);
+    InstrumentModel* createCopy(SessionItem* parent = nullptr) override;
+    QVector<SessionItem*> nonXMLData() const override;
 
     InstrumentItem *instrumentItem();
 };

--- a/GUI/coregui/Models/ItemCatalogue.cpp
+++ b/GUI/coregui/Models/ItemCatalogue.cpp
@@ -49,6 +49,7 @@
 #include "ParticleDistributionItem.h"
 #include "ParticleItem.h"
 #include "ParticleLayoutItem.h"
+#include "PointwiseAxisItem.h"
 #include "ProjectionItems.h"
 #include "PropertyItem.h"
 #include "RealDataItem.h"
@@ -182,6 +183,7 @@ ItemCatalogue::ItemCatalogue()
     add(Constants::DataItem1DPropertiesType, create_new<Data1DProperties>);
 
     add(Constants::BasicAxisType, create_new<BasicAxisItem>);
+    add(Constants::PointwiseAxisType, create_new<PointwiseAxisItem>);
     add(Constants::AmplitudeAxisType, create_new<AmplitudeAxisItem>);
 
     add(Constants::BeamWavelengthType, create_new<BeamWavelengthItem>);

--- a/GUI/coregui/Models/ItemFileNameUtils.cpp
+++ b/GUI/coregui/Models/ItemFileNameUtils.cpp
@@ -2,8 +2,8 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Models/JobItemFunctions.cpp
-//! @brief     Defines auxiliary functions in JobItemFunctions namespace.
+//! @file      GUI/coregui/Models/ItemFileNameUtils.cpp
+//! @brief     Defines auxiliary functions in ItemFileNameUtils namespace.
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -12,7 +12,7 @@
 //
 // ************************************************************************** //
 
-#include "JobItemFunctions.h"
+#include "ItemFileNameUtils.h"
 #include "GUIHelpers.h"
 #include "InstrumentItems.h"
 #include "JobItem.h"
@@ -32,26 +32,26 @@ QString intensityDataFileName(const QString& itemName, const QString& prefix);
 
 //! Constructs the name of the file with simulated intensities.
 
-QString JobItemFunctions::jobResultsFileName(const JobItem& jobItem)
+QString ItemFileNameUtils::jobResultsFileName(const JobItem& jobItem)
 {
     return intensityDataFileName(jobItem.itemName(), jobdata_file_prefix);
 }
 
 //! Constructs the name of the file with reference data.
 
-QString JobItemFunctions::jobReferenceFileName(const JobItem& jobItem)
+QString ItemFileNameUtils::jobReferenceFileName(const JobItem& jobItem)
 {
     return intensityDataFileName(jobItem.itemName(), refdata_file_prefix);
 }
 
 //! Constructs the name of the intensity file belonging to real data item.
 
-QString JobItemFunctions::realDataFileName(const RealDataItem& realDataItem)
+QString ItemFileNameUtils::realDataFileName(const RealDataItem& realDataItem)
 {
     return intensityDataFileName(realDataItem.itemName(), realdata_file_prefix);
 }
 
-QString JobItemFunctions::instrumentDataFileName(const InstrumentItem& instrumentItem)
+QString ItemFileNameUtils::instrumentDataFileName(const InstrumentItem& instrumentItem)
 {
     auto instrument_id = instrumentItem.getItemValue(InstrumentItem::P_IDENTIFIER).toString();
     return intensityDataFileName(instrument_id, instrument_file_prefix);
@@ -59,7 +59,7 @@ QString JobItemFunctions::instrumentDataFileName(const InstrumentItem& instrumen
 
 //! Returns list of fileName filters related to nonXML data stored by JobModel and RealDataModel.
 
-QStringList JobItemFunctions::nonXMLFileNameFilters()
+QStringList ItemFileNameUtils::nonXMLFileNameFilters()
 {
     QStringList result = QStringList()
         << QString(jobdata_file_prefix+"_*.int.gz")

--- a/GUI/coregui/Models/ItemFileNameUtils.h
+++ b/GUI/coregui/Models/ItemFileNameUtils.h
@@ -2,8 +2,8 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Models/JobItemFunctions.h
-//! @brief     Defines auxiliary functions in JobItemFunctions namespace.
+//! @file      GUI/coregui/Models/ItemFileNameUtils.h
+//! @brief     Defines auxiliary functions in ItemFileNameUtils namespace.
 //!
 //! @homepage  http://www.bornagainproject.org
 //! @license   GNU General Public License v3 or higher (see COPYING)
@@ -24,7 +24,7 @@ class RealDataItem;
 
 //! Contains set of convenience methods for JobItem and its children.
 
-namespace JobItemFunctions
+namespace ItemFileNameUtils
 {
 
 BA_CORE_API_ QString jobResultsFileName(const JobItem& jobItem);

--- a/GUI/coregui/Models/JobItem.cpp
+++ b/GUI/coregui/Models/JobItem.cpp
@@ -19,7 +19,7 @@
 #include "GUIHelpers.h"
 #include "InstrumentItems.h"
 #include "IntensityDataItem.h"
-#include "JobItemFunctions.h"
+#include "ItemFileNameUtils.h"
 #include "JobItemUtils.h"
 #include "MaskUnitsConverter.h"
 #include "MultiLayerItem.h"
@@ -269,12 +269,12 @@ void JobItem::updateIntensityDataFileName()
 {
     if (DataItem* item = dataItem())
         item->setItemValue(DataItem::P_FILE_NAME,
-                           JobItemFunctions::jobResultsFileName(*this));
+                           ItemFileNameUtils::jobResultsFileName(*this));
 
     if (RealDataItem* realItem = realDataItem())
         if (DataItem* item = realItem->dataItem())
             item->setItemValue(DataItem::P_FILE_NAME,
-                               JobItemFunctions::jobReferenceFileName(*this));
+                               ItemFileNameUtils::jobReferenceFileName(*this));
 }
 
 SimulationOptionsItem* JobItem::simulationOptionsItem()

--- a/GUI/coregui/Models/JobItemFunctions.cpp
+++ b/GUI/coregui/Models/JobItemFunctions.cpp
@@ -14,46 +14,47 @@
 
 #include "JobItemFunctions.h"
 #include "GUIHelpers.h"
+#include "InstrumentItems.h"
 #include "JobItem.h"
 #include "RealDataItem.h"
 #include "item_constants.h"
 
-namespace JobItemFunctions
+namespace
 {
 const QString jobdata_file_prefix = "jobdata";
 const QString refdata_file_prefix = "refdata";
 const QString realdata_file_prefix = "realdata";
-
-QString intensityDataFileName(const QString& itemName, const QString& prefix);
-}
+const QString instrument_file_prefix = "instrdata";
 
 //! Constructs the name of the file for intensity data.
-
-QString JobItemFunctions::intensityDataFileName(const QString& itemName, const QString& prefix)
-{
-    QString bodyName = GUIHelpers::getValidFileName(itemName);
-    return QString("%1_%2_0.int.gz").arg(prefix).arg(bodyName);
-}
+QString intensityDataFileName(const QString& itemName, const QString& prefix);
+} // namespace
 
 //! Constructs the name of the file with simulated intensities.
 
 QString JobItemFunctions::jobResultsFileName(const JobItem& jobItem)
 {
-    return JobItemFunctions::intensityDataFileName(jobItem.itemName(), jobdata_file_prefix);
+    return intensityDataFileName(jobItem.itemName(), jobdata_file_prefix);
 }
 
 //! Constructs the name of the file with reference data.
 
 QString JobItemFunctions::jobReferenceFileName(const JobItem& jobItem)
 {
-    return JobItemFunctions::intensityDataFileName(jobItem.itemName(), refdata_file_prefix);
+    return intensityDataFileName(jobItem.itemName(), refdata_file_prefix);
 }
 
 //! Constructs the name of the intensity file belonging to real data item.
 
 QString JobItemFunctions::realDataFileName(const RealDataItem& realDataItem)
 {
-    return JobItemFunctions::intensityDataFileName(realDataItem.itemName(), realdata_file_prefix);
+    return intensityDataFileName(realDataItem.itemName(), realdata_file_prefix);
+}
+
+QString JobItemFunctions::instrumentDataFileName(const InstrumentItem& instrumentItem)
+{
+    auto instrument_id = instrumentItem.getItemValue(InstrumentItem::P_IDENTIFIER).toString();
+    return intensityDataFileName(instrument_id, instrument_file_prefix);
 }
 
 //! Returns list of fileName filters related to nonXML data stored by JobModel and RealDataModel.
@@ -63,8 +64,17 @@ QStringList JobItemFunctions::nonXMLFileNameFilters()
     QStringList result = QStringList()
         << QString(jobdata_file_prefix+"_*.int.gz")
         << QString(refdata_file_prefix+"_*.int.gz")
-        << QString(realdata_file_prefix+"_*.int.gz");
+        << QString(realdata_file_prefix+"_*.int.gz")
+        << QString(instrument_file_prefix+"_*.int.gz");
 
     return result;
 }
 
+namespace
+{
+QString intensityDataFileName(const QString& itemName, const QString& prefix)
+{
+    QString bodyName = GUIHelpers::getValidFileName(itemName);
+    return QString("%1_%2_0.int.gz").arg(prefix).arg(bodyName);
+}
+} // namespace

--- a/GUI/coregui/Models/JobItemFunctions.h
+++ b/GUI/coregui/Models/JobItemFunctions.h
@@ -18,6 +18,7 @@
 #include "WinDllMacros.h"
 #include <QString>
 
+class InstrumentItem;
 class JobItem;
 class RealDataItem;
 
@@ -31,6 +32,8 @@ BA_CORE_API_ QString jobResultsFileName(const JobItem& jobItem);
 BA_CORE_API_ QString jobReferenceFileName(const JobItem& jobItem);
 
 BA_CORE_API_ QString realDataFileName(const RealDataItem& realDataItem);
+
+BA_CORE_API_ QString instrumentDataFileName(const InstrumentItem& instrumentItem);
 
 BA_CORE_API_ QStringList nonXMLFileNameFilters();
 

--- a/GUI/coregui/Models/JobModel.cpp
+++ b/GUI/coregui/Models/JobModel.cpp
@@ -85,12 +85,10 @@ JobItem *JobModel::addJob(const MultiLayerItem *multiLayerItem,
 
     SessionItem *multilayer = copyItem(multiLayerItem, jobItem, JobItem::T_SAMPLE);
     multilayer->setItemName(Constants::MultiLayerType);
-    SessionItem *instrument = copyItem(instrumentItem, jobItem, JobItem::T_INSTRUMENT);
-    instrument->setItemName(instrumentItem->modelType());
+    JobModelFunctions::setupJobItemInstrument(jobItem, instrumentItem);
     copyItem(optionItem, jobItem, JobItem::T_SIMULATION_OPTIONS);
 
     jobItem->getItem(JobItem::P_SAMPLE_NAME)->setValue(multiLayerItem->itemName());
-    jobItem->getItem(JobItem::P_INSTRUMENT_NAME)->setValue(instrumentItem->itemName());
 
     ParameterTreeUtils::createParameterTree(jobItem);
 

--- a/GUI/coregui/Models/JobModel.cpp
+++ b/GUI/coregui/Models/JobModel.cpp
@@ -13,6 +13,7 @@
 // ************************************************************************** //
 
 #include "JobModel.h"
+#include "AxesItems.h"
 #include "FitSuiteItem.h"
 #include "GUIHelpers.h"
 #include "InstrumentItems.h"
@@ -29,7 +30,7 @@
 
 JobModel::JobModel(QObject *parent)
     : SessionModel(SessionXML::JobModelTag, parent)
-    , m_queue_data(0)
+    , m_queue_data(nullptr)
 {
     m_queue_data = new JobQueueData(this);
     connect(m_queue_data, SIGNAL(focusRequest(JobItem *)), this, SIGNAL(focusRequest(JobItem *)));
@@ -64,7 +65,7 @@ JobItem *JobModel::getJobItemForIdentifier(const QString &identifier)
         JobItem *jobItem = getJobItemForIndex(itemIndex);
         if(jobItem->getIdentifier() == identifier) return jobItem;
     }
-    return 0;
+    return nullptr;
 }
 
 
@@ -137,6 +138,14 @@ QVector<SessionItem *> JobModel::nonXMLData() const
         if (auto real_data = dynamic_cast<RealDataItem*>(jobItem->getItem(JobItem::T_REALDATA))) {
             if (auto data_item = real_data->dataItem())
                 result.push_back(data_item);
+        }
+
+        auto instrument =
+            dynamic_cast<SpecularInstrumentItem*>(jobItem->getItem(JobItem::T_INSTRUMENT));
+        if (instrument) {
+            auto axis_group = instrument->beamItem()->inclinationAxisGroup();
+            if (auto pointwise_axis = axis_group->getChildOfType(Constants::PointwiseAxisType))
+                result.push_back(pointwise_axis);
         }
     }
 

--- a/GUI/coregui/Models/JobModelFunctions.cpp
+++ b/GUI/coregui/Models/JobModelFunctions.cpp
@@ -41,6 +41,15 @@ void createFitContainers(JobItem* jobItem);
 void initDataView(JobItem* jobItem);
 }
 
+void JobModelFunctions::setupJobItemInstrument(JobItem* jobItem,
+                                               const InstrumentItem* instrumentItem)
+{
+    auto model = jobItem->model();
+    SessionItem* instrument = model->copyItem(instrumentItem, jobItem, JobItem::T_INSTRUMENT);
+    instrument->setItemName(instrumentItem->modelType());
+    jobItem->getItem(JobItem::P_INSTRUMENT_NAME)->setValue(instrumentItem->itemName());
+}
+
 //! Setup items intended for storing results of the job.
 
 void JobModelFunctions::setupJobItemOutput(JobItem* jobItem)

--- a/GUI/coregui/Models/JobModelFunctions.cpp
+++ b/GUI/coregui/Models/JobModelFunctions.cpp
@@ -24,7 +24,7 @@
 #include "InstrumentItems.h"
 #include "IntensityDataItem.h"
 #include "JobItem.h"
-#include "JobItemFunctions.h"
+#include "ItemFileNameUtils.h"
 #include "JobItemUtils.h"
 #include "JobModel.h"
 #include "MaskItems.h"
@@ -110,7 +110,7 @@ void JobModelFunctions::copyRealDataItem(JobItem* jobItem, const RealDataItem* r
 
     // adapting the name to job name
     realDataItemCopy->dataItem()->setItemValue(DataItem::P_FILE_NAME,
-                                               JobItemFunctions::jobReferenceFileName(*jobItem));
+                                               ItemFileNameUtils::jobReferenceFileName(*jobItem));
 }
 
 //! Links RealDataItem to the JobItem's instrument.

--- a/GUI/coregui/Models/JobModelFunctions.h
+++ b/GUI/coregui/Models/JobModelFunctions.h
@@ -19,12 +19,16 @@
 
 class JobItem;
 class RealDataItem;
+class InstrumentItem;
 
 //! Contains set of functions to extend JobModel functionality.
 //! Handles setup of JobItem in fitting context.
 
 namespace JobModelFunctions
 {
+//! Properly copies instrument into job item
+BA_CORE_API_ void setupJobItemInstrument(JobItem* jobItem, const InstrumentItem* instrumentItem);
+
 BA_CORE_API_ void setupJobItemOutput(JobItem* jobItem);
 
 BA_CORE_API_ void setupJobItemForFit(JobItem* jobItem, const RealDataItem* realDataItem);

--- a/GUI/coregui/Models/PointwiseAxisItem.cpp
+++ b/GUI/coregui/Models/PointwiseAxisItem.cpp
@@ -1,0 +1,118 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Models/PointwiseAxisItem.cpp
+//! @brief     Implements pointwise axis item
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#include "PointwiseAxisItem.h"
+#include "IntensityDataIOFactory.h"
+#include "OutputData.h"
+#include "PointwiseAxis.h"
+
+namespace {
+std::unique_ptr<OutputData<double>> makeOutputData(const PointwiseAxis& axis);
+}
+
+const QString PointwiseAxisItem::P_FILE_NAME = "FileName";
+
+PointwiseAxisItem::PointwiseAxisItem()
+    : BasicAxisItem(Constants::PointwiseAxisType)
+{
+    getItem(P_MIN)->setEnabled(false);
+    getItem(P_NBINS)->setEnabled(false);
+    getItem(P_MAX)->setEnabled(false);
+    addProperty(P_FILE_NAME,QStringLiteral("undefined"))->setVisible(false);
+    setLastModified(QDateTime::currentDateTime());
+    mapper()->setOnPropertyChange([this](const QString& name) {
+        if (name == P_FILE_NAME)
+            setLastModified(QDateTime::currentDateTime());
+    });
+}
+
+PointwiseAxisItem::~PointwiseAxisItem() = default;
+
+void PointwiseAxisItem::setAxis(const IAxis* axis)
+{
+    setLastModified(QDateTime::currentDateTime());
+    if (!axis) {
+        m_axis.reset();
+        return;
+    }
+    m_axis = std::make_unique<PointwiseAxis>(axis->getName(), axis->getBinCenters());
+    getItem(P_MIN)->setValue(m_axis->getMin());
+    getItem(P_MIN)->setValue(m_axis->getMax());
+    getItem(P_NBINS)->setValue(static_cast<int>(m_axis->size()));
+}
+
+const IAxis* PointwiseAxisItem::getAxis()
+{
+    return m_axis.get();
+}
+
+std::unique_ptr<IAxis> PointwiseAxisItem::createAxis(double scale) const
+{
+    if (!m_axis)
+        return nullptr;
+    std::vector<double> centers = m_axis->getBinCenters();
+    std::for_each(centers.begin(), centers.end(),
+                  [scale](double& value) { value = value * scale; });
+    return std::make_unique<PointwiseAxis>(m_axis->getName(), std::move(centers));
+}
+
+bool PointwiseAxisItem::load(const QString& projectDir)
+{
+    QString filename = SaveLoadInterface::fileName(projectDir);
+    auto data = IntensityDataIOFactory::readOutputData(filename.toStdString());
+    if (!data)
+        return false;
+
+    setAxis(&data->getAxis(0));
+    return true;
+}
+
+bool PointwiseAxisItem::save(const QString& projectDir)
+{
+    if (!containsNonXMLData())
+        return false;
+
+    IntensityDataIOFactory::writeOutputData(*makeOutputData(*m_axis),
+                                            SaveLoadInterface::fileName(projectDir).toStdString());
+    return true;
+}
+
+bool PointwiseAxisItem::containsNonXMLData() const
+{
+    return static_cast<bool>(m_axis);
+}
+
+QDateTime PointwiseAxisItem::lastModified() const
+{
+    return m_last_modified;
+}
+
+QString PointwiseAxisItem::fileName() const
+{
+    return getItemValue(PointwiseAxisItem::P_FILE_NAME).toString();
+}
+
+void PointwiseAxisItem::setLastModified(const QDateTime& dtime)
+{
+    m_last_modified = dtime;
+}
+
+namespace {
+std::unique_ptr<OutputData<double>> makeOutputData(const PointwiseAxis& axis)
+{
+    std::unique_ptr<OutputData<double>> result(new OutputData<double>);
+    result->addAxis(axis);
+    return result;
+}
+}

--- a/GUI/coregui/Models/PointwiseAxisItem.h
+++ b/GUI/coregui/Models/PointwiseAxisItem.h
@@ -1,0 +1,50 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Models/PointwiseAxisItem.h
+//! @brief     Defines pointwise axis item
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#ifndef POINTWISEAXISITEM_H
+#define POINTWISEAXISITEM_H
+
+#include "AxesItems.h"
+#include "SaveLoadInterface.h"
+
+class IAxis;
+class PointwiseAxis;
+
+//! Item for non-uniform axis with specified coordinates.
+class BA_CORE_API_ PointwiseAxisItem : public BasicAxisItem, public SaveLoadInterface
+{
+public:
+    static const QString P_FILE_NAME;
+
+    explicit PointwiseAxisItem();
+    ~PointwiseAxisItem() override;
+
+    bool containsNonXMLData() const override;
+    QDateTime lastModified() const override;
+    QString fileName() const override;
+
+    void setAxis(const IAxis* axis);
+    const IAxis* getAxis();
+    std::unique_ptr<IAxis> createAxis(double scale) const override;
+
+private:
+    bool load(const QString& projectDir) override;
+    bool save(const QString& projectDir) override;
+    void setLastModified(const QDateTime& dtime);
+
+    std::unique_ptr<PointwiseAxis> m_axis;
+    QDateTime m_last_modified;
+};
+
+#endif // POINTWISEAXISITEM_H

--- a/GUI/coregui/Models/RealDataItem.cpp
+++ b/GUI/coregui/Models/RealDataItem.cpp
@@ -17,7 +17,7 @@
 #include "ImportDataUtils.h"
 #include "IntensityDataItem.h"
 #include "InstrumentItems.h"
-#include "JobItemFunctions.h"
+#include "ItemFileNameUtils.h"
 #include "JobItemUtils.h"
 #include "SessionModel.h"
 #include "SpecularDataItem.h"
@@ -145,7 +145,7 @@ MaskContainerItem* RealDataItem::maskContainerItem()
 void RealDataItem::updateIntensityDataFileName()
 {
     if (DataItem* item = dataItem())
-        item->setItemValue(DataItem::P_FILE_NAME, JobItemFunctions::realDataFileName(*this));
+        item->setItemValue(DataItem::P_FILE_NAME, ItemFileNameUtils::realDataFileName(*this));
 }
 
 void RealDataItem::updateToInstrument()

--- a/GUI/coregui/Models/SpecularBeamInclinationItem.cpp
+++ b/GUI/coregui/Models/SpecularBeamInclinationItem.cpp
@@ -43,6 +43,13 @@ double SpecularBeamInclinationItem::scaleFactor() const
     return Units::degree;
 }
 
+void SpecularBeamInclinationItem::updateFileName(const QString& filename)
+{
+    auto& group_item = item<GroupItem>(P_ALPHA_AXIS);
+    auto axis_item = group_item.getChildOfType(Constants::PointwiseAxisType);
+    axis_item->setItemValue(PointwiseAxisItem::P_FILE_NAME, filename);
+}
+
 void SpecularBeamInclinationItem::setupAxisGroup()
 {
     auto group_item =

--- a/GUI/coregui/Models/SpecularBeamInclinationItem.cpp
+++ b/GUI/coregui/Models/SpecularBeamInclinationItem.cpp
@@ -14,12 +14,14 @@
 
 #include "SpecularBeamInclinationItem.h"
 #include "AxesItems.h"
+#include "GroupItem.h"
+#include "PointwiseAxisItem.h"
 #include "Units.h"
 
 namespace
 {
-void addAxisGroupProperty(SessionItem* parent, const QString& tag);
 void setupDistributionMean(SessionItem* distribution);
+void setAxisPresentationDefaults(SessionItem* axis_item, const QString& type);
 }
 
 const QString SpecularBeamInclinationItem::P_ALPHA_AXIS = "Alpha axis";
@@ -28,7 +30,7 @@ SpecularBeamInclinationItem::SpecularBeamInclinationItem()
     : BeamDistributionItem(Constants::SpecularBeamInclinationType, m_show_mean)
 {
     register_distribution_group(Constants::DistributionWithZeroAverageGroup);
-    addAxisGroupProperty(this, P_ALPHA_AXIS);
+    setupAxisGroup();
     setupDistributionMean(getGroupItem(P_DISTRIBUTION));
 
     initDistributionItem(m_show_mean);
@@ -41,23 +43,29 @@ double SpecularBeamInclinationItem::scaleFactor() const
     return Units::degree;
 }
 
-namespace
+void SpecularBeamInclinationItem::setupAxisGroup()
 {
-void addAxisGroupProperty(SessionItem* parent, const QString& tag)
-{
-    auto item = parent->addGroupProperty(tag, Constants::BasicAxisType);
-    item->setToolTip("Inclination angle range [deg]");
-    item->getItem(BasicAxisItem::P_TITLE)->setVisible(false);
-    item->getItem(BasicAxisItem::P_NBINS)->setToolTip("Number of points in scan");
-    item->getItem(BasicAxisItem::P_MIN)->setToolTip("Starting value [deg]");
-    item->getItem(BasicAxisItem::P_MAX)->setToolTip("Ending value [deg]");
+    auto group_item =
+        dynamic_cast<GroupItem*>(this->addGroupProperty(P_ALPHA_AXIS, Constants::AxesGroup));
 
-    item->setItemValue(BasicAxisItem::P_TITLE, "alpha_i");
-    item->setItemValue(BasicAxisItem::P_MIN, 0.0);
-    item->setItemValue(BasicAxisItem::P_MAX, 3.0);
-    item->setItemValue(BasicAxisItem::P_NBINS, 500);
+    // Both underlying axis items are created, since it
+    // strongly simplifies their representation and state
+    // handling (no signal emulation required).
+    // Basic axis item is the default one.
+
+    group_item->setCurrentType(Constants::PointwiseAxisType);
+    setAxisPresentationDefaults(group_item->currentItem(), group_item->currentType());
+
+    group_item->setCurrentType(Constants::BasicAxisType);
+    setAxisPresentationDefaults(group_item->currentItem(), group_item->currentType());
+
+    group_item->setToolTip("Axis type selected");
+    group_item->setDisplayName("Axis type");
+    group_item->setEnabled(false);
 }
 
+namespace
+{
 void setupDistributionMean(SessionItem* distribution)
 {
     Q_ASSERT(distribution);
@@ -68,5 +76,24 @@ void setupDistributionMean(SessionItem* distribution)
     valueItem->setLimits(RealLimits::limited(-90.0, 90.0));
     valueItem->setDecimals(3);
     valueItem->setValue(0.0);
+}
+
+void setAxisPresentationDefaults(SessionItem* axis_item, const QString& type)
+{
+    axis_item->getItem(BasicAxisItem::P_TITLE)->setVisible(false);
+    axis_item->setItemValue(BasicAxisItem::P_TITLE, "alpha_i");
+    axis_item->getItem(BasicAxisItem::P_NBINS)->setToolTip("Number of points in scan");
+    axis_item->getItem(BasicAxisItem::P_MIN)->setToolTip("Starting value [deg]");
+    axis_item->getItem(BasicAxisItem::P_MAX)->setToolTip("Ending value [deg]");
+
+    if (type == Constants::BasicAxisType) {
+        axis_item->setItemValue(BasicAxisItem::P_MIN, 0.0);
+        axis_item->setItemValue(BasicAxisItem::P_MAX, 3.0);
+        axis_item->setItemValue(BasicAxisItem::P_NBINS, 500);
+    } else if (type == Constants::PointwiseAxisType) {
+        axis_item->getItem(BasicAxisItem::P_MIN)->setEnabled(false);
+        axis_item->getItem(BasicAxisItem::P_MAX)->setEnabled(false);
+        axis_item->getItem(BasicAxisItem::P_NBINS)->setEnabled(false);
+    }
 }
 } // namespace

--- a/GUI/coregui/Models/SpecularBeamInclinationItem.h
+++ b/GUI/coregui/Models/SpecularBeamInclinationItem.h
@@ -28,11 +28,12 @@ public:
     static const QString P_ALPHA_AXIS;
 
     SpecularBeamInclinationItem();
-    virtual ~SpecularBeamInclinationItem();
+    ~SpecularBeamInclinationItem() override;
 
     double scaleFactor() const override;
 
 private:
+    void setupAxisGroup();
     static const bool m_show_mean = false;
 };
 

--- a/GUI/coregui/Models/SpecularBeamInclinationItem.h
+++ b/GUI/coregui/Models/SpecularBeamInclinationItem.h
@@ -32,6 +32,8 @@ public:
 
     double scaleFactor() const override;
 
+    void updateFileName(const QString& filename);
+
 private:
     void setupAxisGroup();
     static const bool m_show_mean = false;

--- a/GUI/coregui/Models/TransformFromDomain.cpp
+++ b/GUI/coregui/Models/TransformFromDomain.cpp
@@ -272,8 +272,7 @@ void TransformFromDomain::setSpecularBeamItem(SpecularBeamItem* beam_item,
     beam_item->setInclinationAngle(0.0); // inclination angle is hardcoded
     beam_item->setAzimuthalAngle(0.0); // azimuthal angle is hardcoded
 
-    auto axis_item = beam_item->getItem(SpecularBeamItem::P_INCLINATION_ANGLE)
-                         ->getItem(SpecularBeamInclinationItem::P_ALPHA_AXIS);
+    auto axis_item = beam_item->currentInclinationAxisItem();
     TransformFromDomain::setAxisItem(axis_item, *simulation.getAlphaAxis(), 1. / Units::deg);
 
     // distribution parameters

--- a/GUI/coregui/Models/item_constants.h
+++ b/GUI/coregui/Models/item_constants.h
@@ -218,6 +218,7 @@ const ModelType RealLimitsGroup = "RealLimits group";
 const ModelType BackgroundGroup = "Background group";
 const ModelType MaterialDataGroup = "Material data group";
 const ModelType FootprintGroup = "Footprint group";
+const ModelType AxesGroup = "Axes group";
 
 // --- Units&Constants----------------------------------------------------------
 

--- a/GUI/coregui/Models/item_constants.h
+++ b/GUI/coregui/Models/item_constants.h
@@ -145,6 +145,7 @@ const ModelType DataPropertyContainerType = "DataPropertyContainer";
 const ModelType DataItem1DPropertiesType = "DataItem1DProperties";
 
 const ModelType BasicAxisType = "BasicAxis";
+const ModelType PointwiseAxisType = "PointwiseAxis";
 const ModelType AmplitudeAxisType = "AmplitudeAxis";
 
 const ModelType BeamDistributionType = "BeamDistribution";

--- a/GUI/coregui/Views/ImportDataWidgets/ImportDataInfo.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/ImportDataInfo.cpp
@@ -1,0 +1,43 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Views/ImportDataWidgets/ImportDataInfo.cpp
+//! @brief     Implements ImportDataInfo helper struct
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#include "ImportDataInfo.h"
+#include "OutputData.h"
+#include <vector>
+
+using COORDINATE = ImportDataInfo::COORDINATE;
+using UNITS = ImportDataInfo::UNITS;
+
+const std::vector<std::pair<COORDINATE, std::vector<UNITS>>> available_units = {
+    {COORDINATE::bins, {UNITS::bins}},
+    {COORDINATE::angle, {UNITS::rads, UNITS::degrees}},
+    {COORDINATE::double_angle, {UNITS::rads, UNITS::degrees}},
+    {COORDINATE::q, {UNITS::inv_angstroms, UNITS::inv_nm}}
+};
+
+ImportDataInfo::ImportDataInfo()
+    : m_coordinate_type(COORDINATE::bins)
+    , m_units(UNITS::bins)
+{
+}
+
+ImportDataInfo::~ImportDataInfo() = default;
+
+std::vector<UNITS> ImportDataInfo::compatibleUnits(COORDINATE coordinate_type)
+{
+    for (auto& pair: available_units)
+        if (coordinate_type == pair.first)
+            return pair.second;
+    return {};
+}

--- a/GUI/coregui/Views/ImportDataWidgets/ImportDataInfo.h
+++ b/GUI/coregui/Views/ImportDataWidgets/ImportDataInfo.h
@@ -1,0 +1,39 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Views/ImportDataWidgets/ImportDataInfo.h
+//! @brief     Defines ImportDataInfo helper struct
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#ifndef IMPORTDATAINFO_H
+#define IMPORTDATAINFO_H
+
+#include <memory>
+#include <vector>
+
+template<class T> class OutputData;
+
+//! Carries information about loaded data.
+
+struct ImportDataInfo
+{
+    enum class COORDINATE {bins, angle, double_angle, q};
+    enum class UNITS {bins, rads, degrees, inv_nm, inv_angstroms};
+
+    ImportDataInfo();
+    ~ImportDataInfo();
+    static std::vector<UNITS> compatibleUnits(COORDINATE coordinate_type);
+
+    std::unique_ptr<OutputData<double>> m_data;
+    COORDINATE m_coordinate_type;
+    UNITS m_units;
+};
+
+#endif // IMPORTDATAINFO_H

--- a/GUI/coregui/Views/InstrumentWidgets/SpecularBeamEditor.cpp
+++ b/GUI/coregui/Views/InstrumentWidgets/SpecularBeamEditor.cpp
@@ -74,9 +74,9 @@ void SpecularBeamEditor::subscribeToItem()
 
     auto inclinationItem = beam_item->getItem(SpecularBeamItem::P_INCLINATION_ANGLE);
     m_inclinationEditor->setItem(
-        inclinationItem->getItem(SpecularBeamInclinationItem::P_ALPHA_AXIS));
-    m_inclinationEditor->addItem(
         inclinationItem->getItem(SpecularBeamInclinationItem::P_DISTRIBUTION));
+    m_inclinationEditor->addItem(
+        inclinationItem->getItem(SpecularBeamInclinationItem::P_ALPHA_AXIS));
 
     m_footprint_editor->setItem(beam_item->getItem(SpecularBeamItem::P_FOOPTPRINT));
 }

--- a/GUI/coregui/mainwindow/ProjectUtils.cpp
+++ b/GUI/coregui/mainwindow/ProjectUtils.cpp
@@ -15,7 +15,7 @@
 #include "ProjectUtils.h"
 #include "projectdocument.h"
 #include "GUIHelpers.h"
-#include "JobItemFunctions.h"
+#include "ItemFileNameUtils.h"
 #include "AppSvc.h"
 #include "projectmanager.h"
 #include <QFileInfo>
@@ -81,7 +81,7 @@ QStringList ProjectUtils::nonXMLDataInDir(const QString &dirname)
         throw GUIHelpers::Error("ProjectUtils::nonXMLDataInDir() -> Error. Non existing "
                                 "directory '"+dirname+"'.");
 
-    return dir.entryList(JobItemFunctions::nonXMLFileNameFilters());
+    return dir.entryList(ItemFileNameUtils::nonXMLFileNameFilters());
 }
 
 bool ProjectUtils::removeRecursively(const QString &dirname)

--- a/Tests/UnitTests/GUI/TestGUI.cpp
+++ b/Tests/UnitTests/GUI/TestGUI.cpp
@@ -50,6 +50,7 @@
 #include "TestParticleLayoutItem.h"
 #include "TestAxesItems.h"
 #include "TestMultiLayerItem.h"
+#include "TestSavingSpecularData.h"
 
 int main(int argc, char** argv) {
     QCoreApplication app(argc, argv);

--- a/Tests/UnitTests/GUI/TestSavingSpecularData.h
+++ b/Tests/UnitTests/GUI/TestSavingSpecularData.h
@@ -1,0 +1,293 @@
+#include "google_test.h"
+#include "ApplicationModels.h"
+#include "DataItem.h"
+#include "GroupItem.h"
+#include "GUIHelpers.h"
+#include "InstrumentItems.h"
+#include "InstrumentModel.h"
+#include "IntensityDataIOFactory.h"
+#include "ItemFileNameUtils.h"
+#include "JobModel.h"
+#include "JobModelFunctions.h"
+#include "JobItem.h"
+#include "OutputData.h"
+#include "OutputDataIOService.h"
+#include "PointwiseAxis.h"
+#include "PointwiseAxisItem.h"
+#include "ProjectUtils.h"
+#include "SpecularBeamInclinationItem.h"
+#include "test_utils.h"
+#include <QTest>
+
+class TestSavingSpecularData : public ::testing::Test
+{
+public:
+    TestSavingSpecularData();
+    ~TestSavingSpecularData();
+
+protected:
+    SpecularInstrumentItem* createSpecularInstrument(ApplicationModels& models);
+    GroupItem* getAxisGroup(SpecularInstrumentItem* instrument);
+    bool isSame(const QString& filename, const IAxis* axis);
+
+    std::unique_ptr<PointwiseAxis> m_axis;
+};
+
+TestSavingSpecularData::TestSavingSpecularData()
+    : m_axis(new PointwiseAxis("x", std::vector<double>{0.1, 0.2, 1.0}))
+{
+}
+
+TestSavingSpecularData::~TestSavingSpecularData() = default;
+
+SpecularInstrumentItem* TestSavingSpecularData::createSpecularInstrument(ApplicationModels& models)
+{
+    return dynamic_cast<SpecularInstrumentItem*>(
+        models.instrumentModel()->insertNewItem(Constants::SpecularInstrumentType));
+}
+
+GroupItem* TestSavingSpecularData::getAxisGroup(SpecularInstrumentItem* instrument)
+{
+    auto axis_item = instrument->getItem(SpecularInstrumentItem::P_BEAM)
+                         ->getItem(BeamItem::P_INCLINATION_ANGLE)
+                         ->getItem(SpecularBeamInclinationItem::P_ALPHA_AXIS);
+    return dynamic_cast<GroupItem*>(axis_item);
+}
+
+bool TestSavingSpecularData::isSame(const QString& filename, const IAxis* axis)
+{
+    std::unique_ptr<OutputData<double>> dataOnDisk(
+        IntensityDataIOFactory::readOutputData(filename.toStdString()));
+    OutputData<double> refData;
+    refData.addAxis(*axis);
+    return TestUtils::isTheSame(*dataOnDisk, refData);
+}
+
+TEST_F(TestSavingSpecularData, test_SpecularInsturment)
+{
+    ApplicationModels models;
+
+    // initial state
+    auto dataItems = models.nonXMLData();
+    EXPECT_EQ(dataItems.size(), 0);
+
+    // adding instrument
+    auto instrument = createSpecularInstrument(models);
+
+    // instrument contains hidden pointwise axis item
+    EXPECT_EQ(models.instrumentModel()->nonXMLData().size(), 1);
+
+    // explicitly switching to pointwise axis item
+    auto axis_group = getAxisGroup(instrument);
+    axis_group->setCurrentType(Constants::PointwiseAxisType);
+    EXPECT_EQ(models.instrumentModel()->nonXMLData().size(), 1);
+
+    // hiding pointwise axis item back
+    axis_group->setCurrentType(Constants::BasicAxisType);
+    EXPECT_EQ(models.instrumentModel()->nonXMLData().size(), 1);
+
+    // checking data items of OutputDataIOService
+    OutputDataIOService service(&models);
+    EXPECT_EQ(service.nonXMLItems().size(), 1);
+
+    // checking data items of ApplicationModels
+    dataItems = models.nonXMLData();
+    EXPECT_EQ(dataItems.size(), 1);
+}
+
+TEST_F(TestSavingSpecularData, test_InstrumentInJobItem)
+{
+    ApplicationModels models;
+
+    // adding JobItem
+    SessionItem* jobItem = models.jobModel()->insertNewItem(Constants::JobItemType);
+    SessionItem* dataItem = models.jobModel()->insertNewItem(
+        Constants::IntensityDataType, jobItem->index(), -1, JobItem::T_OUTPUT);
+    EXPECT_EQ(models.jobModel()->nonXMLData().size(), 1);
+
+    // adding instrument
+    auto instrument = dynamic_cast<SpecularInstrumentItem*>(models.jobModel()->insertNewItem(
+        Constants::SpecularInstrumentType, jobItem->index(), -1, JobItem::T_INSTRUMENT));
+    // instrument contains hidden pointwise axis item
+    EXPECT_EQ(models.jobModel()->nonXMLData().size(), 2);
+
+    // explicitly switching to pointwise axis item
+    auto axis_group = getAxisGroup(instrument);
+    axis_group->setCurrentType(Constants::PointwiseAxisType);
+    EXPECT_EQ(models.jobModel()->nonXMLData().size(), 2);
+
+    OutputDataIOService service(&models);
+    EXPECT_EQ(service.nonXMLItems().size(), 2);
+
+    auto dataItems = models.nonXMLData();
+    EXPECT_EQ(dataItems.size(), 2);
+    EXPECT_EQ(dataItems.indexOf(dataItem), 0);
+
+    // hiding pointwise axis, should be saved anyway
+    axis_group->setCurrentType(Constants::BasicAxisType);
+    EXPECT_EQ(models.jobModel()->nonXMLData().size(), 2);
+    EXPECT_EQ(service.nonXMLItems().size(), 2);
+    dataItems = models.nonXMLData();
+    EXPECT_EQ(dataItems.size(), 2);
+    EXPECT_EQ(dataItems.indexOf(dataItem), 0);
+}
+
+TEST_F(TestSavingSpecularData, test_setLastModified)
+{
+    SessionModel model("TempModel");
+    auto item = dynamic_cast<PointwiseAxisItem*>(model.insertNewItem(Constants::PointwiseAxisType));
+
+    const int nap_time(10);
+    QTest::qSleep(nap_time);
+
+    OutputDataSaveInfo info = OutputDataSaveInfo::createSaved(item);
+    EXPECT_FALSE(info.wasModifiedSinceLastSave());
+
+    QTest::qSleep(nap_time);
+    item->setAxis(m_axis.get());
+    EXPECT_TRUE(info.wasModifiedSinceLastSave());
+
+    info = OutputDataSaveInfo::createSaved(item);
+    QTest::qSleep(nap_time);
+    item->setItemValue(PointwiseAxisItem::P_FILE_NAME, QString("new_value"));
+    EXPECT_TRUE(info.wasModifiedSinceLastSave());
+}
+
+TEST_F(TestSavingSpecularData, test_DirHistory)
+{
+    SessionModel model("TempModel");
+    auto item1 = dynamic_cast<PointwiseAxisItem*>(model.insertNewItem(Constants::PointwiseAxisType));
+
+    auto item2 = dynamic_cast<PointwiseAxisItem*>(model.insertNewItem(Constants::PointwiseAxisType));
+    item1->setAxis(m_axis.get());
+
+    // empty history
+    OutputDataDirHistory history;
+    EXPECT_FALSE(history.contains(item1));
+    // non-existing item is treated as modified
+    EXPECT_TRUE(history.wasModifiedSinceLastSave(item1));
+
+    // Saving item in a history
+    history.markAsSaved(item1);
+    history.markAsSaved(item2);
+
+    EXPECT_TRUE(history.contains(item1));
+    // Empty DataItems are not added to history:
+    EXPECT_FALSE(history.contains(item2));
+    EXPECT_FALSE(history.wasModifiedSinceLastSave(item1));
+
+    // Attempt to save same item second time
+    EXPECT_THROW(history.markAsSaved(item1), GUIHelpers::Error);
+
+    // Modifying item
+    QTest::qSleep(10);
+    item1->setAxis(m_axis.get());
+
+    EXPECT_TRUE(history.wasModifiedSinceLastSave(item1));
+}
+
+//! Testing saving abilities of OutputDataIOService class.
+
+TEST_F(TestSavingSpecularData, test_OutputDataIOService)
+{
+    const QString projectDir("test_SpecularDataSave");
+    TestUtils::create_dir(projectDir);
+
+    // setting up items and data
+
+    ApplicationModels models;
+    auto instrument1 = createSpecularInstrument(models);
+    auto instrument2 = createSpecularInstrument(models);
+
+    auto axis_group1 = getAxisGroup(instrument1);
+    auto pointwise_axis_item1 =
+        dynamic_cast<PointwiseAxisItem*>(axis_group1->getChildOfType(Constants::PointwiseAxisType));
+    pointwise_axis_item1->setAxis(m_axis.get());
+
+    auto axis_group2 = getAxisGroup(instrument2);
+    auto pointwise_axis_item2 =
+        dynamic_cast<PointwiseAxisItem*>(axis_group2->getChildOfType(Constants::PointwiseAxisType));
+    PointwiseAxis tmp("y", std::vector<double>{1.0, 2.0, 3.0});
+    pointwise_axis_item2->setAxis(&tmp);
+
+    // Saving first time
+    OutputDataIOService service(&models);
+    service.save(projectDir);
+    QTest::qSleep(10);
+
+    // Checking existance of data on disk
+    QString fname1 = "./" + projectDir + "/" + pointwise_axis_item1->fileName();
+    QString fname2 = "./" + projectDir + "/" + pointwise_axis_item2->fileName();
+    EXPECT_TRUE(ProjectUtils::exists(fname1));
+    EXPECT_TRUE(ProjectUtils::exists(fname2));
+
+    // Reading data from disk, checking it is the same
+    EXPECT_TRUE(isSame(fname1, pointwise_axis_item1->getAxis()));
+    EXPECT_TRUE(isSame(fname2, pointwise_axis_item2->getAxis()));;
+
+    // Modifying data and saving the project.
+    PointwiseAxis tmp2("z", std::vector<double>{2.0, 3.0, 4.0});
+    pointwise_axis_item2->setAxis(&tmp2);
+    service.save(projectDir);
+    QTest::qSleep(10);
+
+    EXPECT_TRUE(isSame(fname1, pointwise_axis_item1->getAxis()));
+    EXPECT_TRUE(isSame(fname2, pointwise_axis_item2->getAxis()));
+
+    // Renaming RealData and check that file on disk changed the name
+    pointwise_axis_item2->setItemValue(PointwiseAxisItem::P_FILE_NAME, "data2new.int.gz");
+    service.save(projectDir);
+    QTest::qSleep(10);
+
+    QString fname2new = "./" + projectDir + "/" + pointwise_axis_item2->fileName();
+    EXPECT_TRUE(ProjectUtils::exists(fname2new));
+    EXPECT_TRUE(isSame(fname2new, pointwise_axis_item2->getAxis()));
+
+    // Check that file with old name was removed.
+    EXPECT_FALSE(ProjectUtils::exists(fname2));
+}
+
+TEST_F(TestSavingSpecularData, test_CopyInstrumentToJobItem)
+{
+    const QString projectDir("test_SpecularDataSave2");
+    TestUtils::create_dir(projectDir);
+
+    ApplicationModels models;
+
+    // adding instrument and initializing pointwise axis
+    auto instrument = createSpecularInstrument(models);
+    auto axis_group = getAxisGroup(instrument);
+    auto pointwise_axis_item =
+        dynamic_cast<PointwiseAxisItem*>(axis_group->getChildOfType(Constants::PointwiseAxisType));
+    pointwise_axis_item->setAxis(m_axis.get());
+
+    // adding JobItem and copying instrument
+    auto jobItem =
+        dynamic_cast<JobItem*>(models.jobModel()->insertNewItem(Constants::JobItemType));
+    JobModelFunctions::setupJobItemInstrument(jobItem, instrument);
+    auto job_instrument =
+        dynamic_cast<SpecularInstrumentItem*>(jobItem->getItem(JobItem::T_INSTRUMENT));
+    auto job_axis_item = dynamic_cast<PointwiseAxisItem*>(
+        getAxisGroup(job_instrument)->getChildOfType(Constants::PointwiseAxisType));
+
+    // checking filenames
+    EXPECT_EQ(pointwise_axis_item->fileName(),
+              ItemFileNameUtils::instrumentDataFileName(*instrument));
+    EXPECT_EQ(job_axis_item->fileName(),
+              ItemFileNameUtils::instrumentDataFileName(*job_instrument));
+
+    // Saving
+    OutputDataIOService service(&models);
+    service.save(projectDir);
+    QTest::qSleep(10);
+
+    // Checking existance of data on disk
+    QString fname1 = "./" + projectDir + "/" + pointwise_axis_item->fileName();
+    QString fname2 = "./" + projectDir + "/" + job_axis_item->fileName();
+    EXPECT_TRUE(ProjectUtils::exists(fname1));
+    EXPECT_TRUE(ProjectUtils::exists(fname2));
+
+    // Reading data from disk, checking it is the same
+    EXPECT_TRUE(isSame(fname1, pointwise_axis_item->getAxis()));
+    EXPECT_TRUE(isSame(fname2, job_axis_item->getAxis()));;
+}

--- a/Tests/UnitTests/GUI/test_utils.cpp
+++ b/Tests/UnitTests/GUI/test_utils.cpp
@@ -15,6 +15,8 @@
 
 #include "test_utils.h"
 #include "GUIHelpers.h"
+#include "IntensityDataIOFactory.h"
+#include "IntensityDataFunctions.h"
 #include "OutputData.h"
 #include "ProjectUtils.h"
 #include "RealDataItem.h"
@@ -51,4 +53,17 @@ RealDataItem* TestUtils::createRealData(const QString& name, SessionModel& model
     result->setOutputData(createData(value, n_dim).release());
     result->setItemValue(SessionItem::P_NAME, name);
     return result;
+}
+
+bool TestUtils::isTheSame(const OutputData<double>& data1, const OutputData<double>& data2)
+{
+    double diff = IntensityDataFunctions::getRelativeDifference(data1, data2);
+    return diff < 1e-10;
+}
+
+bool TestUtils::isTheSame(const QString& fileName, const OutputData<double>& data)
+{
+    std::unique_ptr<OutputData<double>> dataOnDisk(
+        IntensityDataIOFactory::readOutputData(fileName.toStdString()));
+    return isTheSame(*dataOnDisk, data);
 }

--- a/Tests/UnitTests/GUI/test_utils.h
+++ b/Tests/UnitTests/GUI/test_utils.h
@@ -67,6 +67,12 @@ T propertyFromXML(const QString& buffer) {
     return item->value().value<T>();
 }
 
+//! Helper function to test if data are the same.
+bool isTheSame(const OutputData<double>& data1, const OutputData<double>& data2);
+
+//! Helper function to check if file on disk represents same data.
+bool isTheSame(const QString& fileName, const OutputData<double>& data);
+
 }
 
 #endif // TEST_UTILS


### PR DESCRIPTION
1. Inclination angle axis in `SpecularInstrumentItem` is now handled through an axis group, which holds both `BasicAxisItem` and `PointwiseAxisItem`. It enables simpler handling of non-xml data.

2. `ImportDataInfo` class stays a little bit of the path of the pull-request. It was introduced to let Juan to proceed with loading data from ASCII files. It is assumed, that this class will replace `std::unique_ptr<OutputData<double>>` in `ImportDataUtils::Import1dData`.

3. `PointwiseAxisItem::P_FILE_NAME` is bound to `InstrumentItem::P_IDENTIFIER`, which helps to keep file names unique for each instrument