### PR TITLE
CsvImportAssistant: Last Data Row Selector + Refactoring

### DIFF
--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/CsvImportAssistant.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/CsvImportAssistant.cpp
@@ -215,16 +215,17 @@ ImportDataInfo CsvImportAssistant::getData()
         int intensityCol = int(m_intensityCol-1);
         int coordinateCol = int(m_coordinateCol-1);
         for(auto row = firstRow; row < nRows; row++) {
-            std::string string_to_parse;
-            std::vector<double> parsed_doubles;
+            coordValues.push_back(
+            helperDoubleParser(
+                            m_tableWidget->item(row,coordinateCol)->text().toStdString()
+                            )
+                        );
 
-            string_to_parse = m_tableWidget->item(row,coordinateCol)->text().toStdString();
-            parsed_doubles = DataFormatUtils::parse_doubles(string_to_parse);
-            coordValues.push_back(parsed_doubles[0]);
-
-            string_to_parse = m_tableWidget->item(row,intensityCol)->text().toStdString();
-            parsed_doubles = DataFormatUtils::parse_doubles(string_to_parse);
-            intensityValues.push_back(parsed_doubles[0]);
+            intensityValues.push_back(
+             helperDoubleParser(
+                           m_tableWidget->item(row,intensityCol)->text().toStdString()
+                            )
+                        );
         }
         auto axisName = m_coordinateName.toStdString();
         PointwiseAxis coordAxis(axisName, coordValues);
@@ -240,12 +241,12 @@ ImportDataInfo CsvImportAssistant::getData()
         std::vector<double> intensityValues;
         int intensityCol = int(m_intensityCol-1);
         for(auto row = firstRow; row < nRows; row++) {
-            std::string string_to_parse;
-            std::vector<double> parsed_doubles;
+            intensityValues.push_back(
+            helperDoubleParser(
+                           m_tableWidget->item(row,intensityCol)->text().toStdString()
+                            )
+                        );
 
-            string_to_parse = m_tableWidget->item(row,intensityCol)->text().toStdString();
-            parsed_doubles = DataFormatUtils::parse_doubles(string_to_parse);
-            intensityValues.push_back(parsed_doubles[0]);
         }
         resultOutputData->addAxis("AXIS", size_t(nRows), 0.0, double(nRows-1));
         for(unsigned i = 0; i < intensityValues.size(); i++)
@@ -662,4 +663,10 @@ void CsvImportAssistant::reset(){
     m_coordinateUnitsSelector->clear();
     m_coordinateUnitsSelector->addItem(UnitsLabels[AxesUnits::NBINS]);
     Reload();
+}
+
+double CsvImportAssistant::helperDoubleParser(std::string string_to_parse){
+        std::vector<double> parsed_doubles;
+        parsed_doubles = DataFormatUtils::parse_doubles(string_to_parse);
+        return parsed_doubles[0];
 }

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/CsvImportAssistant.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/CsvImportAssistant.cpp
@@ -33,15 +33,16 @@ const QSize default_dialog_size(300, 400);
 CsvImportAssistant::CsvImportAssistant(QString& file, QWidget* parent):
         QDialog(parent)
       ,m_fileName(file)
-      ,m_lastDataRow(0)
       ,m_intensityCol(0)
       ,m_coordinateCol(0)
       ,m_units(AxesUnits::NBINS)
       ,m_tableWidget(nullptr)
       ,m_separatorField(nullptr)
       ,m_firstDataRowSpinBox(nullptr)
+      ,m_lastDataRowSpinBox(nullptr)
       ,m_importButton(nullptr)
       ,m_csvFile(nullptr)
+      ,m_csvArray()
       ,m_coordinateUnitsSelector(nullptr)
       ,m_setAsTheta(new QAction(HeaderLabels[_theta_],nullptr))
       ,m_setAs2Theta(new QAction(HeaderLabels[_2theta_],nullptr))
@@ -58,17 +59,12 @@ CsvImportAssistant::CsvImportAssistant(QString& file, QWidget* parent):
     StyleUtils::setResizable(this);
     setLayout(createLayout());
 
-    try {
-        if(!m_fileName.isEmpty())
-            m_csvFile = std::make_unique<CSVFile>(m_fileName.toStdString(), separator());
-    }
-    catch (...) {
-        showErrorMessage("There was a problem opening the file \"" + m_fileName.toStdString() + "\"");
+    if(!initialSetup()){
+        showErrorMessage("The file exist but it seems to be empty");
         return;
     }
 
     Reload();
-
 }
 
 QBoxLayout* CsvImportAssistant::createLayout()
@@ -77,7 +73,6 @@ QBoxLayout* CsvImportAssistant::createLayout()
     m_tableWidget = new QTableWidget();
     m_tableWidget->setContextMenuPolicy(Qt::CustomContextMenu);
     m_tableWidget->setEditTriggers(QAbstractItemView::NoEditTriggers);
-    connect(m_tableWidget, &QTableWidget::cellClicked, this, &CsvImportAssistant::OnColumnClicked);
     connect(m_tableWidget, &QTableWidget::customContextMenuRequested, this, &CsvImportAssistant::onColumnRightClick);
 
     //Import button
@@ -101,7 +96,27 @@ QBoxLayout* CsvImportAssistant::createLayout()
     m_firstDataRowSpinBox->setMaximum(1);
     m_firstDataRowSpinBox->setValue(1);
     m_firstDataRowSpinBox->setMaximumWidth(100);
-    connect(m_firstDataRowSpinBox, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, [this](){ Reload(); });
+    connect(m_firstDataRowSpinBox, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+            [this]()
+            {
+                m_lastDataRowSpinBox->setMinimum(m_firstDataRowSpinBox->value());
+                Reload();
+            }
+    );
+
+    //Last Row SpinBox
+    m_lastDataRowSpinBox = new QSpinBox();
+    m_lastDataRowSpinBox->setMinimum(1);
+    m_lastDataRowSpinBox->setMaximum(1);
+    m_lastDataRowSpinBox->setValue(1);
+    m_lastDataRowSpinBox->setMaximumWidth(100);
+    connect(m_lastDataRowSpinBox, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+            [this]()
+            {
+                m_firstDataRowSpinBox->setMaximum(m_lastDataRowSpinBox->value());
+                Reload();
+            }
+    );
 
     //Column type selector
     m_coordinateUnitsSelector = new QComboBox();
@@ -124,6 +139,7 @@ QBoxLayout* CsvImportAssistant::createLayout()
     controlsLayout->addRow(tr("&Corodinate Units: "), m_coordinateUnitsSelector);
     controlsLayout->addRow(tr("&Separator: "), m_separatorField);
     controlsLayout->addRow(tr("&From row: "), m_firstDataRowSpinBox);
+    controlsLayout->addRow(tr("&To row: "), m_lastDataRowSpinBox);
 
     //buttons layout
     auto buttonsLayout = new QHBoxLayout;
@@ -143,6 +159,44 @@ QBoxLayout* CsvImportAssistant::createLayout()
 
     return layout;
 }
+
+bool CsvImportAssistant::initialSetup(){
+    try {
+        m_csvFile = std::make_unique<CSVFile>(m_fileName.toStdString(), separator());
+    }
+    catch (...) {
+        showErrorMessage("There was a problem opening the file \"" + m_fileName.toStdString() + "\"");
+        return false;
+    }
+
+    size_t lastRow = m_csvFile->NumberOfRows();
+    auto csvArray = m_csvFile->asArray();
+
+
+    if (lastRow < 1) {
+        m_importButton->setDisabled(true);
+        return false;
+    }
+
+    //Automatically ignore empty lines at the end:
+    while(QString::fromStdString(accumulate(csvArray[lastRow-1].begin(), csvArray[lastRow-1].end(), std::string(""))).trimmed() == ""){
+        lastRow--;
+        if (lastRow < 1) {
+            m_importButton->setDisabled(true);
+            return false;
+        }
+    }
+
+    //Set maximum values for spinboxes
+    m_firstDataRowSpinBox->setMaximum(int(lastRow));
+    m_lastDataRowSpinBox->setMaximum(int(lastRow));
+    m_lastDataRowSpinBox->setValue(int(lastRow));
+
+    std::vector<std::vector<std::string>> tmp(csvArray.begin() , csvArray.begin() + maxLines());
+    m_csvArray.swap(tmp);
+    return true;
+}
+
 
 void CsvImportAssistant::Reload()
 {
@@ -171,14 +225,7 @@ void CsvImportAssistant::Reload()
 
 void CsvImportAssistant::reloadCsvFile(){
     reset();
-    try {
-        if(!m_fileName.isEmpty())
-            m_csvFile = std::make_unique<CSVFile>(m_fileName.toStdString(), separator());
-    }
-    catch (...) {
-        showErrorMessage("There was a problem opening the file \"" + m_fileName.toStdString() + "\"");
-        return;
-    }
+    initialSetup();
     Reload();
 }
 
@@ -206,6 +253,7 @@ ImportDataInfo CsvImportAssistant::getData()
 
     auto nRows = m_tableWidget->rowCount();
     auto firstRow = int(firstLine()-1);
+    auto lastRow = int(lastLine());
 
     //Coordinate and Intensity columns selected
     if(m_coordinateCol * m_intensityCol > 0){
@@ -214,7 +262,7 @@ ImportDataInfo CsvImportAssistant::getData()
         std::vector<double> intensityValues;
         int intensityCol = int(m_intensityCol-1);
         int coordinateCol = int(m_coordinateCol-1);
-        for(auto row = firstRow; row < nRows; row++) {
+        for(auto row = firstRow; row < lastRow; row++) {
             coordValues.push_back(
             helperDoubleParser(
                             m_tableWidget->item(row,coordinateCol)->text().toStdString()
@@ -240,7 +288,7 @@ ImportDataInfo CsvImportAssistant::getData()
         //Fill intensity values
         std::vector<double> intensityValues;
         int intensityCol = int(m_intensityCol-1);
-        for(auto row = firstRow; row < nRows; row++) {
+        for(auto row = firstRow; row < lastRow; row++) {
             intensityValues.push_back(
             helperDoubleParser(
                            m_tableWidget->item(row,intensityCol)->text().toStdString()
@@ -269,48 +317,24 @@ ImportDataInfo CsvImportAssistant::getData()
     */
 }
 
-
 void CsvImportAssistant::generate_table() {
-    m_firstDataRowSpinBox->setMaximum(int(m_csvFile->NumberOfRows()));
-    m_lastDataRow = unsigned(int(m_csvFile->NumberOfRows()));
-    std::vector<std::vector<std::string>> csvArray = m_csvFile->asArray();
+    removeBlankColumns();
 
-    if (m_lastDataRow < 1) {
-        m_importButton->setDisabled(true);
-        return;
-    }
-
-
-    //Remove empty lines at the end automatically:
-    while(QString::fromStdString(accumulate(csvArray[m_lastDataRow-1].begin(), csvArray[m_lastDataRow-1].end(), std::string(""))).trimmed() == ""){
-        m_lastDataRow--;
-        m_firstDataRowSpinBox->setMaximum(int(m_lastDataRow));
-        if (m_lastDataRow < 1) {
-            m_importButton->setDisabled(true);
-            return;
-        }
-    }
-
-    std::vector<std::vector<std::string>> dataArray( csvArray.begin() , csvArray.begin() + m_lastDataRow );
-
-    removeBlankColumns(dataArray);
-
-    set_table_data(dataArray);
+    set_table_data();
 
     greyOutCells();
-
 }
 
-void CsvImportAssistant::set_table_data(std::vector<std::vector<std::string>> dataArray){
+void CsvImportAssistant::set_table_data(){
 
-    if(dataArray.empty()){
+    if(m_csvArray.empty()){
         m_tableWidget->clearContents();
         m_tableWidget->setRowCount(0);
         return;
     }
 
-    size_t nRows = dataArray.size();
-    size_t nCols = dataArray[0].size();
+    size_t nRows = m_csvArray.size();
+    size_t nCols = m_csvArray[0].size();
     m_tableWidget->clearContents();
     m_tableWidget->setColumnCount(int(nCols));
     m_tableWidget->setRowCount(0);
@@ -318,8 +342,8 @@ void CsvImportAssistant::set_table_data(std::vector<std::vector<std::string>> da
     for(unsigned i = 0; i < nRows ; i++){
         m_tableWidget->insertRow(m_tableWidget->rowCount());
         unsigned I = unsigned(m_tableWidget->rowCount()) - 1;
-        for(unsigned j = 0; j < dataArray[i].size(); j++){
-            m_tableWidget->setItem(int(I),int(j),new QTableWidgetItem(QString::fromStdString(dataArray[i][j])));
+        for(unsigned j = 0; j < m_csvArray[i].size(); j++){
+            m_tableWidget->setItem(int(I),int(j),new QTableWidgetItem(QString::fromStdString(m_csvArray[i][j])));
         }
     }
 }
@@ -333,6 +357,13 @@ void CsvImportAssistant::greyOutCells(){
 
     //grey out non useful first rows
     for(int i = 0; i < int(firstLine()) - 1; i++)
+        for(int j = 0; j < nCols; j++){
+            m_tableWidget->item(i,j)->setBackground(Qt::gray);
+            m_tableWidget->item(i,j)->setFont(italicFont);
+        }
+
+    //grey out non useful last rows
+    for(int i = int(lastLine()); i < nRows; i++)
         for(int j = 0; j < nCols; j++){
             m_tableWidget->item(i,j)->setBackground(Qt::gray);
             m_tableWidget->item(i,j)->setFont(italicFont);
@@ -352,19 +383,19 @@ void CsvImportAssistant::greyOutCells(){
             }
 }
 
-void CsvImportAssistant::removeBlankColumns(std::vector<std::vector<std::string> > &dataArray){
+void CsvImportAssistant::removeBlankColumns(){
 
-    if(dataArray.empty())
+    if(m_csvArray.empty())
         return;
 
     std::vector<std::vector<std::string>> buffer2d;
     std::vector<std::string> buffer1d;
     std::vector<int> to_be_removed;
 
-    size_t nRows = dataArray.size();
-    size_t nCols = dataArray[0].size();
+    size_t nRows = m_csvArray.size();
+    size_t nCols = m_csvArray[0].size();
 
-    if(!hasEqualLengthLines(dataArray)){
+    if(!hasEqualLengthLines(m_csvArray)){
         throw Exceptions::NotImplementedException("All inner vectors should have the same length already.");
     }
 
@@ -372,7 +403,7 @@ void CsvImportAssistant::removeBlankColumns(std::vector<std::vector<std::string>
     for(size_t j = 0; j < nCols; j++){
         buffer1d.clear();
         for(size_t i = 0; i < nRows; i++){
-            buffer1d.push_back(dataArray[i][j]);
+            buffer1d.push_back(m_csvArray[i][j]);
         }
         if(QString::fromStdString(accumulate(buffer1d.begin(), buffer1d.end(), std::string(""))).trimmed() == "")
             continue;
@@ -381,7 +412,7 @@ void CsvImportAssistant::removeBlankColumns(std::vector<std::vector<std::string>
     }
 
     if(buffer2d.empty()){
-        dataArray.clear();
+        m_csvArray.clear();
         return;
     }
 
@@ -390,13 +421,13 @@ void CsvImportAssistant::removeBlankColumns(std::vector<std::vector<std::string>
     nRows = buffer2d[0].size();
 
     //Save the modified array --i.e. transpose buffer2d
-    dataArray.clear();
+    m_csvArray.clear();
     for(size_t i = 0; i < nRows; i++){
         buffer1d.clear();
         for(size_t j = 0; j < nCols; j++){
             buffer1d.push_back(buffer2d[j][i]);
         }
-        dataArray.push_back(buffer1d);
+        m_csvArray.push_back(buffer1d);
     }
 }
 
@@ -478,24 +509,11 @@ unsigned CsvImportAssistant::firstLine() const{
 }
 
 unsigned CsvImportAssistant::lastLine() const{
-    return m_lastDataRow;
+    return unsigned(m_lastDataRowSpinBox->value());
 }
 
-void CsvImportAssistant::OnColumnClicked(int row, int column)
-{
-    if(column < -1) return;
-    if(row < -1) return;
-
-    //m_tableWidget->clearSelection();
-    //m_tableWidget->selectionModel()->select
-    //    QModelIndex left   = m_tableWidget->model()->index(row, 0);
-    //   QModelIndex right  = m_tableWidget->model()->index(row, m_tableWidget->columnCount() - 1);
-    //  QModelIndex top    = m_tableWidget->model()->index(0, column);
-    // QModelIndex bottom = m_tableWidget->model()->index(m_tableWidget->rowCount() - 1, column);
-
-    //    QItemSelection selection(left, right);
-    //    selection.merge(QItemSelection(top, bottom), QItemSelectionModel::Select);
-    //    m_tableWidget->selectionModel()->select(selection, QItemSelectionModel::Select);
+unsigned CsvImportAssistant::maxLines() const{
+    return unsigned(m_lastDataRowSpinBox->maximum());
 }
 
 void CsvImportAssistant::onColumnRightClick(const QPoint position)
@@ -504,17 +522,19 @@ void CsvImportAssistant::onColumnRightClick(const QPoint position)
     if(!item) return;
     auto row = item->row();
     auto col = item->column();
-
     if(row*col < 0) return;
 
-    OnColumnClicked(row,col);
     QMenu menu;
-
 
     //Action "select from this row"
     QAction selectFromThisRowOn("Set as first data row",nullptr);
     menu.addAction(&selectFromThisRowOn);
     connect(&selectFromThisRowOn,&QAction::triggered,this,[this](){setFirstRow();});
+
+    //Action "select until this row"
+    QAction selectUntilThisRow("Set as last data row",nullptr);
+    menu.addAction(&selectUntilThisRow);
+    connect(&selectUntilThisRow,&QAction::triggered,this,[this](){setLastRow();});
 
     menu.addSeparator();
 
@@ -550,11 +570,10 @@ void CsvImportAssistant::onColumnRightClick(const QPoint position)
     //Action "reset"
     QAction resetAction("reset",nullptr);
     menu.addAction(&resetAction);
-    connect(&resetAction,&QAction::triggered, this, [this](){reset();});
+    connect(&resetAction,&QAction::triggered, this, [this](){reset(); Reload();});
 
     menu.exec(m_tableWidget->mapToGlobal(position));
 }
-
 
 bool CsvImportAssistant::hasEqualLengthLines(std::vector<std::vector<std::string>> &dataArray){
     auto tf =  all_of( begin(dataArray), end(dataArray), [dataArray](const std::vector<std::string>& x) {
@@ -562,7 +581,6 @@ bool CsvImportAssistant::hasEqualLengthLines(std::vector<std::vector<std::string
     });
     return tf;
 }
-
 
 void CsvImportAssistant::showErrorMessage(std::string message){
     QMessageBox msgBox;
@@ -641,8 +659,6 @@ void CsvImportAssistant::setCoordinateUnits(){
         m_units = AxesUnits::QSPACE;
 }
 
-
-
 void CsvImportAssistant::setFirstRow(){
     //get selected column
     auto selectedRanges = m_tableWidget->selectedRanges();
@@ -650,7 +666,25 @@ void CsvImportAssistant::setFirstRow(){
         return;
     auto front = selectedRanges.front();
     auto row = front.topRow();
-    m_firstDataRowSpinBox->setValue(row+1);
+    auto currentMax = m_firstDataRowSpinBox->maximum();
+    auto desiredVal = row+1;
+    auto newMax = std::max(currentMax,desiredVal);
+    m_firstDataRowSpinBox->setMaximum(newMax);
+    m_firstDataRowSpinBox->setValue(desiredVal);
+}
+
+void CsvImportAssistant::setLastRow(){
+    //get selected column
+    auto selectedRanges = m_tableWidget->selectedRanges();
+    if (selectedRanges.empty())
+        return;
+    auto front = selectedRanges.front();
+    auto row = front.topRow();
+    auto currentMin = m_firstDataRowSpinBox->minimum();
+    auto desiredVal = row+1;
+    auto newMin = std::min(currentMin,desiredVal);
+    m_lastDataRowSpinBox->setMinimum(newMin);
+    m_lastDataRowSpinBox->setValue(desiredVal);
 }
 
 void CsvImportAssistant::reset(){
@@ -658,11 +692,11 @@ void CsvImportAssistant::reset(){
     m_coordinateCol = 0;
     m_coordinateName = "";
     m_firstDataRowSpinBox->setValue(0);
+    m_lastDataRowSpinBox->setValue(int(maxLines()));
     setHeaders();
     m_units = AxesUnits::NBINS;
     m_coordinateUnitsSelector->clear();
     m_coordinateUnitsSelector->addItem(UnitsLabels[AxesUnits::NBINS]);
-    Reload();
 }
 
 double CsvImportAssistant::helperDoubleParser(std::string string_to_parse){

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/CsvImportAssistant.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/CsvImportAssistant.cpp
@@ -14,6 +14,8 @@
 
 #include "DataFormatUtils.cpp"
 #include "CsvImportAssistant.h"
+#include "DataSelector.h"
+#include "ImportDataInfo.h"
 #include "mainwindow_constants.h"
 #include "StyleUtils.h"
 #include <QPushButton>
@@ -25,144 +27,64 @@
 #include <QMenu>
 #include <QFormLayout>
 
-namespace
-{
-const QSize default_dialog_size(300, 400);
-}
-
-CsvImportAssistant::CsvImportAssistant(QString& file, QWidget* parent):
-        QDialog(parent)
-      ,m_fileName(file)
-      ,m_intensityCol(0)
-      ,m_coordinateCol(0)
-      ,m_units(AxesUnits::NBINS)
-      ,m_tableWidget(nullptr)
-      ,m_separatorField(nullptr)
-      ,m_firstDataRowSpinBox(nullptr)
-      ,m_lastDataRowSpinBox(nullptr)
-      ,m_importButton(nullptr)
+CsvImportAssistant::CsvImportAssistant(const QString& file, QWidget* parent):
+      m_fileName(file)
       ,m_csvFile(nullptr)
       ,m_csvArray()
-      ,m_coordinateUnitsSelector(nullptr)
-      ,m_setAsTheta(new QAction(HeaderLabels[_theta_],nullptr))
-      ,m_setAs2Theta(new QAction(HeaderLabels[_2theta_],nullptr))
-      ,m_setAsQ(new QAction(HeaderLabels[_q_],nullptr))
-      ,m_setAsIntensity(new QAction("Set as " + HeaderLabels[_intensity_] + " column",nullptr))
+      ,m_separator('\0')
+      ,m_intensityCol(0)
+      ,m_coordinateCol(0)
+      ,m_firstRow(0)
+      ,m_lastRow(0)
+      ,m_units(AxesUnits::NBINS)
+      ,m_dataAvailable(false)
 {
-    //We disable 2theta until the functionallity to handle it is implemented
-    m_setAs2Theta->setDisabled(true);
-    //
-    setWindowTitle("Data Importer");
-    setMinimumSize(default_dialog_size);
-    resize(600, 600);
-    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    StyleUtils::setResizable(this);
-    setLayout(createLayout());
-
-    if(!initialSetup()){
-        showErrorMessage("The file exist but it seems to be empty");
+    if(!loadCsvFile()){
         return;
     }
 
-    Reload();
+    runDataSelector(parent);
+
 }
 
-QBoxLayout* CsvImportAssistant::createLayout()
-{
-    //table Widget
-    m_tableWidget = new QTableWidget();
-    m_tableWidget->setContextMenuPolicy(Qt::CustomContextMenu);
-    m_tableWidget->setEditTriggers(QAbstractItemView::NoEditTriggers);
-    connect(m_tableWidget, &QTableWidget::customContextMenuRequested, this, &CsvImportAssistant::onColumnRightClick);
+void CsvImportAssistant::runDataSelector(QWidget* parent){
+    DataSelector selector(m_csvArray, parent);
 
-    //Import button
-    m_importButton = new QPushButton("Import");
-    m_importButton->setDefault(true);
-    connect(m_importButton, &QPushButton::clicked, this, &CsvImportAssistant::onImportButton);
-
-    //Reject button
-    auto rejectButton = new QPushButton("Cancel");
-    connect(rejectButton, &QPushButton::clicked, this, &CsvImportAssistant::onRejectButton);
-
-    //Separator field
-    m_separatorField = new QLineEdit(QString(""));
-    m_separatorField->setMaxLength(1);
-    m_separatorField->setMaximumWidth(100);
-    connect(m_separatorField, &QLineEdit::editingFinished, this, &CsvImportAssistant::reloadCsvFile);
-
-    //First Row SpinBox
-    m_firstDataRowSpinBox = new QSpinBox();
-    m_firstDataRowSpinBox->setMinimum(1);
-    m_firstDataRowSpinBox->setMaximum(1);
-    m_firstDataRowSpinBox->setValue(1);
-    m_firstDataRowSpinBox->setMaximumWidth(100);
-    connect(m_firstDataRowSpinBox, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
-            [this]()
-            {
-                m_lastDataRowSpinBox->setMinimum(m_firstDataRowSpinBox->value());
-                Reload();
-            }
+    connect(
+        &selector,
+        &DataSelector::separatorChanged,
+        this,
+        [this, &selector](char newSep){
+            m_separator = newSep;
+            loadCsvFile();
+            selector.setDataArray(m_csvArray);
+        }
     );
 
-    //Last Row SpinBox
-    m_lastDataRowSpinBox = new QSpinBox();
-    m_lastDataRowSpinBox->setMinimum(1);
-    m_lastDataRowSpinBox->setMaximum(1);
-    m_lastDataRowSpinBox->setValue(1);
-    m_lastDataRowSpinBox->setMaximumWidth(100);
-    connect(m_lastDataRowSpinBox, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
-            [this]()
-            {
-                m_firstDataRowSpinBox->setMaximum(m_lastDataRowSpinBox->value());
-                Reload();
-            }
-    );
+    int res = selector.exec();
 
-    //Column type selector
-    m_coordinateUnitsSelector = new QComboBox();
-    m_coordinateUnitsSelector->setMaximumWidth(100);
-    m_coordinateUnitsSelector->addItem(UnitsLabels[AxesUnits::NBINS]);
-    connect(m_coordinateUnitsSelector,static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),this, [this](){ setCoordinateUnits(); });
+    if(res == selector.Accepted){
+        m_intensityCol = selector.intensityColumn();
+        m_coordinateCol = selector.coordinateColumn();
+        m_units = selector.units();
+        m_firstRow = selector.firstLine();
+        m_lastRow = selector.lastLine();
+        m_dataAvailable = true;
+    }
+    else if(res == selector.Rejected){
+        m_dataAvailable = false;
+        return;
+    }
 
-
-    auto layout = new QVBoxLayout;
-    layout->setContentsMargins(0, 0, 0, 0);
-
-    //place table Widget
-    auto tableLayout = new QVBoxLayout;
-    tableLayout->setMargin(10);
-    tableLayout->addWidget(new QLabel("Right click on the table to select what will be imported"));
-    tableLayout->addWidget(m_tableWidget);
-
-    //place separator_field and first_row:
-    auto controlsLayout = new QFormLayout;
-    controlsLayout->addRow(tr("&Corodinate Units: "), m_coordinateUnitsSelector);
-    controlsLayout->addRow(tr("&Separator: "), m_separatorField);
-    controlsLayout->addRow(tr("&From row: "), m_firstDataRowSpinBox);
-    controlsLayout->addRow(tr("&To row: "), m_lastDataRowSpinBox);
-
-    //buttons layout
-    auto buttonsLayout = new QHBoxLayout;
-    buttonsLayout->addWidget(m_importButton);
-    buttonsLayout->addWidget(rejectButton);
-
-    //place controls and import/reject buttons
-    auto controlsAndButtonsGrid = new QGridLayout;
-    controlsAndButtonsGrid->setMargin(10);
-    controlsAndButtonsGrid->addItem(new QSpacerItem(10000,1),1,1,2,1);
-    controlsAndButtonsGrid->addLayout(controlsLayout, 1, 2, 1, 1, Qt::AlignRight);
-    controlsAndButtonsGrid->addLayout(buttonsLayout, 2, 2, 1, 1, Qt::AlignLeft);
-
-    //build all the layout
-    layout->addLayout(tableLayout);
-    layout->addLayout(controlsAndButtonsGrid);
-
-    return layout;
 }
 
-bool CsvImportAssistant::initialSetup(){
+bool CsvImportAssistant::loadCsvFile(){
+
     try {
-        m_csvFile = std::make_unique<CSVFile>(m_fileName.toStdString(), separator());
+        if(m_separator=='\0')
+            m_separator = guessSeparator();
+
+        m_csvFile = std::make_unique<CSVFile>(m_fileName.toStdString(), m_separator);
     }
     catch (...) {
         showErrorMessage("There was a problem opening the file \"" + m_fileName.toStdString() + "\"");
@@ -170,217 +92,80 @@ bool CsvImportAssistant::initialSetup(){
     }
 
     size_t lastRow = m_csvFile->NumberOfRows();
-    auto csvArray = m_csvFile->asArray();
 
-
-    if (lastRow < 1) {
-        m_importButton->setDisabled(true);
+    if (lastRow < 1){
+        CsvImportAssistant::showErrorMessage("The file exist but it seems to be empty");
         return false;
     }
+
+    auto csvArray = m_csvFile->asArray();
 
     //Automatically ignore empty lines at the end:
     while(QString::fromStdString(accumulate(csvArray[lastRow-1].begin(), csvArray[lastRow-1].end(), std::string(""))).trimmed() == ""){
         lastRow--;
         if (lastRow < 1) {
-            m_importButton->setDisabled(true);
             return false;
         }
     }
 
-    //Set maximum values for spinboxes
-    m_firstDataRowSpinBox->setMaximum(int(lastRow));
-    m_lastDataRowSpinBox->setMaximum(int(lastRow));
-    m_lastDataRowSpinBox->setValue(int(lastRow));
-
-    std::vector<std::vector<std::string>> tmp(csvArray.begin() , csvArray.begin() + maxLines());
+    csv::DataArray tmp(csvArray.begin() , csvArray.begin() + int(lastRow));
     m_csvArray.swap(tmp);
     return true;
 }
 
+void CsvImportAssistant::resetAssistant(){
+    resetSelection();
+    loadCsvFile();
+}
 
-void CsvImportAssistant::Reload()
+ImportDataInfo CsvImportAssistant::fillData()
 {
-    m_importButton->setEnabled(false);
-    m_coordinateUnitsSelector->setEnabled(false);
-    std::ifstream f(m_fileName.toStdString());
-    if(f.good()){
-        generate_table();
-    }else{
-        QMessageBox msgBox;
-        std::string message = "There was a problem opening the file \"" + m_fileName.toStdString() + "\"";
-        message += "\n Check for any errors in the path and try again.";
-        msgBox.setText(QString::fromStdString(message));
-        msgBox.setIcon(msgBox.Critical);
-        msgBox.exec();
-    }
-
-    //Enable import button only if the user has selected its columns for 1d import
-    if( m_intensityCol > 0 )
-        m_importButton->setEnabled(true);
-
-    //Enable Coordinate Selector
-    if( m_coordinateCol > 0 )
-        m_coordinateUnitsSelector->setEnabled(true);
-}
-
-void CsvImportAssistant::reloadCsvFile(){
-    reset();
-    initialSetup();
-    Reload();
-}
-
-void CsvImportAssistant::onRejectButton(){
-    reject();
-}
-
-
-void CsvImportAssistant::onImportButton()
-{
-    try {
-        auto data = getData();
-        accept();
-    } catch(std::exception& e){
-        QString message = QString("Unable to import, the following exception was thrown:\n") + QString::fromStdString(e.what());
-        QMessageBox::warning(nullptr, "Wrong data format", message);
-    }
-}
-
-ImportDataInfo CsvImportAssistant::getData()
-{
+    // In case a 2d import is needed in the future
+    // Use ArrayUtils::Create2dData(vector<vector<double>>)
+    // ArrayUtils::Create2d
 
     std::unique_ptr<OutputData<double>> resultOutputData;
     resultOutputData = std::make_unique<OutputData<double>>();
+    std::vector<double> intensityValues;
+    std::vector<double> coordinateValues;
+    if(m_intensityCol > 0)
+        intensityValues = getValuesFromColumn(m_intensityCol-1);
 
-    auto nRows = m_tableWidget->rowCount();
-    auto firstRow = int(firstLine()-1);
-    auto lastRow = int(lastLine());
-
-    //Coordinate and Intensity columns selected
-    if(m_coordinateCol * m_intensityCol > 0){
-        //Fill intensity values and coordinate values:
-        std::vector<double> coordValues;
-        std::vector<double> intensityValues;
-        int intensityCol = int(m_intensityCol-1);
-        int coordinateCol = int(m_coordinateCol-1);
-        for(auto row = firstRow; row < lastRow; row++) {
-            coordValues.push_back(
-            helperDoubleParser(
-                            m_tableWidget->item(row,coordinateCol)->text().toStdString()
-                            )
-                        );
-
-            intensityValues.push_back(
-             helperDoubleParser(
-                           m_tableWidget->item(row,intensityCol)->text().toStdString()
-                            )
-                        );
-        }
-        auto axisName = m_coordinateName.toStdString();
-        PointwiseAxis coordAxis(axisName, coordValues);
-        resultOutputData->addAxis(coordAxis);
-
-        for(unsigned i = 0; i < intensityValues.size(); i++)
-            (*resultOutputData)[i] = intensityValues[i];
+    if(m_coordinateCol > 0){
+        coordinateValues = getValuesFromColumn(m_coordinateCol-1);
     }
-
-    //Single column selected
-    else if( m_intensityCol > 0){
-        //Fill intensity values
-        std::vector<double> intensityValues;
-        int intensityCol = int(m_intensityCol-1);
-        for(auto row = firstRow; row < lastRow; row++) {
-            intensityValues.push_back(
-            helperDoubleParser(
-                           m_tableWidget->item(row,intensityCol)->text().toStdString()
-                            )
-                        );
-
-        }
-        resultOutputData->addAxis("AXIS", size_t(nRows), 0.0, double(nRows-1));
-        for(unsigned i = 0; i < intensityValues.size(); i++)
-            (*resultOutputData)[i] = intensityValues[i];
-
-    }
-
-    //We shouldn't be here
     else{
-        showErrorMessage("Somethig went wrong during 1D data import.");
-        return ImportDataInfo();
+        for(size_t i = 0; i < intensityValues.size(); i++)
+            coordinateValues.push_back(double(i));
     }
+
+    auto axisName = UnitsLabels[m_units].toStdString();
+    PointwiseAxis coordAxis(axisName, coordinateValues);
+    resultOutputData->addAxis(coordAxis);
+    resultOutputData->setRawDataVector(intensityValues);
+
+    for(unsigned i = 0; i < intensityValues.size(); i++)
+        std::cout << (*resultOutputData)[i] << std::endl;
+
+
+    //for(unsigned i = 0; i < intensityValues.size(); i++)
+    //    (*resultOutputData)[i] = intensityValues[i];
 
     ImportDataInfo result(std::move(resultOutputData),m_units);
     return result;
-
-    /*In case a 2d import is needed in the future
-     *Use ArrayUtils::Create2dData(vector<vector<double>>)
-     * ArrayUtils::Create2d
-    */
 }
 
-void CsvImportAssistant::generate_table() {
-    removeBlankColumns();
 
-    set_table_data();
+std::vector<double> CsvImportAssistant::getValuesFromColumn(size_t jCol)
+{
+    std::vector<double> result;
+    auto firstRow = m_firstRow - 1;
+    auto lastRow = m_lastRow ;
 
-    greyOutCells();
-}
+    for(auto row = firstRow; row < lastRow; row++)
+        result.push_back(stringToDouble(m_csvArray[row][jCol]));
 
-void CsvImportAssistant::set_table_data(){
-
-    if(m_csvArray.empty()){
-        m_tableWidget->clearContents();
-        m_tableWidget->setRowCount(0);
-        return;
-    }
-
-    size_t nRows = m_csvArray.size();
-    size_t nCols = m_csvArray[0].size();
-    m_tableWidget->clearContents();
-    m_tableWidget->setColumnCount(int(nCols));
-    m_tableWidget->setRowCount(0);
-
-    for(unsigned i = 0; i < nRows ; i++){
-        m_tableWidget->insertRow(m_tableWidget->rowCount());
-        unsigned I = unsigned(m_tableWidget->rowCount()) - 1;
-        for(unsigned j = 0; j < m_csvArray[i].size(); j++){
-            m_tableWidget->setItem(int(I),int(j),new QTableWidgetItem(QString::fromStdString(m_csvArray[i][j])));
-        }
-    }
-}
-
-void CsvImportAssistant::greyOutCells(){
-    int nRows = m_tableWidget->rowCount();
-    int nCols = m_tableWidget->columnCount();
-    QFont italicFont;
-    italicFont.setItalic(true);
-    italicFont.setStrikeOut(true);
-
-    //grey out non useful first rows
-    for(int i = 0; i < int(firstLine()) - 1; i++)
-        for(int j = 0; j < nCols; j++){
-            m_tableWidget->item(i,j)->setBackground(Qt::gray);
-            m_tableWidget->item(i,j)->setFont(italicFont);
-        }
-
-    //grey out non useful last rows
-    for(int i = int(lastLine()); i < nRows; i++)
-        for(int j = 0; j < nCols; j++){
-            m_tableWidget->item(i,j)->setBackground(Qt::gray);
-            m_tableWidget->item(i,j)->setFont(italicFont);
-        }
-
-    //Return if there are no columns to grey out
-    if( m_intensityCol  < 1 )
-        return;
-
-    //Grey out columns
-    for(int i = 0; i < nRows; i++)
-        for(int j = 0; j < nCols; j++)
-            if(j+1 != int(m_coordinateCol) &&
-                            j+1 != int(m_intensityCol) ){
-                m_tableWidget->item(i,j)->setBackground(Qt::gray);
-                m_tableWidget->item(i,j)->setFont(italicFont);
-            }
+    return result;
 }
 
 void CsvImportAssistant::removeBlankColumns(){
@@ -388,8 +173,8 @@ void CsvImportAssistant::removeBlankColumns(){
     if(m_csvArray.empty())
         return;
 
-    std::vector<std::vector<std::string>> buffer2d;
-    std::vector<std::string> buffer1d;
+    csv::DataArray buffer2d;
+    csv::DataRow buffer1d;
     std::vector<int> to_be_removed;
 
     size_t nRows = m_csvArray.size();
@@ -431,19 +216,6 @@ void CsvImportAssistant::removeBlankColumns(){
     }
 }
 
-char CsvImportAssistant::separator() const{
-    char separator;
-    QString tmpstr = m_separatorField->text();
-    if(tmpstr.size() < 1){
-        separator = guessSeparator();
-        m_separatorField->setText(QString(QChar::fromLatin1(separator)));
-    }
-    else{
-        separator = tmpstr.at(0).toLatin1();
-    }
-    return separator;
-}
-
 char CsvImportAssistant::guessSeparator() const{
     int frequencies[127] = {0};
 
@@ -462,7 +234,6 @@ char CsvImportAssistant::guessSeparator() const{
     preferredSeparators.push_back('_');
     preferredSeparators.push_back('\'');
     preferredSeparators.push_back('\"');
-
 
     //count number of occurences of each char in the file:
     char c;
@@ -494,89 +265,9 @@ char CsvImportAssistant::guessSeparator() const{
     return guessedSep;
 }
 
-void CsvImportAssistant::setHeaders(){
-    //Reset header labels
-    QStringList headers;
 
-    for(int j = 0; j < m_tableWidget->columnCount(); j++)
-        headers.append(QString::number(j + 1));
-
-    m_tableWidget->setHorizontalHeaderLabels(headers);
-}
-
-unsigned CsvImportAssistant::firstLine() const{
-    return unsigned(m_firstDataRowSpinBox->value());
-}
-
-unsigned CsvImportAssistant::lastLine() const{
-    return unsigned(m_lastDataRowSpinBox->value());
-}
-
-unsigned CsvImportAssistant::maxLines() const{
-    return unsigned(m_lastDataRowSpinBox->maximum());
-}
-
-void CsvImportAssistant::onColumnRightClick(const QPoint position)
-{
-    auto item = m_tableWidget->itemAt(position);
-    if(!item) return;
-    auto row = item->row();
-    auto col = item->column();
-    if(row*col < 0) return;
-
-    QMenu menu;
-
-    //Action "select from this row"
-    QAction selectFromThisRowOn("Set as first data row",nullptr);
-    menu.addAction(&selectFromThisRowOn);
-    connect(&selectFromThisRowOn,&QAction::triggered,this,[this](){setFirstRow();});
-
-    //Action "select until this row"
-    QAction selectUntilThisRow("Set as last data row",nullptr);
-    menu.addAction(&selectUntilThisRow);
-    connect(&selectUntilThisRow,&QAction::triggered,this,[this](){setLastRow();});
-
-    menu.addSeparator();
-
-
-    //Set column as "Intensity".
-    m_setAsIntensity->setDisabled(m_intensityCol>0);
-    menu.addAction(m_setAsIntensity);
-    connect(m_setAsIntensity,&QAction::triggered,this, [this](){setColumnAsIntensity();});
-    //.connect(m_setAsIntensity,&QAction::triggered,this, m_setAsIntensityColumnAsIntensity());
-
-
-    //Coordinate menu disabled if a coordinate column is already set.
-    QMenu *coordMenu = menu.addMenu("Set as coordinate column...");
-    coordMenu->setDisabled(m_coordinateCol>0);
-
-
-    //Set column as "Theta".
-    coordMenu->addAction(m_setAsTheta);
-    connect(m_setAsTheta,&QAction::triggered,this, [this](){setColumnAsCoordinate(_theta_);});
-
-
-    //Set column as "2Theta".
-    coordMenu->addAction(m_setAs2Theta);
-    connect(m_setAs2Theta,&QAction::triggered,this, [this](){setColumnAsCoordinate(_2theta_);});
-
-
-    //Set column as "q".
-    coordMenu->addAction(m_setAsQ);
-    connect(m_setAsQ,&QAction::triggered,this, [this](){setColumnAsCoordinate(_q_);});
-
-    menu.addSeparator();
-
-    //Action "reset"
-    QAction resetAction("reset",nullptr);
-    menu.addAction(&resetAction);
-    connect(&resetAction,&QAction::triggered, this, [this](){reset(); Reload();});
-
-    menu.exec(m_tableWidget->mapToGlobal(position));
-}
-
-bool CsvImportAssistant::hasEqualLengthLines(std::vector<std::vector<std::string>> &dataArray){
-    auto tf =  all_of( begin(dataArray), end(dataArray), [dataArray](const std::vector<std::string>& x) {
+bool CsvImportAssistant::hasEqualLengthLines(csv::DataArray &dataArray){
+    auto tf =  all_of( begin(dataArray), end(dataArray), [dataArray](const csv::DataRow& x) {
         return x.size() == dataArray.front().size();
     });
     return tf;
@@ -589,118 +280,17 @@ void CsvImportAssistant::showErrorMessage(std::string message){
     msgBox.exec();
 }
 
-void CsvImportAssistant::populateUnitsComboBox(int coord){
-    m_coordinateUnitsSelector->clear();
-    switch(coord){
-
-    case _theta_:
-        m_coordinateUnitsSelector->addItem(UnitsLabels[AxesUnits::DEGREES]);
-        m_coordinateUnitsSelector->addItem(UnitsLabels[AxesUnits::RADIANS]);
-        break;
-
-    case _2theta_:
-        m_coordinateUnitsSelector->addItem(UnitsLabels[AxesUnits::DEGREES]);
-        m_coordinateUnitsSelector->addItem(UnitsLabels[AxesUnits::RADIANS]);
-        break;
-
-    case _q_:
-        m_coordinateUnitsSelector->addItem(UnitsLabels[AxesUnits::QSPACE]);
-        break;
-
-    default:
-        m_coordinateUnitsSelector->addItem(UnitsLabels[AxesUnits::NBINS]);
-        break;
-    }
-}
-
-void CsvImportAssistant::setColumnAsCoordinate(int coord){
-    auto selectedRanges = m_tableWidget->selectedRanges();
-    if (selectedRanges.empty())
-        return;
-    auto front = selectedRanges.front();
-    auto col = front.leftColumn();
-
-    m_tableWidget->setHorizontalHeaderItem( col, new QTableWidgetItem( HeaderLabels[coord]) );
-    m_coordinateCol = unsigned(col+1);
-    m_coordinateName = m_tableWidget->horizontalHeaderItem(col)->text();
-    populateUnitsComboBox(coord);
-    if(m_coordinateCol == m_intensityCol){
-        m_intensityCol=0;
-    }
-    Reload();
-}
-
-void CsvImportAssistant::setColumnAsIntensity() {
-    //get selected column
-    auto selectedRanges = m_tableWidget->selectedRanges();
-    if (selectedRanges.empty())
-        return;
-    auto front = selectedRanges.front();
-    auto col = front.leftColumn();
-
-    m_tableWidget->clearSelection();
-    m_tableWidget->setHorizontalHeaderItem(col, new QTableWidgetItem(HeaderLabels[_intensity_]));
-    m_intensityCol = unsigned(col + 1);
-    if (m_coordinateCol == m_intensityCol) {
-        m_coordinateCol = 0;
-    }
-    Reload();
-}
-
-void CsvImportAssistant::setCoordinateUnits(){
-    m_units = AxesUnits::NBINS;
-    if(m_coordinateUnitsSelector->currentText() == UnitsLabels[AxesUnits::DEGREES])
-        m_units = AxesUnits::DEGREES;
-
-    if(m_coordinateUnitsSelector->currentText() == UnitsLabels[AxesUnits::RADIANS])
-        m_units = AxesUnits::RADIANS;
-
-    if(m_coordinateUnitsSelector->currentText() == UnitsLabels[AxesUnits::QSPACE])
-        m_units = AxesUnits::QSPACE;
-}
-
-void CsvImportAssistant::setFirstRow(){
-    //get selected column
-    auto selectedRanges = m_tableWidget->selectedRanges();
-    if (selectedRanges.empty())
-        return;
-    auto front = selectedRanges.front();
-    auto row = front.topRow();
-    auto currentMax = m_firstDataRowSpinBox->maximum();
-    auto desiredVal = row+1;
-    auto newMax = std::max(currentMax,desiredVal);
-    m_firstDataRowSpinBox->setMaximum(newMax);
-    m_firstDataRowSpinBox->setValue(desiredVal);
-}
-
-void CsvImportAssistant::setLastRow(){
-    //get selected column
-    auto selectedRanges = m_tableWidget->selectedRanges();
-    if (selectedRanges.empty())
-        return;
-    auto front = selectedRanges.front();
-    auto row = front.topRow();
-    auto currentMin = m_firstDataRowSpinBox->minimum();
-    auto desiredVal = row+1;
-    auto newMin = std::min(currentMin,desiredVal);
-    m_lastDataRowSpinBox->setMinimum(newMin);
-    m_lastDataRowSpinBox->setValue(desiredVal);
-}
-
-void CsvImportAssistant::reset(){
+void CsvImportAssistant::resetSelection(){
+    m_csvArray.clear();
     m_intensityCol = 0;
     m_coordinateCol = 0;
-    m_coordinateName = "";
-    m_firstDataRowSpinBox->setValue(0);
-    m_lastDataRowSpinBox->setValue(int(maxLines()));
-    setHeaders();
+    m_firstRow = 0;
+    m_lastRow = 0;
     m_units = AxesUnits::NBINS;
-    m_coordinateUnitsSelector->clear();
-    m_coordinateUnitsSelector->addItem(UnitsLabels[AxesUnits::NBINS]);
+    m_dataAvailable = false;
 }
 
-double CsvImportAssistant::helperDoubleParser(std::string string_to_parse){
-        std::vector<double> parsed_doubles;
-        parsed_doubles = DataFormatUtils::parse_doubles(string_to_parse);
-        return parsed_doubles[0];
+double CsvImportAssistant::stringToDouble(std::string stringToParse){
+            return DataFormatUtils::parse_doubles(stringToParse)[0];
 }
+

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/CsvImportAssistant.h
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/CsvImportAssistant.h
@@ -35,14 +35,17 @@ class BA_CORE_API_ CsvImportAssistant: public QObject
     Q_OBJECT
 public:
     CsvImportAssistant(const QString& file, QWidget* parent = nullptr);
-    bool loadCsvFile();
     ImportDataInfo getData(){return m_dataAvailable ? fillData() : ImportDataInfo();}
-    ImportDataInfo fillData();
-    bool hasEqualLengthLines(csv::DataArray &dataArray);
     static void showErrorMessage(std::string message);
     static double stringToDouble(std::string string_to_parse);
 
 private:
+    bool loadCsvFile();
+    ImportDataInfo fillData();
+    bool hasEqualLengthLines(csv::DataArray &dataArray);
+
+
+
 
     char guessSeparator() const;
     void removeBlankColumns();

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/CsvImportAssistant.h
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/CsvImportAssistant.h
@@ -34,10 +34,6 @@ enum  RelevantColumns {_intensity_,_theta_,_2theta_,_q_};
 const QStringList HeaderLabels{"Intensity","theta","2theta","q"};
 const QStringList UnitsLabels{"default", "bin", "rad", "deg", "mm", "1/nm"};
 
-namespace{
-}
-
-
 //! Dialog to hold ImportAssistant.
 class BA_CORE_API_ CsvImportAssistant : public QDialog
 {
@@ -49,25 +45,25 @@ public:
     void setHeaders();
     unsigned firstLine() const;
     unsigned lastLine() const;
+    unsigned maxLines() const;
     void Reload();
     ImportDataInfo getData();
 
 public slots:
     void onImportButton();
     void onRejectButton();
-    void OnColumnClicked(int row, int column);
     void onColumnRightClick(QPoint position);
 
 private:
     QBoxLayout* createLayout();
     QBoxLayout* createFileDetailsLayout();
+    bool initialSetup();
 
     char guessSeparator() const;
     void reloadCsvFile();
     void generate_table();
-    void set_table_data(std::vector<std::vector<std::string>> dataArray);
-    void removeBlankColumns(std::vector<std::vector<std::string>> &dataArray);
-    void extractDesiredColumns(std::vector<std::vector<std::string>> &dataArray);
+    void set_table_data();
+    void removeBlankColumns();
     bool hasEqualLengthLines(std::vector<std::vector<std::string> > &dataArray);
     void populateUnitsComboBox(int coordinate);
     void greyOutCells();
@@ -76,13 +72,13 @@ private:
     void setColumnAsIntensity();
     void setCoordinateUnits();
     void setFirstRow();
+    void setLastRow();
     void reset();
     double helperDoubleParser(std::string string_to_parse);
 
 
 
     QString m_fileName;
-    unsigned m_lastDataRow;
     unsigned m_intensityCol;
     unsigned m_coordinateCol;
     AxesUnits m_units;
@@ -91,8 +87,10 @@ private:
     QTableWidget* m_tableWidget;
     QLineEdit* m_separatorField;
     QSpinBox* m_firstDataRowSpinBox;
+    QSpinBox* m_lastDataRowSpinBox;
     QPushButton* m_importButton;
     std::unique_ptr<CSVFile> m_csvFile;
+    std::vector<std::vector<std::string>> m_csvArray;
     QComboBox* m_coordinateUnitsSelector;
     QAction* m_setAsTheta;
     QAction* m_setAs2Theta;

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/CsvImportAssistant.h
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/CsvImportAssistant.h
@@ -18,6 +18,7 @@
 #include "WinDllMacros.h"
 #include "CsvReader.h"
 #include "ImportDataInfo.h"
+#include "DataFormatUtils.h"
 #include <QAction>
 #include <QDialog>
 #include <QTableWidget>
@@ -33,8 +34,11 @@ enum  RelevantColumns {_intensity_,_theta_,_2theta_,_q_};
 const QStringList HeaderLabels{"Intensity","theta","2theta","q"};
 const QStringList UnitsLabels{"default", "bin", "rad", "deg", "mm", "1/nm"};
 
-//! Dialog to hold ImportAssistant.
+namespace{
+}
 
+
+//! Dialog to hold ImportAssistant.
 class BA_CORE_API_ CsvImportAssistant : public QDialog
 {
     Q_OBJECT
@@ -73,6 +77,8 @@ private:
     void setCoordinateUnits();
     void setFirstRow();
     void reset();
+    double helperDoubleParser(std::string string_to_parse);
+
 
 
     QString m_fileName;
@@ -96,5 +102,6 @@ private:
     QAction* m_setCoordinateUnits;
 
 };
+
 
 #endif // CSVIMPORTASSISTANT_H

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/CsvImportAssistant.h
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/CsvImportAssistant.h
@@ -19,87 +19,49 @@
 #include "CsvReader.h"
 #include "ImportDataInfo.h"
 #include "DataFormatUtils.h"
-#include <QAction>
-#include <QDialog>
-#include <QTableWidget>
-#include <QLineEdit>
-#include <QLabel>
-#include <QSpinBox>
-#include <QComboBox>
+#include <QStringList>
+#include <QWidget>
 #include <memory>
 
-class QBoxLayout;
+namespace csv{
+typedef std::vector<std::vector<std::string>> DataArray ;
+typedef std::vector<std::string> DataRow;
+}
 
-enum  RelevantColumns {_intensity_,_theta_,_2theta_,_q_};
-const QStringList HeaderLabels{"Intensity","theta","2theta","q"};
-const QStringList UnitsLabels{"default", "bin", "rad", "deg", "mm", "1/nm"};
+//! Logic for importing intensity data from csv files
 
-//! Dialog to hold ImportAssistant.
-class BA_CORE_API_ CsvImportAssistant : public QDialog
+class BA_CORE_API_ CsvImportAssistant: public QObject
 {
     Q_OBJECT
-
 public:
-    CsvImportAssistant(QString& file, QWidget* parent = nullptr);
-    char separator() const;
-    void setHeaders();
-    unsigned firstLine() const;
-    unsigned lastLine() const;
-    unsigned maxLines() const;
-    void Reload();
-    ImportDataInfo getData();
-
-public slots:
-    void onImportButton();
-    void onRejectButton();
-    void onColumnRightClick(QPoint position);
+    CsvImportAssistant(const QString& file, QWidget* parent = nullptr);
+    bool loadCsvFile();
+    ImportDataInfo getData(){return m_dataAvailable ? fillData() : ImportDataInfo();}
+    ImportDataInfo fillData();
+    bool hasEqualLengthLines(csv::DataArray &dataArray);
+    static void showErrorMessage(std::string message);
+    static double stringToDouble(std::string string_to_parse);
 
 private:
-    QBoxLayout* createLayout();
-    QBoxLayout* createFileDetailsLayout();
-    bool initialSetup();
 
     char guessSeparator() const;
-    void reloadCsvFile();
-    void generate_table();
-    void set_table_data();
     void removeBlankColumns();
-    bool hasEqualLengthLines(std::vector<std::vector<std::string> > &dataArray);
-    void populateUnitsComboBox(int coordinate);
-    void greyOutCells();
-    void showErrorMessage(std::string message);
-    void setColumnAsCoordinate(int coord);
-    void setColumnAsIntensity();
-    void setCoordinateUnits();
-    void setFirstRow();
-    void setLastRow();
-    void reset();
-    double helperDoubleParser(std::string string_to_parse);
+    void runDataSelector(QWidget* parent);
+    std::vector<double> getValuesFromColumn(size_t jcol);
+    void resetSelection();
+    void resetAssistant();
 
-
+    //Helpers:
 
     QString m_fileName;
+    std::unique_ptr<CSVFile> m_csvFile;
+    csv::DataArray m_csvArray;
+    char m_separator;
     unsigned m_intensityCol;
     unsigned m_coordinateCol;
+    unsigned m_firstRow;
+    unsigned m_lastRow;
     AxesUnits m_units;
-    QString  m_coordinateName;
-
-    QTableWidget* m_tableWidget;
-    QLineEdit* m_separatorField;
-    QSpinBox* m_firstDataRowSpinBox;
-    QSpinBox* m_lastDataRowSpinBox;
-    QPushButton* m_importButton;
-    std::unique_ptr<CSVFile> m_csvFile;
-    std::vector<std::vector<std::string>> m_csvArray;
-    QComboBox* m_coordinateUnitsSelector;
-    QAction* m_setAsTheta;
-    QAction* m_setAs2Theta;
-    QAction* m_setAsQ;
-    QAction* m_setAsIntensity;
-    QAction* m_setAsIntensityBins;
-    QAction* m_setCoordinateUnits;
-
+    bool m_dataAvailable;
 };
-
-
 #endif // CSVIMPORTASSISTANT_H

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/DataSelector.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/DataSelector.cpp
@@ -30,137 +30,6 @@ namespace
 const QSize default_dialog_size(300, 400);
 }
 
-QBoxLayout* DataSelector::createLayout()
-{
-    //table Widget
-    m_tableWidget = new QTableWidget();
-    m_tableWidget->setContextMenuPolicy(Qt::CustomContextMenu);
-    m_tableWidget->setEditTriggers(QAbstractItemView::NoEditTriggers);
-    connect(m_tableWidget, &QTableWidget::customContextMenuRequested, this, &DataSelector::onColumnRightClick);
-
-    //Import button
-    m_importButton = new QPushButton("Import");
-    m_importButton->setDefault(true);
-    connect(m_importButton, &QPushButton::clicked, this, &DataSelector::onImportButton);
-
-    //Reject button
-    m_cancelButton = new QPushButton("Cancel");
-    connect(m_cancelButton, &QPushButton::clicked, this, [this](){reject();});
-
-    //Separator field -- This needs to communicate with importAssistant
-    // TODO
-    m_separatorField = new QLineEdit(QString(""));
-    m_separatorField->setMaxLength(1);
-    m_separatorField->setMaximumWidth(100);
-    connect(m_separatorField, &QLineEdit::editingFinished, this,
-            [this]()
-            {
-                emit separatorChanged(separator());
-            }
-    );
-
-    //First Row SpinBox
-    m_firstDataRowSpinBox = new QSpinBox();
-    m_firstDataRowSpinBox->setMinimum(1);
-    m_firstDataRowSpinBox->setMaximum(1);
-    m_firstDataRowSpinBox->setValue(1);
-    m_firstDataRowSpinBox->setMaximumWidth(100);
-    connect(m_firstDataRowSpinBox, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
-            [this]()
-            {
-                m_lastDataRowSpinBox->setMinimum(m_firstDataRowSpinBox->value());
-                updateSelection();
-            }
-    );
-
-    //Last Row SpinBox
-    m_lastDataRowSpinBox = new QSpinBox();
-    m_lastDataRowSpinBox->setMinimum(1);
-    m_lastDataRowSpinBox->setMaximum(1);
-    m_lastDataRowSpinBox->setValue(1);
-    m_lastDataRowSpinBox->setMaximumWidth(100);
-    connect(m_lastDataRowSpinBox, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
-            [this]()
-            {
-                m_firstDataRowSpinBox->setMaximum(m_lastDataRowSpinBox->value());
-                updateSelection();
-            }
-    );
-
-    //Column type selector
-    m_coordinateUnitsSelector = new QComboBox();
-    m_coordinateUnitsSelector->setMaximumWidth(100);
-    m_coordinateUnitsSelector->addItem(UnitsLabels[AxesUnits::NBINS]);
-    //connect(m_coordinateUnitsSelector,static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),this, [this](){ setCoordinateUnits(); });
-
-
-    auto layout = new QVBoxLayout;
-    layout->setContentsMargins(0, 0, 0, 0);
-
-    //place table Widget
-    auto tableLayout = new QVBoxLayout;
-    tableLayout->setMargin(10);
-    tableLayout->addWidget(new QLabel("Right click on the table to select what will be imported"));
-    tableLayout->addWidget(m_tableWidget);
-
-    //place separator_field and first_row:
-    auto controlsLayout = new QFormLayout;
-    controlsLayout->addRow(tr("&Corodinate Units: "), m_coordinateUnitsSelector);
-    controlsLayout->addRow(tr("&Separator: "), m_separatorField);
-    controlsLayout->addRow(tr("&From row: "), m_firstDataRowSpinBox);
-    controlsLayout->addRow(tr("&To row: "), m_lastDataRowSpinBox);
-
-    //buttons layout
-    auto buttonsLayout = new QHBoxLayout;
-    buttonsLayout->addWidget(m_importButton);
-    buttonsLayout->addWidget(m_cancelButton);
-
-    //place controls and import/reject buttons
-    auto controlsAndButtonsGrid = new QGridLayout;
-    controlsAndButtonsGrid->setMargin(10);
-    controlsAndButtonsGrid->addItem(new QSpacerItem(10000,1),1,1,2,1);
-    controlsAndButtonsGrid->addLayout(controlsLayout, 1, 2, 1, 1, Qt::AlignRight);
-    controlsAndButtonsGrid->addLayout(buttonsLayout, 2, 2, 1, 1, Qt::AlignLeft);
-
-    //build all the layout
-    layout->addLayout(tableLayout);
-    layout->addLayout(controlsAndButtonsGrid);
-
-    return layout;
-}
-
-void DataSelector::onCancelButton()
-{
-    reject();
-}
-
-void DataSelector::onImportButton()
-{
-    if(dataLooksGood()){
-        accept();
-    }
-}
-
-bool DataSelector::dataLooksGood(){
-    try{
-        for(auto i = firstLine() - 1; i < lastLine(); i++){
-            CsvImportAssistant::stringToDouble(
-                                    m_tableWidget->item(i,m_intensityCol-1)->text().toStdString()
-                                    );
-            if(m_coordinateCol > 0)
-                CsvImportAssistant::stringToDouble(
-                                        m_tableWidget->item(i,m_intensityCol-1)->text().toStdString()
-                                        );
-        }
-
-    } catch(std::exception& e){
-        QString message = QString("Unable to import, the following exception was thrown:\n") + QString::fromStdString(e.what());
-        QMessageBox::warning(nullptr, "Wrong data format", message);
-        return false;
-    }
-    return true;
-}
-
 DataSelector::DataSelector(csv::DataArray csvArray, QWidget* parent):
         QDialog(parent)
       ,m_data(csvArray)
@@ -190,7 +59,6 @@ DataSelector::DataSelector(csv::DataArray csvArray, QWidget* parent):
 
     if(!updateData())
         return;
-
 }
 
 bool DataSelector::updateData(){
@@ -206,24 +74,8 @@ bool DataSelector::updateData(){
     m_lastDataRowSpinBox->setMaximum(int(lastRow));
     m_lastDataRowSpinBox->setValue(int(lastRow));
     setTableData();
-    updateSelection();
 
     return true;
-}
-
-void DataSelector::updateSelection()
-{
-    m_importButton->setEnabled(false);
-    m_coordinateUnitsSelector->setEnabled(false);
-    greyoutTableRegions();
-
-    //Enable import button only if the user has selected its columns for 1d import
-    if( m_intensityCol > 0 )
-        m_importButton->setEnabled(true);
-
-    //Enable Coordinate Selector
-    if( m_coordinateCol > 0 )
-        m_coordinateUnitsSelector->setEnabled(true);
 }
 
 void DataSelector::setTableData(){
@@ -247,6 +99,72 @@ void DataSelector::setTableData(){
             m_tableWidget->setItem(int(I),int(j),new QTableWidgetItem(QString::fromStdString(m_data[i][j])));
         }
     }
+}
+
+void DataSelector::onColumnRightClick(const QPoint position)
+{
+    auto item = m_tableWidget->itemAt(position);
+    if(!item) return;
+    auto row = item->row();
+    auto col = item->column();
+    if(row*col < 0) return;
+
+    QMenu menu;
+
+    //Action "select from this row"
+    QAction selectFromThisRowOn("Set as first data row",nullptr);
+    menu.addAction(&selectFromThisRowOn);
+    connect(&selectFromThisRowOn,&QAction::triggered,this,[this](){setFirstRow();});
+
+    //Action "select until this row"
+    QAction selectUntilThisRow("Set as last data row",nullptr);
+    menu.addAction(&selectUntilThisRow);
+    connect(&selectUntilThisRow,&QAction::triggered,this,[this](){setLastRow();});
+
+    menu.addSeparator();
+
+    //Set column as "Intensity".
+    menu.addAction(m_setAsIntensity);
+    connect(m_setAsIntensity,&QAction::triggered,this, [this](){setColumnAs(_intensity_);});
+
+    //Coordinate menu disabled if a coordinate column is already set.
+    QMenu *coordMenu = menu.addMenu("Set as coordinate column...");
+
+    //Set column as "Theta".
+    coordMenu->addAction(m_setAsTheta);
+    connect(m_setAsTheta,&QAction::triggered,this, [this](){setColumnAs(_theta_);});
+
+    //Set column as "2Theta".
+    coordMenu->addAction(m_setAs2Theta);
+    connect(m_setAs2Theta,&QAction::triggered,this, [this](){setColumnAs(_2theta_);});
+
+    //Set column as "q".
+    coordMenu->addAction(m_setAsQ);
+    connect(m_setAsQ,&QAction::triggered,this, [this](){setColumnAs(_q_);});
+
+    menu.addSeparator();
+
+    //Action "reset"
+    QAction resetAction("reset",nullptr);
+    menu.addAction(&resetAction);
+    connect(&resetAction,&QAction::triggered, this, [this](){resetSelection(); updateSelection();});
+
+    menu.exec(m_tableWidget->mapToGlobal(position));
+}
+
+void DataSelector::updateSelection()
+{
+    m_importButton->setEnabled(false);
+    m_coordinateUnitsSelector->setEnabled(false);
+    greyoutTableRegions();
+
+    //Enable import button only if the user has selected its columns for 1d import
+    if( m_intensityCol > 0 )
+        m_importButton->setEnabled(true);
+
+    //Enable Coordinate Selector
+    if( m_coordinateCol > 0 )
+        m_coordinateUnitsSelector->setEnabled(true);
 }
 
 void DataSelector::greyoutTableRegions(){
@@ -278,74 +196,39 @@ void DataSelector::greyoutCell(int i, int j, bool yes){
 
 bool DataSelector::needsGreyout(int iRow, int jCol){
 
-    if( m_intensityCol  < 1 )
-        return false;
-
     bool greyTop  = iRow < int(firstLine() - 1);
     bool greyBott = iRow > int(lastLine()  - 1);
     bool greyCol  =  jCol+1 != int(m_coordinateCol) &&
-                     jCol+1 != int(m_intensityCol);
+                     jCol+1 != int(m_intensityCol) &&
+                     m_intensityCol > 0;
 
     return greyTop || greyBott || greyCol;
 }
 
-void DataSelector::onColumnRightClick(const QPoint position)
-{
-    auto item = m_tableWidget->itemAt(position);
-    if(!item) return;
-    auto row = item->row();
-    auto col = item->column();
-    if(row*col < 0) return;
-
-    QMenu menu;
-
-    //Action "select from this row"
-    QAction selectFromThisRowOn("Set as first data row",nullptr);
-    menu.addAction(&selectFromThisRowOn);
-    connect(&selectFromThisRowOn,&QAction::triggered,this,[this](){setFirstRow();});
-
-    //Action "select until this row"
-    QAction selectUntilThisRow("Set as last data row",nullptr);
-    menu.addAction(&selectUntilThisRow);
-    connect(&selectUntilThisRow,&QAction::triggered,this,[this](){setLastRow();});
-
-    menu.addSeparator();
+void DataSelector::setColumnAs(DataColumn coordOrInt){
+    auto selectedRanges = m_tableWidget->selectedRanges();
+    if (selectedRanges.empty())
+        return;
+    auto front = selectedRanges.front();
+    auto col = front.leftColumn();
 
 
-    //Set column as "Intensity".
-    m_setAsIntensity->setDisabled(m_intensityCol>0);
-    menu.addAction(m_setAsIntensity);
-    connect(m_setAsIntensity,&QAction::triggered,this, [this](){setColumnAsIntensity();});
-    //.connect(m_setAsIntensity,&QAction::triggered,this, m_setAsIntensityColumnAsIntensity());
-
-
-    //Coordinate menu disabled if a coordinate column is already set.
-    QMenu *coordMenu = menu.addMenu("Set as coordinate column...");
-    coordMenu->setDisabled(m_coordinateCol>0);
-
-
-    //Set column as "Theta".
-    coordMenu->addAction(m_setAsTheta);
-    connect(m_setAsTheta,&QAction::triggered,this, [this](){setColumnAsCoordinate(_theta_);});
-
-
-    //Set column as "2Theta".
-    coordMenu->addAction(m_setAs2Theta);
-    connect(m_setAs2Theta,&QAction::triggered,this, [this](){setColumnAsCoordinate(_2theta_);});
-
-
-    //Set column as "q".
-    coordMenu->addAction(m_setAsQ);
-    connect(m_setAsQ,&QAction::triggered,this, [this](){setColumnAsCoordinate(_q_);});
-
-    menu.addSeparator();
-
-    //Action "reset"
-    QAction resetAction("reset",nullptr);
-    menu.addAction(&resetAction);
-    connect(&resetAction,&QAction::triggered, this, [this](){resetSelection(); updateSelection();});
-
-    menu.exec(m_tableWidget->mapToGlobal(position));
+    if(coordOrInt == _intensity_) {
+        m_intensityCol = unsigned(col + 1);
+        if (m_coordinateCol == m_intensityCol) {
+            m_coordinateCol = 0;
+        }
+    }
+    else{
+        m_coordinateCol = unsigned(col+1);
+        m_coordinateName = HeaderLabels[coordOrInt];
+        populateUnitsComboBox(coordOrInt);
+        if(m_coordinateCol == m_intensityCol){
+            m_intensityCol=0;
+        }
+    }
+    updateSelection();
+    setHeaders();
 }
 
 void DataSelector::populateUnitsComboBox(int coord){
@@ -372,39 +255,7 @@ void DataSelector::populateUnitsComboBox(int coord){
     }
 }
 
-void DataSelector::setColumnAsCoordinate(int coord){
-    auto selectedRanges = m_tableWidget->selectedRanges();
-    if (selectedRanges.empty())
-        return;
-    auto front = selectedRanges.front();
-    auto col = front.leftColumn();
 
-    m_tableWidget->setHorizontalHeaderItem( col, new QTableWidgetItem( HeaderLabels[coord]) );
-    m_coordinateCol = unsigned(col+1);
-    m_coordinateName = m_tableWidget->horizontalHeaderItem(col)->text();
-    populateUnitsComboBox(coord);
-    if(m_coordinateCol == m_intensityCol){
-        m_intensityCol=0;
-    }
-    updateSelection();
-}
-
-void DataSelector::setColumnAsIntensity() {
-    //get selected column
-    auto selectedRanges = m_tableWidget->selectedRanges();
-    if (selectedRanges.empty())
-        return;
-    auto front = selectedRanges.front();
-    auto col = front.leftColumn();
-
-    m_tableWidget->clearSelection();
-    m_tableWidget->setHorizontalHeaderItem(col, new QTableWidgetItem(HeaderLabels[_intensity_]));
-    m_intensityCol = unsigned(col + 1);
-    if (m_coordinateCol == m_intensityCol) {
-        m_coordinateCol = 0;
-    }
-    updateSelection();
-}
 
 void DataSelector::setFirstRow(){
     //get selected column
@@ -453,6 +304,15 @@ void DataSelector::setHeaders(){
         headers.append(QString::number(j + 1));
 
     m_tableWidget->setHorizontalHeaderLabels(headers);
+
+    if(m_intensityCol > 0){
+        int intCol = int(m_intensityCol) - 1;
+        m_tableWidget->setHorizontalHeaderItem(intCol , new QTableWidgetItem( HeaderLabels[_intensity_]) );
+    }
+    if(m_coordinateCol > 0){
+        int coordCol = int(m_coordinateCol) - 1;
+        m_tableWidget->setHorizontalHeaderItem(coordCol , new QTableWidgetItem( m_coordinateName ));
+    }
 }
 
 unsigned DataSelector::firstLine() const{
@@ -475,16 +335,146 @@ AxesUnits DataSelector::units() const{
     return defaultUnits;
 }
 
-// TODO
 char DataSelector::separator() const{
     char separator;
     QString tmpstr = m_separatorField->text();
     if(tmpstr.size() < 1){
         separator = '\0';
-        //m_separatorField->setText(QString(QChar::fromLatin1(separator)));
     }
     else{
         separator = tmpstr.at(0).toLatin1();
     }
     return separator;
 }
+
+void DataSelector::onCancelButton()
+{
+    reject();
+}
+
+void DataSelector::onImportButton()
+{
+    if(dataLooksGood()){
+        accept();
+    }
+}
+
+bool DataSelector::dataLooksGood(){
+    int iCol = int(m_intensityCol)-1;
+    int cCol = int(m_coordinateCol)-1;
+    try{
+        for(int i = int(firstLine()) - 1; i < int(lastLine()); i++){
+            CsvImportAssistant::stringToDouble(
+                                    m_tableWidget->item(i,iCol)->text().toStdString()
+                                    );
+            if(m_coordinateCol > 0)
+                CsvImportAssistant::stringToDouble(
+                                        m_tableWidget->item(i,cCol)->text().toStdString()
+                                        );
+        }
+
+    } catch(std::exception& e){
+        QString message = QString("Unable to import, the following exception was thrown:\n") + QString::fromStdString(e.what());
+        QMessageBox::warning(nullptr, "Wrong data format", message);
+        return false;
+    }
+    return true;
+}
+
+QBoxLayout* DataSelector::createLayout()
+{
+    //table Widget
+    m_tableWidget = new QTableWidget();
+    m_tableWidget->setContextMenuPolicy(Qt::CustomContextMenu);
+    m_tableWidget->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    connect(m_tableWidget, &QTableWidget::customContextMenuRequested, this, &DataSelector::onColumnRightClick);
+
+    //Import button
+    m_importButton = new QPushButton("Import");
+    m_importButton->setDefault(true);
+    connect(m_importButton, &QPushButton::clicked, this, &DataSelector::onImportButton);
+
+    //Reject button
+    m_cancelButton = new QPushButton("Cancel");
+    connect(m_cancelButton, &QPushButton::clicked, this, [this](){reject();});
+
+    //Separator field -- This needs to communicate with importAssistant
+    m_separatorField = new QLineEdit(QString(""));
+    m_separatorField->setMaxLength(1);
+    m_separatorField->setMaximumWidth(100);
+    connect(m_separatorField, &QLineEdit::editingFinished, this,
+            [this]()
+            {
+                emit separatorChanged(separator());
+            }
+    );
+
+    //First Row SpinBox
+    m_firstDataRowSpinBox = new QSpinBox();
+    m_firstDataRowSpinBox->setMinimum(1);
+    m_firstDataRowSpinBox->setMaximum(1);
+    m_firstDataRowSpinBox->setValue(1);
+    m_firstDataRowSpinBox->setMaximumWidth(100);
+    connect(m_firstDataRowSpinBox, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+            [this]()
+            {
+                m_lastDataRowSpinBox->setMinimum(m_firstDataRowSpinBox->value());
+                updateSelection();
+            }
+    );
+
+    //Last Row SpinBox
+    m_lastDataRowSpinBox = new QSpinBox();
+    m_lastDataRowSpinBox->setMinimum(1);
+    m_lastDataRowSpinBox->setMaximum(1);
+    m_lastDataRowSpinBox->setValue(1);
+    m_lastDataRowSpinBox->setMaximumWidth(100);
+    connect(m_lastDataRowSpinBox, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+            [this]()
+            {
+                m_firstDataRowSpinBox->setMaximum(m_lastDataRowSpinBox->value());
+                updateSelection();
+            }
+    );
+
+    //Column type selector
+    m_coordinateUnitsSelector = new QComboBox();
+    m_coordinateUnitsSelector->setMaximumWidth(100);
+    m_coordinateUnitsSelector->addItem(UnitsLabels[AxesUnits::NBINS]);
+
+
+    auto layout = new QVBoxLayout;
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    //place table Widget
+    auto tableLayout = new QVBoxLayout;
+    tableLayout->setMargin(10);
+    tableLayout->addWidget(new QLabel("Right click on the table to select what will be imported"));
+    tableLayout->addWidget(m_tableWidget);
+
+    //place separator_field and first_row:
+    auto controlsLayout = new QFormLayout;
+    controlsLayout->addRow(tr("&Corodinate Units: "), m_coordinateUnitsSelector);
+    controlsLayout->addRow(tr("&Separator: "), m_separatorField);
+    controlsLayout->addRow(tr("&From row: "), m_firstDataRowSpinBox);
+    controlsLayout->addRow(tr("&To row: "), m_lastDataRowSpinBox);
+
+    //buttons layout
+    auto buttonsLayout = new QHBoxLayout;
+    buttonsLayout->addWidget(m_importButton);
+    buttonsLayout->addWidget(m_cancelButton);
+
+    //place controls and import/reject buttons
+    auto controlsAndButtonsGrid = new QGridLayout;
+    controlsAndButtonsGrid->setMargin(10);
+    controlsAndButtonsGrid->addItem(new QSpacerItem(10000,1),1,1,2,1);
+    controlsAndButtonsGrid->addLayout(controlsLayout, 1, 2, 1, 1, Qt::AlignRight);
+    controlsAndButtonsGrid->addLayout(buttonsLayout, 2, 2, 1, 1, Qt::AlignLeft);
+
+    //build all the layout
+    layout->addLayout(tableLayout);
+    layout->addLayout(controlsAndButtonsGrid);
+
+    return layout;
+}
+

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/DataSelector.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/DataSelector.cpp
@@ -1,0 +1,490 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Views/ImportDataWidgets/DataSelector.cpp
+//! @brief     Implements class DataSelector
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#include "DataSelector.h"
+#include "ImportDataInfo.h"
+#include "mainwindow_constants.h"
+#include "StyleUtils.h"
+#include <QPushButton>
+#include <QTableWidget>
+#include <QSettings>
+#include <QVBoxLayout>
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QMenu>
+#include <QFormLayout>
+
+namespace
+{
+const QSize default_dialog_size(300, 400);
+}
+
+QBoxLayout* DataSelector::createLayout()
+{
+    //table Widget
+    m_tableWidget = new QTableWidget();
+    m_tableWidget->setContextMenuPolicy(Qt::CustomContextMenu);
+    m_tableWidget->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    connect(m_tableWidget, &QTableWidget::customContextMenuRequested, this, &DataSelector::onColumnRightClick);
+
+    //Import button
+    m_importButton = new QPushButton("Import");
+    m_importButton->setDefault(true);
+    connect(m_importButton, &QPushButton::clicked, this, &DataSelector::onImportButton);
+
+    //Reject button
+    m_cancelButton = new QPushButton("Cancel");
+    connect(m_cancelButton, &QPushButton::clicked, this, [this](){reject();});
+
+    //Separator field -- This needs to communicate with importAssistant
+    // TODO
+    m_separatorField = new QLineEdit(QString(""));
+    m_separatorField->setMaxLength(1);
+    m_separatorField->setMaximumWidth(100);
+    connect(m_separatorField, &QLineEdit::editingFinished, this,
+            [this]()
+            {
+                emit separatorChanged(separator());
+            }
+    );
+
+    //First Row SpinBox
+    m_firstDataRowSpinBox = new QSpinBox();
+    m_firstDataRowSpinBox->setMinimum(1);
+    m_firstDataRowSpinBox->setMaximum(1);
+    m_firstDataRowSpinBox->setValue(1);
+    m_firstDataRowSpinBox->setMaximumWidth(100);
+    connect(m_firstDataRowSpinBox, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+            [this]()
+            {
+                m_lastDataRowSpinBox->setMinimum(m_firstDataRowSpinBox->value());
+                updateSelection();
+            }
+    );
+
+    //Last Row SpinBox
+    m_lastDataRowSpinBox = new QSpinBox();
+    m_lastDataRowSpinBox->setMinimum(1);
+    m_lastDataRowSpinBox->setMaximum(1);
+    m_lastDataRowSpinBox->setValue(1);
+    m_lastDataRowSpinBox->setMaximumWidth(100);
+    connect(m_lastDataRowSpinBox, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+            [this]()
+            {
+                m_firstDataRowSpinBox->setMaximum(m_lastDataRowSpinBox->value());
+                updateSelection();
+            }
+    );
+
+    //Column type selector
+    m_coordinateUnitsSelector = new QComboBox();
+    m_coordinateUnitsSelector->setMaximumWidth(100);
+    m_coordinateUnitsSelector->addItem(UnitsLabels[AxesUnits::NBINS]);
+    //connect(m_coordinateUnitsSelector,static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),this, [this](){ setCoordinateUnits(); });
+
+
+    auto layout = new QVBoxLayout;
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    //place table Widget
+    auto tableLayout = new QVBoxLayout;
+    tableLayout->setMargin(10);
+    tableLayout->addWidget(new QLabel("Right click on the table to select what will be imported"));
+    tableLayout->addWidget(m_tableWidget);
+
+    //place separator_field and first_row:
+    auto controlsLayout = new QFormLayout;
+    controlsLayout->addRow(tr("&Corodinate Units: "), m_coordinateUnitsSelector);
+    controlsLayout->addRow(tr("&Separator: "), m_separatorField);
+    controlsLayout->addRow(tr("&From row: "), m_firstDataRowSpinBox);
+    controlsLayout->addRow(tr("&To row: "), m_lastDataRowSpinBox);
+
+    //buttons layout
+    auto buttonsLayout = new QHBoxLayout;
+    buttonsLayout->addWidget(m_importButton);
+    buttonsLayout->addWidget(m_cancelButton);
+
+    //place controls and import/reject buttons
+    auto controlsAndButtonsGrid = new QGridLayout;
+    controlsAndButtonsGrid->setMargin(10);
+    controlsAndButtonsGrid->addItem(new QSpacerItem(10000,1),1,1,2,1);
+    controlsAndButtonsGrid->addLayout(controlsLayout, 1, 2, 1, 1, Qt::AlignRight);
+    controlsAndButtonsGrid->addLayout(buttonsLayout, 2, 2, 1, 1, Qt::AlignLeft);
+
+    //build all the layout
+    layout->addLayout(tableLayout);
+    layout->addLayout(controlsAndButtonsGrid);
+
+    return layout;
+}
+
+void DataSelector::onCancelButton()
+{
+    reject();
+}
+
+void DataSelector::onImportButton()
+{
+    if(dataLooksGood()){
+        accept();
+    }
+}
+
+bool DataSelector::dataLooksGood(){
+    try{
+        for(auto i = firstLine() - 1; i < lastLine(); i++){
+            CsvImportAssistant::stringToDouble(
+                                    m_tableWidget->item(i,m_intensityCol-1)->text().toStdString()
+                                    );
+            if(m_coordinateCol > 0)
+                CsvImportAssistant::stringToDouble(
+                                        m_tableWidget->item(i,m_intensityCol-1)->text().toStdString()
+                                        );
+        }
+
+    } catch(std::exception& e){
+        QString message = QString("Unable to import, the following exception was thrown:\n") + QString::fromStdString(e.what());
+        QMessageBox::warning(nullptr, "Wrong data format", message);
+        return false;
+    }
+    return true;
+}
+
+DataSelector::DataSelector(csv::DataArray csvArray, QWidget* parent):
+        QDialog(parent)
+      ,m_data(csvArray)
+      ,m_intensityCol(0)
+      ,m_coordinateCol(0)
+      ,m_coordinateName("")
+      ,m_tableWidget(nullptr)
+      ,m_separatorField(nullptr)
+      ,m_firstDataRowSpinBox(nullptr)
+      ,m_lastDataRowSpinBox(nullptr)
+      ,m_importButton(nullptr)
+      ,m_coordinateUnitsSelector(nullptr)
+      ,m_setAsTheta(new QAction(HeaderLabels[_theta_],nullptr))
+      ,m_setAs2Theta(new QAction(HeaderLabels[_2theta_],nullptr))
+      ,m_setAsQ(new QAction(HeaderLabels[_q_],nullptr))
+      ,m_setAsIntensity(new QAction("Set as " + HeaderLabels[_intensity_] + " column",nullptr))
+{
+    // TODO: add machinery to handle 2theta
+    m_setAs2Theta->setDisabled(true);
+
+    setWindowTitle("Data Importer");
+    setMinimumSize(default_dialog_size);
+    resize(600, 600);
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    StyleUtils::setResizable(this);
+    setLayout(createLayout());
+
+    if(!updateData())
+        return;
+
+}
+
+bool DataSelector::updateData(){
+    size_t lastRow = m_data.size();
+
+    if (lastRow < 1) {
+        m_importButton->setDisabled(true);
+        CsvImportAssistant::showErrorMessage("There is no data to show");
+        return false;
+    }
+
+    m_firstDataRowSpinBox->setMaximum(int(lastRow));
+    m_lastDataRowSpinBox->setMaximum(int(lastRow));
+    m_lastDataRowSpinBox->setValue(int(lastRow));
+    setTableData();
+    updateSelection();
+
+    return true;
+}
+
+void DataSelector::updateSelection()
+{
+    m_importButton->setEnabled(false);
+    m_coordinateUnitsSelector->setEnabled(false);
+    greyoutTableRegions();
+
+    //Enable import button only if the user has selected its columns for 1d import
+    if( m_intensityCol > 0 )
+        m_importButton->setEnabled(true);
+
+    //Enable Coordinate Selector
+    if( m_coordinateCol > 0 )
+        m_coordinateUnitsSelector->setEnabled(true);
+}
+
+void DataSelector::setTableData(){
+
+    if(m_data.empty()){
+        m_tableWidget->clearContents();
+        m_tableWidget->setRowCount(0);
+        return;
+    }
+
+    size_t nRows = m_data.size();
+    size_t nCols = m_data[0].size();
+    m_tableWidget->clearContents();
+    m_tableWidget->setColumnCount(int(nCols));
+    m_tableWidget->setRowCount(0);
+
+    for(unsigned i = 0; i < nRows ; i++){
+        m_tableWidget->insertRow(m_tableWidget->rowCount());
+        unsigned I = unsigned(m_tableWidget->rowCount()) - 1;
+        for(unsigned j = 0; j < m_data[i].size(); j++){
+            m_tableWidget->setItem(int(I),int(j),new QTableWidgetItem(QString::fromStdString(m_data[i][j])));
+        }
+    }
+}
+
+void DataSelector::greyoutTableRegions(){
+    int nRows = m_tableWidget->rowCount();
+    int nCols = m_tableWidget->columnCount();
+
+    //Grey out columns
+    for(int i = 0; i < nRows; i++)
+        for(int j = 0; j < nCols; j++)
+            greyoutCell(i,j,needsGreyout(i,j));
+}
+
+void DataSelector::greyoutCell(int i, int j, bool yes){
+    if(yes){
+        QFont italicFont;
+        italicFont.setItalic(true);
+        italicFont.setStrikeOut(true);
+        m_tableWidget->item(i,j)->setBackground(Qt::gray);
+        m_tableWidget->item(i,j)->setFont(italicFont);
+    }
+    else{
+        QFont standardFont;
+        standardFont.setItalic(false);
+        standardFont.setStrikeOut(false);
+        m_tableWidget->item(i,j)->setBackground(Qt::white);
+        m_tableWidget->item(i,j)->setFont(standardFont);
+    }
+}
+
+bool DataSelector::needsGreyout(int iRow, int jCol){
+
+    if( m_intensityCol  < 1 )
+        return false;
+
+    bool greyTop  = iRow < int(firstLine() - 1);
+    bool greyBott = iRow > int(lastLine()  - 1);
+    bool greyCol  =  jCol+1 != int(m_coordinateCol) &&
+                     jCol+1 != int(m_intensityCol);
+
+    return greyTop || greyBott || greyCol;
+}
+
+void DataSelector::onColumnRightClick(const QPoint position)
+{
+    auto item = m_tableWidget->itemAt(position);
+    if(!item) return;
+    auto row = item->row();
+    auto col = item->column();
+    if(row*col < 0) return;
+
+    QMenu menu;
+
+    //Action "select from this row"
+    QAction selectFromThisRowOn("Set as first data row",nullptr);
+    menu.addAction(&selectFromThisRowOn);
+    connect(&selectFromThisRowOn,&QAction::triggered,this,[this](){setFirstRow();});
+
+    //Action "select until this row"
+    QAction selectUntilThisRow("Set as last data row",nullptr);
+    menu.addAction(&selectUntilThisRow);
+    connect(&selectUntilThisRow,&QAction::triggered,this,[this](){setLastRow();});
+
+    menu.addSeparator();
+
+
+    //Set column as "Intensity".
+    m_setAsIntensity->setDisabled(m_intensityCol>0);
+    menu.addAction(m_setAsIntensity);
+    connect(m_setAsIntensity,&QAction::triggered,this, [this](){setColumnAsIntensity();});
+    //.connect(m_setAsIntensity,&QAction::triggered,this, m_setAsIntensityColumnAsIntensity());
+
+
+    //Coordinate menu disabled if a coordinate column is already set.
+    QMenu *coordMenu = menu.addMenu("Set as coordinate column...");
+    coordMenu->setDisabled(m_coordinateCol>0);
+
+
+    //Set column as "Theta".
+    coordMenu->addAction(m_setAsTheta);
+    connect(m_setAsTheta,&QAction::triggered,this, [this](){setColumnAsCoordinate(_theta_);});
+
+
+    //Set column as "2Theta".
+    coordMenu->addAction(m_setAs2Theta);
+    connect(m_setAs2Theta,&QAction::triggered,this, [this](){setColumnAsCoordinate(_2theta_);});
+
+
+    //Set column as "q".
+    coordMenu->addAction(m_setAsQ);
+    connect(m_setAsQ,&QAction::triggered,this, [this](){setColumnAsCoordinate(_q_);});
+
+    menu.addSeparator();
+
+    //Action "reset"
+    QAction resetAction("reset",nullptr);
+    menu.addAction(&resetAction);
+    connect(&resetAction,&QAction::triggered, this, [this](){resetSelection(); updateSelection();});
+
+    menu.exec(m_tableWidget->mapToGlobal(position));
+}
+
+void DataSelector::populateUnitsComboBox(int coord){
+    m_coordinateUnitsSelector->clear();
+    switch(coord){
+
+    case _theta_:
+        m_coordinateUnitsSelector->addItem(UnitsLabels[AxesUnits::DEGREES]);
+        m_coordinateUnitsSelector->addItem(UnitsLabels[AxesUnits::RADIANS]);
+        break;
+
+    case _2theta_:
+        m_coordinateUnitsSelector->addItem(UnitsLabels[AxesUnits::DEGREES]);
+        m_coordinateUnitsSelector->addItem(UnitsLabels[AxesUnits::RADIANS]);
+        break;
+
+    case _q_:
+        m_coordinateUnitsSelector->addItem(UnitsLabels[AxesUnits::QSPACE]);
+        break;
+
+    default:
+        m_coordinateUnitsSelector->addItem(UnitsLabels[AxesUnits::NBINS]);
+        break;
+    }
+}
+
+void DataSelector::setColumnAsCoordinate(int coord){
+    auto selectedRanges = m_tableWidget->selectedRanges();
+    if (selectedRanges.empty())
+        return;
+    auto front = selectedRanges.front();
+    auto col = front.leftColumn();
+
+    m_tableWidget->setHorizontalHeaderItem( col, new QTableWidgetItem( HeaderLabels[coord]) );
+    m_coordinateCol = unsigned(col+1);
+    m_coordinateName = m_tableWidget->horizontalHeaderItem(col)->text();
+    populateUnitsComboBox(coord);
+    if(m_coordinateCol == m_intensityCol){
+        m_intensityCol=0;
+    }
+    updateSelection();
+}
+
+void DataSelector::setColumnAsIntensity() {
+    //get selected column
+    auto selectedRanges = m_tableWidget->selectedRanges();
+    if (selectedRanges.empty())
+        return;
+    auto front = selectedRanges.front();
+    auto col = front.leftColumn();
+
+    m_tableWidget->clearSelection();
+    m_tableWidget->setHorizontalHeaderItem(col, new QTableWidgetItem(HeaderLabels[_intensity_]));
+    m_intensityCol = unsigned(col + 1);
+    if (m_coordinateCol == m_intensityCol) {
+        m_coordinateCol = 0;
+    }
+    updateSelection();
+}
+
+void DataSelector::setFirstRow(){
+    //get selected column
+    auto selectedRanges = m_tableWidget->selectedRanges();
+    if (selectedRanges.empty())
+        return;
+    auto front = selectedRanges.front();
+    auto row = front.topRow();
+    auto currentMax = m_firstDataRowSpinBox->maximum();
+    auto desiredVal = row+1;
+    auto newMax = std::max(currentMax,desiredVal);
+    m_firstDataRowSpinBox->setMaximum(newMax);
+    m_firstDataRowSpinBox->setValue(desiredVal);
+}
+
+void DataSelector::setLastRow(){
+    //get selected column
+    auto selectedRanges = m_tableWidget->selectedRanges();
+    if (selectedRanges.empty())
+        return;
+    auto front = selectedRanges.front();
+    auto row = front.topRow();
+    auto currentMin = m_firstDataRowSpinBox->minimum();
+    auto desiredVal = row+1;
+    auto newMin = std::min(currentMin,desiredVal);
+    m_lastDataRowSpinBox->setMinimum(newMin);
+    m_lastDataRowSpinBox->setValue(desiredVal);
+}
+
+void DataSelector::resetSelection(){
+    m_intensityCol = 0;
+    m_coordinateCol = 0;
+    m_coordinateName = "";
+    m_firstDataRowSpinBox->setValue(0);
+    m_lastDataRowSpinBox->setValue(int(maxLines()));
+    setHeaders();
+    m_coordinateUnitsSelector->clear();
+    m_coordinateUnitsSelector->addItem(UnitsLabels[AxesUnits::NBINS]);
+}
+
+void DataSelector::setHeaders(){
+    //Reset header labels
+    QStringList headers;
+
+    for(int j = 0; j < m_tableWidget->columnCount(); j++)
+        headers.append(QString::number(j + 1));
+
+    m_tableWidget->setHorizontalHeaderLabels(headers);
+}
+
+unsigned DataSelector::firstLine() const{
+    return unsigned(m_firstDataRowSpinBox->value());
+}
+
+unsigned DataSelector::lastLine() const{
+    return unsigned(m_lastDataRowSpinBox->value());
+}
+
+unsigned DataSelector::maxLines() const{
+    return unsigned(m_lastDataRowSpinBox->maximum());
+}
+
+AxesUnits DataSelector::units() const{
+    AxesUnits defaultUnits = AxesUnits::NBINS;
+    for(auto i = 0; i < UnitsLabels.size(); i++)
+        if(m_coordinateUnitsSelector->currentText() == UnitsLabels[i])
+            return AxesUnits(i);
+    return defaultUnits;
+}
+
+// TODO
+char DataSelector::separator() const{
+    char separator;
+    QString tmpstr = m_separatorField->text();
+    if(tmpstr.size() < 1){
+        separator = '\0';
+        //m_separatorField->setText(QString(QChar::fromLatin1(separator)));
+    }
+    else{
+        separator = tmpstr.at(0).toLatin1();
+    }
+    return separator;
+}

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/DataSelector.h
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/DataSelector.h
@@ -29,11 +29,11 @@
 
 class QBoxLayout;
 
-enum  RelevantColumns {_intensity_,_theta_,_2theta_,_q_};
+enum  DataColumn {_intensity_,_theta_,_2theta_,_q_};
 const QStringList HeaderLabels{"Intensity","theta","2theta","q"};
 const QStringList UnitsLabels{"default", "bin", "rad", "deg", "mm", "1/nm"};
 
-//! Dialog to hold ImportAssistant.
+//! Dialog to hold DataSelector.
 
 class DataSelector : public QDialog
 {
@@ -44,44 +44,42 @@ public:
     unsigned lastLine() const;
     unsigned intensityColumn() const {return m_intensityCol;}
     unsigned coordinateColumn() const {return m_coordinateCol;}
-    unsigned maxLines() const;
     AxesUnits units() const;
-    char separator() const;
-    void setHeaders();
-    void setColumnAsCoordinate(int coord);
-    void setColumnAsIntensity();
-    void setCoordinateUnits();
-    void setFirstRow();
-    void setLastRow();
-    void setDataArray(csv::DataArray csvArray){m_data = csvArray; updateData();}
-    void resetSelection();
-    void updateSelection();
+    void setDataArray(csv::DataArray csvArray){m_data = csvArray; updateData(); resetSelection(); }
+    void setSeparator(char newSeparator){m_separatorField->setText(QString(QChar(newSeparator)));}
 
 public slots:
     void onImportButton();
     void onCancelButton();
     void onColumnRightClick(QPoint position);
 
+
 signals:
     void separatorChanged(char newSeparator);
 
 private:
+    unsigned maxLines() const;
+    char separator() const;
+    void setHeaders();
+    void setColumnAs(DataColumn coordOrInt);
+    void setCoordinateUnits();
+    void setFirstRow();
+    void setLastRow();
+    void resetSelection();
+    void updateSelection();
     bool updateData();
     QBoxLayout* createLayout();
     void setTableData();
     void populateUnitsComboBox(int coordinate);
     void greyoutTableRegions();
     bool dataLooksGood();
-
     bool needsGreyout(int iRow, int jCol);
     void greyoutCell(int i, int j, bool yes);
 
     csv::DataArray m_data;
-
     unsigned m_intensityCol;
     unsigned m_coordinateCol;
     QString m_coordinateName;
-
     QTableWidget* m_tableWidget;
     QLineEdit* m_separatorField;
     QSpinBox* m_firstDataRowSpinBox;
@@ -94,5 +92,4 @@ private:
     QAction* m_setAsQ;
     QAction* m_setAsIntensity;
 };
-
 #endif // DATASELECTOR_H

--- a/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/DataSelector.h
+++ b/GUI/coregui/Views/ImportDataWidgets/CsvImportAssistant/DataSelector.h
@@ -1,0 +1,98 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Views/ImportDataWidgets/DataSelector.h
+//! @brief     Defines class DataSelector
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#ifndef DATASELECTOR_H
+#define DATASELECTOR_H
+
+#include "WinDllMacros.h"
+#include "ImportDataInfo.h"
+#include "CsvImportAssistant.h"
+#include <QAction>
+#include <QDialog>
+#include <QTableWidget>
+#include <QLineEdit>
+#include <QLabel>
+#include <QSpinBox>
+#include <QComboBox>
+#include <memory>
+
+class QBoxLayout;
+
+enum  RelevantColumns {_intensity_,_theta_,_2theta_,_q_};
+const QStringList HeaderLabels{"Intensity","theta","2theta","q"};
+const QStringList UnitsLabels{"default", "bin", "rad", "deg", "mm", "1/nm"};
+
+//! Dialog to hold ImportAssistant.
+
+class DataSelector : public QDialog
+{
+    Q_OBJECT
+public:
+    DataSelector(csv::DataArray csvArray, QWidget* parent = nullptr);
+    unsigned firstLine() const;
+    unsigned lastLine() const;
+    unsigned intensityColumn() const {return m_intensityCol;}
+    unsigned coordinateColumn() const {return m_coordinateCol;}
+    unsigned maxLines() const;
+    AxesUnits units() const;
+    char separator() const;
+    void setHeaders();
+    void setColumnAsCoordinate(int coord);
+    void setColumnAsIntensity();
+    void setCoordinateUnits();
+    void setFirstRow();
+    void setLastRow();
+    void setDataArray(csv::DataArray csvArray){m_data = csvArray; updateData();}
+    void resetSelection();
+    void updateSelection();
+
+public slots:
+    void onImportButton();
+    void onCancelButton();
+    void onColumnRightClick(QPoint position);
+
+signals:
+    void separatorChanged(char newSeparator);
+
+private:
+    bool updateData();
+    QBoxLayout* createLayout();
+    void setTableData();
+    void populateUnitsComboBox(int coordinate);
+    void greyoutTableRegions();
+    bool dataLooksGood();
+
+    bool needsGreyout(int iRow, int jCol);
+    void greyoutCell(int i, int j, bool yes);
+
+    csv::DataArray m_data;
+
+    unsigned m_intensityCol;
+    unsigned m_coordinateCol;
+    QString m_coordinateName;
+
+    QTableWidget* m_tableWidget;
+    QLineEdit* m_separatorField;
+    QSpinBox* m_firstDataRowSpinBox;
+    QSpinBox* m_lastDataRowSpinBox;
+    QPushButton* m_importButton;
+    QPushButton* m_cancelButton;
+    QComboBox* m_coordinateUnitsSelector;
+    QAction* m_setAsTheta;
+    QAction* m_setAs2Theta;
+    QAction* m_setAsQ;
+    QAction* m_setAsIntensity;
+};
+
+#endif // DATASELECTOR_H

--- a/GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.cpp
@@ -99,12 +99,9 @@ ImportDataInfo ImportDataUtils::Import1dData(QString& baseNameOfLoadedFile)
 ImportDataInfo ImportDataUtils::UseImportAssistant(QString& fileName){
     try{
         CsvImportAssistant assistant(fileName);
-        int res = assistant.exec();
-        if(res == assistant.Accepted){
-            return assistant.getData();
-        }
+        return assistant.getData();
     }catch(std::exception& e){
-        QString message = QString("Unable to read file:\n\n'%1'\n\n%2\n\nCheck that the file exists and it is not being used by other program.\n\n")
+        QString message = QString("There was a problem while trying to import data from file:\n\n'%1'\n--\n%2\n--\n")
                 .arg(fileName)
                 .arg(QString::fromStdString(std::string(e.what())));
         QMessageBox::warning(nullptr, "IO Problem", message);


### PR DESCRIPTION
 - Corrupted files open as binary symbols (garbage).
 - Empty files won't open in the importer --A dialog box is shown instead.
 - Import button only active when the intensity column is selected
   - If the data cannot be parsed as doubles, the importer is kept open after a failed import.
   - If a PointwiseAxis exception is thrown, a dialog box is shown without making BA crash.
 - On changing field separator the file is reloaded.
 - Intensity and coordinate columns can be changed without needing to hit the reset button.