### PR TITLE
Fixed unit test crash when LD_LIBRARY contains own libgtest

### DIFF
--- a/Tests/UnitTests/CMakeLists.txt
+++ b/Tests/UnitTests/CMakeLists.txt
@@ -4,6 +4,12 @@
 
 include(AddGTest)
 
+# Disabling RUNPATH build time manipulation on unit tests executables.
+# We will provide our own RPATH to not to depend on LD_LIBRARY_PATH, see AddGtest.cmake.
+if(UNIX AND NOT APPLE)
+    SET(CMAKE_SKIP_BUILD_RPATH TRUE)
+endif()
+
 include_as_system_directory("${EIGEN3_INCLUDE_DIR}")
 include_directories(
     ${CMAKE_SOURCE_DIR}/Tests/UnitTests/utilities

--- a/Tests/UnitTests/GUI/CMakeLists.txt
+++ b/Tests/UnitTests/GUI/CMakeLists.txt
@@ -25,5 +25,11 @@ add_executable(${test} ${source_files} ${include_files})
 target_link_libraries(${test} ${BornAgainGUI_LIBRARY} ${ba3d_LIBRARY} gtest)
 target_link_libraries(${test} Qt5::Core Qt5::Test)
 
+if(UNIX AND NOT APPLE)
+# Unit tests will have RPATH set (instead of RUNPATH) to not to depend on LD_LIBRARY_PATH
+set(link_flags "-Wl,--disable-new-dtags,-rpath,'${CMAKE_LIBRARY_OUTPUT_DIRECTORY}'")
+set_target_properties(${test} PROPERTIES LINK_FLAGS ${link_flags})
+endif()
+
 # add execution of TestCore just after compilation
 add_custom_target(${test}_run ALL DEPENDS ${test} COMMAND ${test})

--- a/ThirdParty/common/gtest/CMakeLists.txt
+++ b/ThirdParty/common/gtest/CMakeLists.txt
@@ -9,5 +9,11 @@ if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_VARIADIC_MAX=10 /wd4100 /wd4275")
 endif()
 
+# instructs CMake to consider libgtest.so as our project library (inspite of the fact, that
+# it is not installed) and to provide @rpath instead of hardcoded links.
+if(APPLE)
+   set(CMAKE_MACOSX_RPATH 1)
+endif()
+
 option(BUILD_SHARED_LIBS "Build shared libraries (DLLs)." ON)
 add_subdirectory(gtest-1.8.0)

--- a/cmake/generic/modules/AddGTest.cmake
+++ b/cmake/generic/modules/AddGTest.cmake
@@ -24,6 +24,13 @@ MACRO(ADD_GTEST project subdir libs stage)
     set(EXE ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TEST_NAME})
     file(GLOB include_files ${subdir}/*.h)
     add_executable(${TEST_NAME} ${subdir}/../../utilities/main_testlist.cpp ${include_files})
+
+    if(UNIX AND NOT APPLE)
+    # Unit tests will have RPATH set (instead of RUNPATH) to not to depend on LD_LIBRARY_PATH
+    set(link_flags "-Wl,--disable-new-dtags,-rpath,'${CMAKE_LIBRARY_OUTPUT_DIRECTORY}'")
+    set_target_properties(${TEST_NAME} PROPERTIES LINK_FLAGS ${link_flags})
+    endif()
+
     target_include_directories(${TEST_NAME} PUBLIC ${subdir})
     target_link_libraries(${TEST_NAME} gtest ${libs})
     if    (${stage} EQUAL 0)


### PR DESCRIPTION
All changes are related only to unit test executables on Linux. They contain now hard coded path to own libBoprnAgain* and libgtest*. It is safe now, if LD_LIBRARY_PATH contain some prev BornAgain/libgtest installations.