### PR TITLE
To Redmine issue 2194: machinery for using and storing dimensional user data

### DIFF
--- a/Core/Instrument/AxisNames.h
+++ b/Core/Instrument/AxisNames.h
@@ -24,14 +24,14 @@
 
 namespace AxisNames
 {
-std::map<AxesUnits, std::string> InitSphericalAxis0();
-std::map<AxesUnits, std::string> InitSphericalAxis1();
-std::map<AxesUnits, std::string> InitRectangularAxis0();
-std::map<AxesUnits, std::string> InitRectangularAxis1();
-std::map<AxesUnits, std::string> InitOffSpecAxis0();
-std::map<AxesUnits, std::string> InitOffSpecAxis1();
-std::map<AxesUnits, std::string> InitSpecAxis();
-std::map<AxesUnits, std::string> InitSampleDepthAxis();
+BA_CORE_API_ std::map<AxesUnits, std::string> InitSphericalAxis0();
+BA_CORE_API_ std::map<AxesUnits, std::string> InitSphericalAxis1();
+BA_CORE_API_ std::map<AxesUnits, std::string> InitRectangularAxis0();
+BA_CORE_API_ std::map<AxesUnits, std::string> InitRectangularAxis1();
+BA_CORE_API_ std::map<AxesUnits, std::string> InitOffSpecAxis0();
+BA_CORE_API_ std::map<AxesUnits, std::string> InitOffSpecAxis1();
+BA_CORE_API_ std::map<AxesUnits, std::string> InitSpecAxis();
+BA_CORE_API_ std::map<AxesUnits, std::string> InitSampleDepthAxis();
 }
 
 #endif // AXISNAMES_H

--- a/Core/Instrument/UnitConverter1D.h
+++ b/Core/Instrument/UnitConverter1D.h
@@ -29,7 +29,7 @@ class BA_CORE_API_ UnitConverter1D : public IUnitConverter
 public:
     //! Constructs the object for unit conversion. Input axis
     //! is in radians.
-    UnitConverter1D(const Beam& beam, const IAxis& axis);
+    UnitConverter1D(const Beam& beam, const IAxis& axis, AxesUnits axis_units = AxesUnits::RADIANS);
     ~UnitConverter1D() override;
 
     UnitConverter1D* clone() const override;
@@ -58,13 +58,16 @@ public:
 private:
     UnitConverter1D(const UnitConverter1D& other);
 
+    //! Returns translating functional (input units --> rads)
+    std::function<double(double)> getTraslatorFrom(AxesUnits units_type) const;
+
     //! Returns translating functional (rads --> desired units)
-    std::function<double (double)> getTranslator(AxesUnits units_type) const;
+    std::function<double(double)> getTraslatorTo(AxesUnits units_type) const;
 
     //! Creates name map for axis in various units
     std::vector<std::map<AxesUnits, std::string>> createNameMaps() const override;
 
-    double m_wavelength; //!< basic wavelength in nm (for translation to q-space).
+    double m_wavelength;           //!< basic wavelength in nm (for translation to q-space).
     std::unique_ptr<IAxis> m_axis; //!< basic inclination angles (in rads).
 };
 

--- a/GUI/coregui/Models/DataItem.cpp
+++ b/GUI/coregui/Models/DataItem.cpp
@@ -16,6 +16,7 @@
 #include "BornAgainNamespace.h"
 #include "ComboProperty.h"
 #include "GUIHelpers.h"
+#include "ImportDataInfo.h"
 #include "IntensityDataIOFactory.h"
 
 const QString DataItem::P_FILE_NAME = "FileName";
@@ -88,6 +89,13 @@ QString DataItem::selectedAxesUnits() const
 void DataItem::resetToDefault()
 {
     ComboProperty combo = ComboProperty() << Constants::UnitsNbins;
+    setItemValue(DataItem::P_AXES_UNITS, combo.variant());
+    getItem(DataItem::P_AXES_UNITS)->setVisible(true);
+}
+
+void DataItem::reset(const ImportDataInfo& data)
+{
+    ComboProperty combo = ComboProperty() << data.unitsLabel();
     setItemValue(DataItem::P_AXES_UNITS, combo.variant());
     getItem(DataItem::P_AXES_UNITS)->setVisible(true);
 }

--- a/GUI/coregui/Models/DataItem.cpp
+++ b/GUI/coregui/Models/DataItem.cpp
@@ -86,13 +86,6 @@ QString DataItem::selectedAxesUnits() const
     return combo.getValue();
 }
 
-void DataItem::resetToDefault()
-{
-    ComboProperty combo = ComboProperty() << Constants::UnitsNbins;
-    setItemValue(DataItem::P_AXES_UNITS, combo.variant());
-    getItem(DataItem::P_AXES_UNITS)->setVisible(true);
-}
-
 void DataItem::reset(const ImportDataInfo& data)
 {
     ComboProperty combo = ComboProperty() << data.unitsLabel();

--- a/GUI/coregui/Models/DataItem.h
+++ b/GUI/coregui/Models/DataItem.h
@@ -21,6 +21,7 @@
 #include <QDateTime>
 #include <mutex>
 
+class ImportDataInfo;
 class InstrumentItem;
 
 //! Provides common functionality for IntensityDataItem and SpecularDataItem
@@ -59,6 +60,7 @@ public:
 
     //! Returns data to default state (no dimensional units, default axes' names)
     virtual void resetToDefault() = 0;
+    virtual void reset(const ImportDataInfo& data) = 0;
 
 protected:
     DataItem(const QString& modelType);

--- a/GUI/coregui/Models/DataItem.h
+++ b/GUI/coregui/Models/DataItem.h
@@ -58,8 +58,8 @@ public:
     virtual void updateAxesUnits(const InstrumentItem* instrument) = 0;
     virtual std::vector<int> shape() const = 0;
 
-    //! Returns data to default state (no dimensional units, default axes' names)
-    virtual void resetToDefault() = 0;
+    //! Returns data to the state defined by user (imported)
+    //! data.
     virtual void reset(const ImportDataInfo& data) = 0;
 
 protected:

--- a/GUI/coregui/Models/DataViewUtils.cpp
+++ b/GUI/coregui/Models/DataViewUtils.cpp
@@ -1,31 +1,13 @@
 #include "DataViewUtils.h"
-#include "ComboProperty.h"
 #include "DataItem.h"
 #include "Data1DViewItem.h"
 #include "DomainObjectBuilder.h"
-#include "GUIHelpers.h"
-#include "InstrumentItems.h"
-#include "IUnitConverter.h"
 #include "JobItem.h"
-#include "OutputData.h"
+#include "JobItemUtils.h"
 #include "DataPropertyContainer.h"
-#include "RealDataItem.h"
-#include "SessionModel.h"
 #include "UnitConverterUtils.h"
 
 namespace {
-const QMap<QString, AxesUnits> units_from_names{{Constants::UnitsNbins, AxesUnits::NBINS},
-                                                {Constants::UnitsRadians, AxesUnits::RADIANS},
-                                                {Constants::UnitsDegrees, AxesUnits::DEGREES},
-                                                {Constants::UnitsMm, AxesUnits::MM},
-                                                {Constants::UnitsQyQz, AxesUnits::QSPACE}};
-
-const QMap<AxesUnits, QString> names_from_units{{AxesUnits::NBINS, Constants::UnitsNbins},
-                                                {AxesUnits::RADIANS, Constants::UnitsRadians},
-                                                {AxesUnits::MM, Constants::UnitsMm},
-                                                {AxesUnits::QSPACE, Constants::UnitsQyQz},
-                                                {AxesUnits::DEGREES, Constants::UnitsDegrees}};
-
 std::unique_ptr<IUnitConverter> getConverter(Data1DViewItem* view_item)
 {
     auto job_item = view_item->jobItem();
@@ -38,7 +20,7 @@ AxesUnits selectedUnits(Data1DViewItem* view_item)
 {
     auto current_unit_name
         = view_item->getItemValue(Data1DViewItem::P_AXES_UNITS).value<ComboProperty>().getValue();
-    return units_from_names[current_unit_name];
+    return JobItemUtils::axesUnitsFromName(current_unit_name);
 }
 }
 

--- a/GUI/coregui/Models/DataViewUtils.cpp
+++ b/GUI/coregui/Models/DataViewUtils.cpp
@@ -40,44 +40,6 @@ AxesUnits selectedUnits(Data1DViewItem* view_item)
         = view_item->getItemValue(Data1DViewItem::P_AXES_UNITS).value<ComboProperty>().getValue();
     return units_from_names[current_unit_name];
 }
-
-ComboProperty availableUnits(const IUnitConverter* converter)
-{
-    assert(converter);
-
-    ComboProperty result;
-    for (auto units : converter->availableUnits())
-        result << names_from_units[units];
-
-    result.setValue(names_from_units[converter->defaultUnits()]);
-    return result;
-}
-}
-
-void DataViewUtils::initDataView(JobItem* job_item)
-{
-    assert(job_item && job_item->isValidForFitting());
-    assert(job_item->instrumentItem()
-           && job_item->instrumentItem()->modelType() == Constants::SpecularInstrumentType);
-    assert(!job_item->getItem(JobItem::T_DATAVIEW));
-
-    SessionModel* model = job_item->model();
-    auto view_item = dynamic_cast<Data1DViewItem*>(model->insertNewItem(
-        Constants::Data1DViewItemType, job_item->index(), -1, JobItem::T_DATAVIEW));
-    assert(view_item);
-
-    auto property_container = dynamic_cast<DataPropertyContainer*>(model->insertNewItem(
-        Constants::DataPropertyContainerType, view_item->index(), -1, Data1DViewItem::T_DATA_PROPERTIES));
-    assert(property_container);
-
-    property_container->addItem(job_item->realDataItem()->dataItem());
-    property_container->addItem(job_item->dataItem());
-
-    // also triggers Data1DViewItem::setAxesRangeToData and DataViewUtils::updateAxesTitle by
-    // setting new value of P_AXES_UNITS.
-    auto converter = DomainObjectBuilder::createUnitConverter(job_item->instrumentItem());
-    view_item->setItemValue(Data1DViewItem::P_AXES_UNITS,
-                            availableUnits(converter.get()).variant());
 }
 
 void DataViewUtils::updateAxesTitle(Data1DViewItem* view_item)

--- a/GUI/coregui/Models/DataViewUtils.h
+++ b/GUI/coregui/Models/DataViewUtils.h
@@ -15,6 +15,8 @@
 #ifndef DATAVIEWUTILS_H
 #define DATAVIEWUTILS_H
 
+#include "IUnitConverter.h"
+#include <QString>
 #include <memory>
 
 class DataItem;

--- a/GUI/coregui/Models/DataViewUtils.h
+++ b/GUI/coregui/Models/DataViewUtils.h
@@ -24,9 +24,6 @@ template<class T> class OutputData;
 
 namespace DataViewUtils
 {
-//! Initializes Data1DViewItem and assigns it to the passed JobItem
-void initDataView(JobItem* jobItem);
-
 void updateAxesTitle(Data1DViewItem* view_item);
 
 std::unique_ptr<OutputData<double>> getTranslatedData(Data1DViewItem* view_item,

--- a/GUI/coregui/Models/IntensityDataItem.cpp
+++ b/GUI/coregui/Models/IntensityDataItem.cpp
@@ -225,22 +225,6 @@ std::vector<int> IntensityDataItem::shape() const
     return {getNbinsX(), getNbinsY()};
 }
 
-void IntensityDataItem::resetToDefault()
-{
-    assert(getOutputData()
-           && "IntensityDataItem::resetToDefault assertion failed: associated output data should "
-              "not be empty");
-    DataItem::resetToDefault();
-
-    setXaxisTitle(x_axis_default_name);
-    setYaxisTitle(y_axis_default_name);
-    MaskUnitsConverter converter;
-    converter.convertToNbins(this);
-    setOutputData(ImportDataUtils::CreateSimplifiedOutputData(*getOutputData()).release());
-    setAxesRangeToData();
-    converter.convertFromNbins(this);
-}
-
 void IntensityDataItem::reset(const ImportDataInfo& data)
 {
     assert(data.unitsLabel() == Constants::UnitsNbins);

--- a/GUI/coregui/Models/IntensityDataItem.cpp
+++ b/GUI/coregui/Models/IntensityDataItem.cpp
@@ -241,6 +241,20 @@ void IntensityDataItem::resetToDefault()
     converter.convertFromNbins(this);
 }
 
+void IntensityDataItem::reset(const ImportDataInfo& data)
+{
+    assert(data.unitsLabel() == Constants::UnitsNbins);
+    DataItem::reset(data);
+
+    setXaxisTitle(data.axisLabel(0));
+    setYaxisTitle(data.axisLabel(1));
+    MaskUnitsConverter converter;
+    converter.convertToNbins(this);
+    setOutputData(data.intensityData().release());
+    setAxesRangeToData();
+    converter.convertFromNbins(this);
+}
+
 void IntensityDataItem::setLowerX(double xmin)
 {
     getItem(P_XAXIS)->setItemValue(BasicAxisItem::P_MIN, xmin);

--- a/GUI/coregui/Models/IntensityDataItem.h
+++ b/GUI/coregui/Models/IntensityDataItem.h
@@ -97,6 +97,7 @@ public:
 
     //! Returns data to default state (no dimensional units, default axes' names)
     void resetToDefault() override;
+    void reset(const ImportDataInfo& data) override;
 
 public slots:
     void setLowerX(double xmin);

--- a/GUI/coregui/Models/IntensityDataItem.h
+++ b/GUI/coregui/Models/IntensityDataItem.h
@@ -95,8 +95,8 @@ public:
     void updateAxesUnits(const InstrumentItem* instrument) override;
     std::vector<int> shape() const override;
 
-    //! Returns data to default state (no dimensional units, default axes' names)
-    void resetToDefault() override;
+    //! Returns data to the state defined by user (imported)
+    //! data.
     void reset(const ImportDataInfo& data) override;
 
 public slots:

--- a/GUI/coregui/Models/JobItem.cpp
+++ b/GUI/coregui/Models/JobItem.cpp
@@ -225,7 +225,7 @@ InstrumentItem* JobItem::instrumentItem()
 
 void JobItem::setResults(const Simulation* simulation)
 {
-    JobItemUtils::setResults(this, simulation);
+    JobItemUtils::setResults(dataItem(), simulation);
     updateIntensityDataFileName();
 }
 

--- a/GUI/coregui/Models/JobItemUtils.cpp
+++ b/GUI/coregui/Models/JobItemUtils.cpp
@@ -120,10 +120,6 @@ AxesUnits JobItemUtils::axesUnitsFromName(const QString& name)
 void JobItemUtils::setIntensityItemAxesUnits(DataItem* intensityItem,
                                               const InstrumentItem* instrumentItem)
 {
-    if (!instrumentItem) {
-        intensityItem->resetToDefault();
-        return;
-    }
     const auto converter = DomainObjectBuilder::createUnitConverter(instrumentItem);
     setIntensityItemAxesUnits(intensityItem, *converter);
 }

--- a/GUI/coregui/Models/JobItemUtils.cpp
+++ b/GUI/coregui/Models/JobItemUtils.cpp
@@ -27,27 +27,17 @@
 
 namespace
 {
-QMap<QString, AxesUnits> init_units_to_description_map()
-{
-    QMap<QString, AxesUnits> result;
-    result[Constants::UnitsNbins] = AxesUnits::NBINS;
-    result[Constants::UnitsRadians] = AxesUnits::RADIANS;
-    result[Constants::UnitsDegrees] = AxesUnits::DEGREES;
-    result[Constants::UnitsMm] = AxesUnits::MM;
-    result[Constants::UnitsQyQz] = AxesUnits::QSPACE;
-    return result;
-}
+const std::map<QString, AxesUnits> units_from_names{{Constants::UnitsNbins, AxesUnits::NBINS},
+                                                    {Constants::UnitsRadians, AxesUnits::RADIANS},
+                                                    {Constants::UnitsDegrees, AxesUnits::DEGREES},
+                                                    {Constants::UnitsMm, AxesUnits::MM},
+                                                    {Constants::UnitsQyQz, AxesUnits::QSPACE}};
 
-QMap<AxesUnits, QString> init_description_to_units_map()
-{
-    QMap<AxesUnits, QString> result;
-    result[AxesUnits::NBINS] = Constants::UnitsNbins;
-    result[AxesUnits::RADIANS] = Constants::UnitsRadians;
-    result[AxesUnits::DEGREES] = Constants::UnitsDegrees;
-    result[AxesUnits::MM] = Constants::UnitsMm;
-    result[AxesUnits::QSPACE] = Constants::UnitsQyQz;
-    return result;
-}
+const std::map<AxesUnits, QString> names_from_units{{AxesUnits::NBINS, Constants::UnitsNbins},
+                                                    {AxesUnits::RADIANS, Constants::UnitsRadians},
+                                                    {AxesUnits::MM, Constants::UnitsMm},
+                                                    {AxesUnits::QSPACE, Constants::UnitsQyQz},
+                                                    {AxesUnits::DEGREES, Constants::UnitsDegrees}};
 
 //! Updates axes' titles
 void updateAxesTitle(DataItem* intensityItem, const IUnitConverter& converter, AxesUnits units);
@@ -87,16 +77,14 @@ void JobItemUtils::updateDataAxes(DataItem* intensityItem,
 
 QString JobItemUtils::nameFromAxesUnits(AxesUnits units)
 {
-    static QMap<AxesUnits, QString> units_to_name = init_description_to_units_map();
-    return units_to_name[units];
+    return names_from_units.at(units);
 }
 
 //! Correspondance of GUI axes units names to their domain counterpart.
 
 AxesUnits JobItemUtils::axesUnitsFromName(const QString& name)
 {
-    static QMap<QString, AxesUnits> name_to_units = init_units_to_description_map();
-    return name_to_units[name];
+    return units_from_names.at(name);
 }
 
 //! Sets axes units suitable for given instrument.

--- a/GUI/coregui/Models/JobItemUtils.cpp
+++ b/GUI/coregui/Models/JobItemUtils.cpp
@@ -111,14 +111,7 @@ void JobItemUtils::setIntensityItemAxesUnits(DataItem* intensityItem,
 void JobItemUtils::setIntensityItemAxesUnits(DataItem *intensityItem,
                                              const IUnitConverter& converter)
 {
-    ComboProperty combo;
-
-    for (auto units : converter.availableUnits())
-        combo << nameFromAxesUnits(units);
-
-    AxesUnits preferrable_units = converter.defaultUnits();
-
-    combo.setValue(nameFromAxesUnits(preferrable_units));
+    ComboProperty combo = availableUnits(converter);
     intensityItem->setItemValue(DataItem::P_AXES_UNITS, combo.variant());
 }
 
@@ -143,6 +136,16 @@ void JobItemUtils::setResults(DataItem* intensityItem, const Simulation* simulat
     auto selected_units = JobItemUtils::axesUnitsFromName(intensityItem->selectedAxesUnits());
     std::unique_ptr<OutputData<double>> data(sim_result.data(selected_units));
     intensityItem->setOutputData(data.release());
+}
+
+ComboProperty JobItemUtils::availableUnits(const IUnitConverter& converter)
+{
+    ComboProperty result;
+    for (auto units : converter.availableUnits())
+        result << nameFromAxesUnits(units);
+
+    result.setValue(nameFromAxesUnits(converter.defaultUnits()));
+    return result;
 }
 
 namespace

--- a/GUI/coregui/Models/JobItemUtils.cpp
+++ b/GUI/coregui/Models/JobItemUtils.cpp
@@ -49,24 +49,8 @@ QMap<AxesUnits, QString> init_description_to_units_map()
     return result;
 }
 
-//! Sets simulation results into the DataItem
-void setResultsToDataItem(DataItem* intensityItem, const Simulation* simulation);
-
 //! Updates axes' titles
 void updateAxesTitle(DataItem* intensityItem, const IUnitConverter& converter, AxesUnits units);
-}
-
-void JobItemUtils::setResults(JobItem* jobItem, const Simulation* simulation)
-{
-    auto dataItem = jobItem->dataItem();
-    Q_ASSERT(dataItem);
-
-    if (dataItem->modelType() == Constants::IntensityDataType
-        || dataItem->modelType() == Constants::SpecularDataType) {
-        setResultsToDataItem(dataItem, simulation);
-    } else {
-        throw GUIHelpers::Error("JobItemUtils::setResults() -> Error. Unsupported data item.");
-    }
 }
 
 //! Updates axes of OutputData in IntensityData item to correspond with ::P_AXES_UNITS selection.
@@ -148,9 +132,7 @@ void JobItemUtils::createDefaultDetectorMap(DataItem* intensityItem,
     updateAxesTitle(intensityItem, *converter, converter->defaultUnits());
 }
 
-namespace
-{
-void setResultsToDataItem(DataItem* intensityItem, const Simulation* simulation)
+void JobItemUtils::setResults(DataItem* intensityItem, const Simulation* simulation)
 {
     const auto sim_result = simulation->result();
     if (intensityItem->getOutputData() == nullptr) {
@@ -163,6 +145,8 @@ void setResultsToDataItem(DataItem* intensityItem, const Simulation* simulation)
     intensityItem->setOutputData(data.release());
 }
 
+namespace
+{
 void updateAxesTitle(DataItem* intensityItem, const IUnitConverter& converter,
                      AxesUnits units)
 {

--- a/GUI/coregui/Models/JobItemUtils.h
+++ b/GUI/coregui/Models/JobItemUtils.h
@@ -15,6 +15,7 @@
 #ifndef JOBITEMUTILS_H
 #define JOBITEMUTILS_H
 
+#include "ComboProperty.h"
 #include "IDetector.h"
 #include <QMap>
 
@@ -49,6 +50,8 @@ BA_CORE_API_ void createDefaultDetectorMap(DataItem* intensityItem,
 
 //! Sets simulation results into the DataItem
 BA_CORE_API_ void setResults(DataItem* intensityItem, const Simulation* simulation);
+
+BA_CORE_API_ ComboProperty availableUnits(const IUnitConverter& converter);
 }
 
 #endif // JOBITEMUTILS_H

--- a/GUI/coregui/Models/JobItemUtils.h
+++ b/GUI/coregui/Models/JobItemUtils.h
@@ -28,10 +28,6 @@ class Simulation;
 
 namespace JobItemUtils
 {
-
-//! Sets simulation results to the JobItem.
-BA_CORE_API_ void setResults(JobItem* jobItem, const Simulation* simulation);
-
 //! updates axes of OutputData in IntensityData item
 BA_CORE_API_ void updateDataAxes(DataItem* intensityItem,
                                  const InstrumentItem* instrumentItem);
@@ -50,6 +46,9 @@ BA_CORE_API_ void setIntensityItemAxesUnits(DataItem* intensityItem,
 
 BA_CORE_API_ void createDefaultDetectorMap(DataItem* intensityItem,
                                            const InstrumentItem* instrumentItem);
+
+//! Sets simulation results into the DataItem
+BA_CORE_API_ void setResults(DataItem* intensityItem, const Simulation* simulation);
 }
 
 #endif // JOBITEMUTILS_H

--- a/GUI/coregui/Models/JobModelFunctions.h
+++ b/GUI/coregui/Models/JobModelFunctions.h
@@ -26,6 +26,9 @@ class InstrumentItem;
 
 namespace JobModelFunctions
 {
+//! Initializes Data1DViewItem and assigns it to the passed JobItem
+BA_CORE_API_ void initDataView(JobItem* jobItem);
+
 //! Properly copies instrument into job item
 BA_CORE_API_ void setupJobItemInstrument(JobItem* jobItem, const InstrumentItem* instrumentItem);
 

--- a/GUI/coregui/Models/RealDataItem.cpp
+++ b/GUI/coregui/Models/RealDataItem.cpp
@@ -25,6 +25,8 @@
 const QString RealDataItem::P_INSTRUMENT_ID = "Instrument Id";
 const QString RealDataItem::P_INSTRUMENT_NAME = "Instrument";
 const QString RealDataItem::T_INTENSITY_DATA = "Intensity data";
+const QString RealDataItem::P_NATIVE_AXIS = "Native user data axis";
+const QString RealDataItem::P_NATIVE_UNITS = "Native user data units";
 
 RealDataItem::RealDataItem()
     : SessionItem(Constants::RealDataType)
@@ -35,13 +37,13 @@ RealDataItem::RealDataItem()
     // Registering this tag even without actual data item to avoid troubles in copying RealDataItem
     registerTag(T_INTENSITY_DATA, 1, 1,
                 QStringList() << Constants::IntensityDataType << Constants::SpecularDataType);
-
-    // TODO: allows to access underlying data item, should be removed. But it is not clear,
-    // what happens if default tag is not present.
     setDefaultTag(T_INTENSITY_DATA);
 
     addProperty(P_INSTRUMENT_ID, QString());
     addProperty(P_INSTRUMENT_NAME, QString());
+
+    addGroupProperty(P_NATIVE_AXIS, Constants::PointwiseAxisType);
+    addProperty(P_NATIVE_UNITS, Constants::UnitsNbins)->setVisible(false);
 
     mapper()->setOnPropertyChange([this](const QString& name) {
         if (name == P_NAME && getItem(T_INTENSITY_DATA))

--- a/GUI/coregui/Models/RealDataItem.cpp
+++ b/GUI/coregui/Models/RealDataItem.cpp
@@ -150,6 +150,10 @@ void RealDataItem::updateIntensityDataFileName()
 
 void RealDataItem::updateToInstrument()
 {
-    if (DataItem* item = dataItem())
-        JobItemUtils::setIntensityItemAxesUnits(item, m_linkedInstrument);
+    if (DataItem* item = dataItem()) {
+        if (!m_linkedInstrument)
+            item->resetToDefault();
+        else
+            JobItemUtils::setIntensityItemAxesUnits(item, m_linkedInstrument);
+    }
 }

--- a/GUI/coregui/Models/RealDataItem.h
+++ b/GUI/coregui/Models/RealDataItem.h
@@ -31,6 +31,9 @@ public:
     static const QString T_INTENSITY_DATA;
     static const QString P_INSTRUMENT_ID;
     static const QString P_INSTRUMENT_NAME;
+    static const QString P_NATIVE_AXIS;
+    static const QString P_NATIVE_UNITS;
+
     RealDataItem();
 
     IntensityDataItem* intensityDataItem();

--- a/GUI/coregui/Models/RealDataItem.h
+++ b/GUI/coregui/Models/RealDataItem.h
@@ -22,6 +22,7 @@ class InstrumentItem;
 class IntensityDataItem;
 class MaskContainerItem;
 template <class T> class OutputData;
+class ImportDataInfo;
 
 //! The RealDataItem class represents intensity data imported from file and intended for fitting.
 
@@ -43,6 +44,7 @@ public:
     const DataItem* dataItem() const;
 
     void setOutputData(OutputData<double>* data);
+    void setImportData(ImportDataInfo data);
 
     void linkToInstrument(const InstrumentItem* instrument, bool make_update = true);
 
@@ -56,6 +58,7 @@ public:
     MaskContainerItem* maskContainerItem();
 
 private:
+    void initDataItem(size_t data_rank);
     void updateIntensityDataFileName();
     void updateToInstrument();
     const InstrumentItem* m_linkedInstrument;

--- a/GUI/coregui/Models/SpecularDataItem.cpp
+++ b/GUI/coregui/Models/SpecularDataItem.cpp
@@ -150,19 +150,6 @@ std::vector<int> SpecularDataItem::shape() const
     return {getNbins()};
 }
 
-void SpecularDataItem::resetToDefault()
-{
-    assert(getOutputData()
-           && "SpecularDataItem::resetToDefault assertion failed: associated output data should "
-              "not be empty");
-    DataItem::resetToDefault();
-
-    setXaxisTitle(x_axis_default_name);
-    setYaxisTitle(y_axis_default_name);
-    setOutputData(ImportDataUtils::CreateSimplifiedOutputData(*getOutputData()).release());
-    setAxesRangeToData();
-}
-
 void SpecularDataItem::reset(const ImportDataInfo& data)
 {
     DataItem::reset(data);

--- a/GUI/coregui/Models/SpecularDataItem.cpp
+++ b/GUI/coregui/Models/SpecularDataItem.cpp
@@ -163,6 +163,16 @@ void SpecularDataItem::resetToDefault()
     setAxesRangeToData();
 }
 
+void SpecularDataItem::reset(const ImportDataInfo& data)
+{
+    DataItem::reset(data);
+
+    setXaxisTitle(data.axisLabel(0));
+    setYaxisTitle(data.axisLabel(1));
+    setOutputData(data.intensityData().release());
+    setAxesRangeToData();
+}
+
 void SpecularDataItem::setLowerX(double xmin)
 {
     getItem(P_XAXIS)->setItemValue(BasicAxisItem::P_MIN, xmin);

--- a/GUI/coregui/Models/SpecularDataItem.h
+++ b/GUI/coregui/Models/SpecularDataItem.h
@@ -68,8 +68,8 @@ public:
     void updateAxesUnits(const InstrumentItem* instrument) override;
     std::vector<int> shape() const override;
 
-    //! Returns data to default state (no dimensional units, default axes' names)
-    void resetToDefault() override;
+    //! Returns data to the state defined by user (imported)
+    //! data.
     void reset(const ImportDataInfo& data) override;
 
 public slots:

--- a/GUI/coregui/Models/SpecularDataItem.h
+++ b/GUI/coregui/Models/SpecularDataItem.h
@@ -70,6 +70,7 @@ public:
 
     //! Returns data to default state (no dimensional units, default axes' names)
     void resetToDefault() override;
+    void reset(const ImportDataInfo& data) override;
 
 public slots:
     void setLowerX(double xmin);

--- a/GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.cpp
@@ -77,14 +77,14 @@ std::unique_ptr<OutputData<double>> ImportDataUtils::Import2dData(QString& baseN
     return result;
 }
 
-std::unique_ptr<OutputData<double>> ImportDataUtils::Import1dData(QString& baseNameOfLoadedFile)
+ImportDataInfo ImportDataUtils::Import1dData(QString& baseNameOfLoadedFile)
 {
     QString dirname = AppSvc::projectManager()->userImportDir();
-    QString fileName = QFileDialog::getOpenFileName(Q_NULLPTR, QStringLiteral("Open Intensity File"),
+    QString fileName = QFileDialog::getOpenFileName(nullptr, QStringLiteral("Open Intensity File"),
                                                     dirname, filter_string);
 
     if (fileName.isEmpty())
-        return nullptr;
+        return ImportDataInfo();
 
     QString newImportDir = GUIHelpers::fileDir(fileName);
     if (newImportDir != dirname)
@@ -95,9 +95,9 @@ std::unique_ptr<OutputData<double>> ImportDataUtils::Import1dData(QString& baseN
 
     std::unique_ptr<OutputData<double>> data;
     if(!UseImportAssistant(fileName, data))
-        return nullptr;
+        return ImportDataInfo();
 
-    return data;
+    return ImportDataInfo(std::move(data), AxesUnits::NBINS);
 }
 
 bool ImportDataUtils::UseImportAssistant(QString& fileName, std::unique_ptr<OutputData<double>>& result){

--- a/GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.cpp
@@ -86,8 +86,6 @@ std::unique_ptr<OutputData<double>> ImportDataUtils::Import1dData(QString& baseN
     if (fileName.isEmpty())
         return nullptr;
 
-    std::unique_ptr<OutputData<double>> result;
-
     QString newImportDir = GUIHelpers::fileDir(fileName);
     if (newImportDir != dirname)
         AppSvc::projectManager()->setImportDir(newImportDir);
@@ -99,9 +97,7 @@ std::unique_ptr<OutputData<double>> ImportDataUtils::Import1dData(QString& baseN
     if(!UseImportAssistant(fileName, data))
         return nullptr;
 
-    result = CreateSimplifiedOutputData(*data.get());
-
-    return result;
+    return data;
 }
 
 bool ImportDataUtils::UseImportAssistant(QString& fileName, std::unique_ptr<OutputData<double>>& result){

--- a/GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.h
+++ b/GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.h
@@ -16,6 +16,7 @@
 #define IMPORTDATAUTILS_H
 
 #include "WinDllMacros.h"
+#include "ImportDataInfo.h"
 #include <QString>
 #include <memory>
 #include <vector>
@@ -31,7 +32,7 @@ namespace ImportDataUtils
 {
 
 BA_CORE_API_ std::unique_ptr<OutputData<double>> Import2dData(QString& baseNameOfLoadedFile);
-BA_CORE_API_ std::unique_ptr<OutputData<double>> Import1dData(QString& baseNameOfLoadedFile);
+BA_CORE_API_ ImportDataInfo Import1dData(QString& baseNameOfLoadedFile);
 BA_CORE_API_ bool UseImportAssistant(QString& fileName, std::unique_ptr<OutputData<double>>& result);
 
 

--- a/GUI/coregui/Views/ImportDataWidgets/RealDataSelectorActions.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/RealDataSelectorActions.cpp
@@ -14,6 +14,7 @@
 
 #include "RealDataSelectorActions.h"
 #include "GUIHelpers.h"
+#include "ImportDataInfo.h"
 #include "ImportDataUtils.h"
 #include "IntensityDataFunctions.h"
 #include "IntensityDataItem.h"
@@ -141,12 +142,12 @@ void RealDataSelectorActions::onImport1dDataAction()
     Q_ASSERT(m_selectionModel);
     QString baseNameOfImportedFile;
 
-    std::unique_ptr<OutputData<double>> data = ImportDataUtils::Import1dData(baseNameOfImportedFile);
+    auto data = ImportDataUtils::Import1dData(baseNameOfImportedFile);
     if (data) {
         RealDataItem* realDataItem
             = dynamic_cast<RealDataItem*>(m_realDataModel->insertNewItem(Constants::RealDataType));
         realDataItem->setItemName(baseNameOfImportedFile);
-        realDataItem->setOutputData(data.release());
+        realDataItem->setImportData(std::move(data));
         m_selectionModel->clearSelection();
         m_selectionModel->select(realDataItem->index(), QItemSelectionModel::Select);
     }

--- a/GUI/coregui/utils/ImportDataInfo.cpp
+++ b/GUI/coregui/utils/ImportDataInfo.cpp
@@ -2,7 +2,7 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/ImportDataWidgets/ImportDataInfo.cpp
+//! @file      GUI/coregui/utils/ImportDataInfo.cpp
 //! @brief     Implements ImportDataInfo helper struct
 //!
 //! @homepage  http://www.bornagainproject.org

--- a/GUI/coregui/utils/ImportDataInfo.h
+++ b/GUI/coregui/utils/ImportDataInfo.h
@@ -15,25 +15,35 @@
 #ifndef IMPORTDATAINFO_H
 #define IMPORTDATAINFO_H
 
+#include "WinDllMacros.h"
+#include "IUnitConverter.h"
+#include <QString>
 #include <memory>
-#include <vector>
 
 template<class T> class OutputData;
 
 //! Carries information about loaded data.
 
-struct ImportDataInfo
+class BA_CORE_API_ ImportDataInfo
 {
-    enum class COORDINATE {bins, angle, double_angle, q};
-    enum class UNITS {bins, rads, degrees, inv_nm, inv_angstroms};
-
+public:
     ImportDataInfo();
+    ImportDataInfo(ImportDataInfo&& other);
+    ImportDataInfo(std::unique_ptr<OutputData<double>> data, AxesUnits units);
+    ImportDataInfo(std::unique_ptr<OutputData<double>> data, const QString& units);
     ~ImportDataInfo();
-    static std::vector<UNITS> compatibleUnits(COORDINATE coordinate_type);
 
+    operator bool() const;
+
+    std::unique_ptr<OutputData<double>> intensityData() const;
+    size_t dataRank() const;
+    QString unitsLabel() const;
+    QString axisLabel(size_t axis_index) const;
+
+private:
+    void checkValidity();
     std::unique_ptr<OutputData<double>> m_data;
-    COORDINATE m_coordinate_type;
-    UNITS m_units;
+    AxesUnits m_units;
 };
 
 #endif // IMPORTDATAINFO_H

--- a/GUI/coregui/utils/ImportDataInfo.h
+++ b/GUI/coregui/utils/ImportDataInfo.h
@@ -2,7 +2,7 @@
 //
 //  BornAgain: simulate and fit scattering at grazing incidence
 //
-//! @file      GUI/coregui/Views/ImportDataWidgets/ImportDataInfo.h
+//! @file      GUI/coregui/utils/ImportDataInfo.h
 //! @brief     Defines ImportDataInfo helper struct
 //!
 //! @homepage  http://www.bornagainproject.org

--- a/Tests/UnitTests/Core/Axes/UnitConverter1DTest.h
+++ b/Tests/UnitTests/Core/Axes/UnitConverter1DTest.h
@@ -106,3 +106,28 @@ TEST_F(UnitConverter1DTest, UnitConverter1DClone)
     std::unique_ptr<UnitConverter1D> converter_clone(converter.clone());
     checkMainFunctionality(*converter_clone);
 }
+
+TEST_F(UnitConverter1DTest, NonDefaultUnitsInInput)
+{
+    PointwiseAxis axis("x", std::vector<double>{0.0, 0.5, 1.0});
+
+    EXPECT_THROW(UnitConverter1D(m_beam, axis, AxesUnits::NBINS),
+                 std::runtime_error);
+
+    UnitConverter1D converter(m_beam, axis, AxesUnits::DEGREES);
+    auto axis_deg_output = converter.createConvertedAxis(0, AxesUnits::DEGREES);
+    EXPECT_TRUE(axis.size() == axis_deg_output->size());
+    EXPECT_DOUBLE_EQ(axis[0], (*axis_deg_output)[0]);
+    EXPECT_DOUBLE_EQ(axis[1], (*axis_deg_output)[1]);
+    EXPECT_DOUBLE_EQ(axis[2], (*axis_deg_output)[2]);
+
+    auto values = axis.getBinCenters();
+    std::for_each(values.begin(), values.end(), [this](double& value){value = getQ(value);});
+    PointwiseAxis q_axis("q", values);
+    UnitConverter1D converter2(m_beam, q_axis, AxesUnits::QSPACE);
+    auto axis_rad_output = converter2.createConvertedAxis(0, AxesUnits::RADIANS);
+    EXPECT_TRUE(axis.size() == axis_rad_output->size());
+    EXPECT_DOUBLE_EQ(axis[0], (*axis_rad_output)[0]);
+    EXPECT_DOUBLE_EQ(axis[1], (*axis_rad_output)[1]);
+    EXPECT_DOUBLE_EQ(axis[2], (*axis_rad_output)[2]);
+}


### PR DESCRIPTION
1. Revised implementation of `ImportDataInfo`
2. Native coordinates information in `RealDataItem`. It could be a good idea to replace these new properties with something like `ImportedDataItem` in order to remove any dimensional information from `RealDataItem`.
3. Minor refactoring in `JobItemUtils` and `DataViewUtils` to get rid of duplicating code (e.g. unit-name maps). In further pull-requests `DataViewUtils` namespace will be eliminated completely.
4. UnitConverter1D is now capable of accepting data in any units making sense for reflectometry instrument and known to BornAgain.