### PR TITLE
Redmine issue 2142: Allow material tuning in real time view

### DIFF
--- a/GUI/coregui/Models/DataItem.cpp
+++ b/GUI/coregui/Models/DataItem.cpp
@@ -86,13 +86,6 @@ QString DataItem::selectedAxesUnits() const
     return combo.getValue();
 }
 
-void DataItem::reset(const ImportDataInfo& data)
-{
-    ComboProperty combo = ComboProperty() << data.unitsLabel();
-    setItemValue(DataItem::P_AXES_UNITS, combo.variant());
-    getItem(DataItem::P_AXES_UNITS)->setVisible(true);
-}
-
 DataItem::DataItem(const QString& modelType) : SessionItem(modelType)
 {
     // name of the file used to serialize given IntensityDataItem

--- a/GUI/coregui/Models/DataItem.h
+++ b/GUI/coregui/Models/DataItem.h
@@ -60,7 +60,7 @@ public:
 
     //! Returns data to the state defined by user (imported)
     //! data.
-    virtual void reset(const ImportDataInfo& data) = 0;
+    virtual void reset(ImportDataInfo data) = 0;
 
 protected:
     DataItem(const QString& modelType);

--- a/GUI/coregui/Models/IntensityDataItem.cpp
+++ b/GUI/coregui/Models/IntensityDataItem.cpp
@@ -228,7 +228,9 @@ std::vector<int> IntensityDataItem::shape() const
 void IntensityDataItem::reset(const ImportDataInfo& data)
 {
     assert(data.unitsLabel() == Constants::UnitsNbins);
-    DataItem::reset(data);
+    ComboProperty combo = ComboProperty() << data.unitsLabel();
+    setItemValue(IntensityDataItem::P_AXES_UNITS, combo.variant());
+    getItem(IntensityDataItem::P_AXES_UNITS)->setVisible(true);
 
     setXaxisTitle(data.axisLabel(0));
     setYaxisTitle(data.axisLabel(1));

--- a/GUI/coregui/Models/IntensityDataItem.cpp
+++ b/GUI/coregui/Models/IntensityDataItem.cpp
@@ -225,7 +225,7 @@ std::vector<int> IntensityDataItem::shape() const
     return {getNbinsX(), getNbinsY()};
 }
 
-void IntensityDataItem::reset(const ImportDataInfo& data)
+void IntensityDataItem::reset(ImportDataInfo data)
 {
     assert(data.unitsLabel() == Constants::UnitsNbins);
     ComboProperty combo = ComboProperty() << data.unitsLabel();
@@ -236,7 +236,7 @@ void IntensityDataItem::reset(const ImportDataInfo& data)
     setYaxisTitle(data.axisLabel(1));
     MaskUnitsConverter converter;
     converter.convertToNbins(this);
-    setOutputData(data.intensityData().release());
+    setOutputData(std::move(data).intensityData().release());
     setAxesRangeToData();
     converter.convertFromNbins(this);
 }

--- a/GUI/coregui/Models/IntensityDataItem.h
+++ b/GUI/coregui/Models/IntensityDataItem.h
@@ -97,7 +97,7 @@ public:
 
     //! Returns data to the state defined by user (imported)
     //! data.
-    void reset(const ImportDataInfo& data) override;
+    void reset(ImportDataInfo data) override;
 
 public slots:
     void setLowerX(double xmin);

--- a/GUI/coregui/Models/ItemCatalogue.cpp
+++ b/GUI/coregui/Models/ItemCatalogue.cpp
@@ -39,6 +39,7 @@
 #include "LayerRoughnessItems.h"
 #include "MaskItems.h"
 #include "MaterialDataItems.h"
+#include "MaterialItemContainer.h"
 #include "MaterialItem.h"
 #include "MesoCrystalItem.h"
 #include "MinimizerItem.h"
@@ -170,6 +171,7 @@ ItemCatalogue::ItemCatalogue()
     add(Constants::HexagonalLatticeType, create_new<HexagonalLatticeItem>);
 
     add(Constants::MaterialType, create_new<MaterialItem>);
+    add(Constants::MaterialContainerType, create_new<MaterialItemContainer>);
 
     add(Constants::MaterialRefractiveDataType, create_new<MaterialRefractiveDataItem>);
     add(Constants::MaterialSLDDataType, create_new<MaterialSLDDataItem>);

--- a/GUI/coregui/Models/JobItem.cpp
+++ b/GUI/coregui/Models/JobItem.cpp
@@ -21,6 +21,7 @@
 #include "IntensityDataItem.h"
 #include "ItemFileNameUtils.h"
 #include "JobItemUtils.h"
+#include "MaterialItemContainer.h"
 #include "MaskUnitsConverter.h"
 #include "MultiLayerItem.h"
 #include "ParameterTreeItems.h"
@@ -41,6 +42,7 @@ const QString JobItem::P_COMMENTS = "Comments";
 const QString JobItem::P_PROGRESS = "Progress";
 const QString JobItem::P_PRESENTATION_TYPE = "Presentation Type";
 const QString JobItem::T_SAMPLE = "Sample Tag";
+const QString JobItem::T_MATERIAL_CONTAINER = "Material Container";
 const QString JobItem::T_INSTRUMENT = "Instrument Tag";
 const QString JobItem::T_OUTPUT = "Output Tag";
 const QString JobItem::T_REALDATA = "Real Data Tag";
@@ -71,6 +73,7 @@ JobItem::JobItem() : SessionItem(Constants::JobItemType)
     addProperty(P_PRESENTATION_TYPE, QVariant::Type::Invalid)->setVisible(false);
 
     registerTag(T_SAMPLE, 1, 1, QStringList() << Constants::MultiLayerType);
+    registerTag(T_MATERIAL_CONTAINER, 1, 1, QStringList{Constants::MaterialContainerType});
     registerTag(T_INSTRUMENT, 1, 1,
                 QStringList() << Constants::GISASInstrumentType
                               << Constants::OffSpecInstrumentType
@@ -256,6 +259,11 @@ FitParameterContainerItem* JobItem::fitParameterContainerItem()
 RealDataItem* JobItem::realDataItem()
 {
     return dynamic_cast<RealDataItem*>(getItem(JobItem::T_REALDATA));
+}
+
+const MaterialItemContainer* JobItem::materialContainerItem() const
+{
+    return static_cast<MaterialItemContainer*>(getItem(JobItem::T_MATERIAL_CONTAINER));
 }
 
 Data1DViewItem* JobItem::dataItemView()

--- a/GUI/coregui/Models/JobItem.h
+++ b/GUI/coregui/Models/JobItem.h
@@ -23,6 +23,7 @@ class FitParameterContainerItem;
 class FitSuiteItem;
 class InstrumentItem;
 class IntensityDataItem;
+class MaterialItemContainer;
 class MultiLayerItem;
 class ParameterContainerItem;
 class RealDataItem;
@@ -45,6 +46,7 @@ public:
     static const QString P_PROGRESS;
     static const QString P_PRESENTATION_TYPE;
     static const QString T_SAMPLE;
+    static const QString T_MATERIAL_CONTAINER;
     static const QString T_INSTRUMENT;
     static const QString T_OUTPUT;
     static const QString T_REALDATA;
@@ -100,6 +102,8 @@ public:
 
     FitParameterContainerItem* fitParameterContainerItem();
     RealDataItem* realDataItem();
+
+    const MaterialItemContainer* materialContainerItem() const;
 
     Data1DViewItem* dataItemView();
 

--- a/GUI/coregui/Models/JobModel.cpp
+++ b/GUI/coregui/Models/JobModel.cpp
@@ -84,8 +84,7 @@ JobItem *JobModel::addJob(const MultiLayerItem *multiLayerItem,
     jobItem->setItemName(generateJobName());
     jobItem->setIdentifier(GUIHelpers::createUuid());
 
-    SessionItem *multilayer = copyItem(multiLayerItem, jobItem, JobItem::T_SAMPLE);
-    multilayer->setItemName(Constants::MultiLayerType);
+    JobModelFunctions::setupJobItemSampleData(jobItem, multiLayerItem);
     JobModelFunctions::setupJobItemInstrument(jobItem, instrumentItem);
     copyItem(optionItem, jobItem, JobItem::T_SIMULATION_OPTIONS);
 

--- a/GUI/coregui/Models/JobModelFunctions.cpp
+++ b/GUI/coregui/Models/JobModelFunctions.cpp
@@ -201,6 +201,13 @@ void JobModelFunctions::copyRealDataItem(JobItem* jobItem, const RealDataItem* r
         DataItem::P_FILE_NAME, ItemFileNameUtils::jobNativeDataFileName(*jobItem));
 }
 
+const JobItem* JobModelFunctions::findJobItem(const SessionItem* item)
+{
+    while (item && item->modelType() != Constants::JobItemType)
+        item = item->parent();
+    return static_cast<const JobItem*>(item);
+}
+
 namespace {
 void processInstrumentLink(JobItem* jobItem)
 {

--- a/GUI/coregui/Models/JobModelFunctions.cpp
+++ b/GUI/coregui/Models/JobModelFunctions.cpp
@@ -29,7 +29,6 @@
 #include "ItemFileNameUtils.h"
 #include "JobItemUtils.h"
 #include "JobModel.h"
-#include "LayerItem.h"
 #include "MaterialItemContainer.h"
 #include "MaterialItemUtils.h"
 #include "MaskItems.h"
@@ -89,7 +88,8 @@ void JobModelFunctions::initDataView(JobItem* job_item)
 void JobModelFunctions::setupJobItemSampleData(JobItem* jobItem, const MultiLayerItem* sampleItem)
 {
     auto model = jobItem->model();
-    SessionItem* multilayer = model->copyItem(sampleItem, jobItem, JobItem::T_SAMPLE);
+    MultiLayerItem* multilayer =
+        static_cast<MultiLayerItem*>(model->copyItem(sampleItem, jobItem, JobItem::T_SAMPLE));
     multilayer->setItemName(Constants::MultiLayerType);
 
     // copying materials
@@ -97,9 +97,8 @@ void JobModelFunctions::setupJobItemSampleData(JobItem* jobItem, const MultiLaye
         Constants::MaterialContainerType, jobItem->index(), -1, JobItem::T_MATERIAL_CONTAINER));
 
     std::map<MaterialItem*, QString> materials;
-    for (auto layer_item: multilayer->getChildrenOfType(Constants::LayerType)) {
-        auto material_property =
-            layer_item->getItemValue(LayerItem::P_MATERIAL).value<ExternalProperty>();
+    for (auto property_item: multilayer->materialPropertyItems()) {
+        auto material_property = property_item->value().value<ExternalProperty>();
         auto material = MaterialItemUtils::findMaterial(material_property);
 
         auto iter = materials.find(material);

--- a/GUI/coregui/Models/JobModelFunctions.cpp
+++ b/GUI/coregui/Models/JobModelFunctions.cpp
@@ -31,6 +31,7 @@
 #include "JobModel.h"
 #include "MaskItems.h"
 #include "MaskUnitsConverter.h"
+#include "MultiLayerItem.h"
 #include "PointwiseAxisItem.h"
 #include "RealDataItem.h"
 
@@ -79,6 +80,13 @@ void JobModelFunctions::initDataView(JobItem* job_item)
     auto converter = DomainObjectBuilder::createUnitConverter(job_item->instrumentItem());
     view_item->setItemValue(Data1DViewItem::P_AXES_UNITS,
                             JobItemUtils::availableUnits(*converter).variant());
+}
+
+void JobModelFunctions::setupJobItemSampleData(JobItem* jobItem, const MultiLayerItem* sampleItem)
+{
+    auto model = jobItem->model();
+    SessionItem* multilayer = model->copyItem(sampleItem, jobItem, JobItem::T_SAMPLE);
+    multilayer->setItemName(Constants::MultiLayerType);
 }
 
 void JobModelFunctions::setupJobItemInstrument(JobItem* jobItem,

--- a/GUI/coregui/Models/JobModelFunctions.h
+++ b/GUI/coregui/Models/JobModelFunctions.h
@@ -17,9 +17,10 @@
 
 #include "WinDllMacros.h"
 
-class JobItem;
-class RealDataItem;
 class InstrumentItem;
+class JobItem;
+class MultiLayerItem;
+class RealDataItem;
 
 //! Contains set of functions to extend JobModel functionality.
 //! Handles setup of JobItem in fitting context.
@@ -28,6 +29,9 @@ namespace JobModelFunctions
 {
 //! Initializes Data1DViewItem and assigns it to the passed JobItem
 BA_CORE_API_ void initDataView(JobItem* jobItem);
+
+//! Properly copies sample and materials into JobItem
+BA_CORE_API_ void setupJobItemSampleData(JobItem* jobItem, const MultiLayerItem* sampleItem);
 
 //! Properly copies instrument into job item
 BA_CORE_API_ void setupJobItemInstrument(JobItem* jobItem, const InstrumentItem* instrumentItem);

--- a/GUI/coregui/Models/JobModelFunctions.h
+++ b/GUI/coregui/Models/JobModelFunctions.h
@@ -21,6 +21,7 @@ class InstrumentItem;
 class JobItem;
 class MultiLayerItem;
 class RealDataItem;
+class SessionItem;
 
 //! Contains set of functions to extend JobModel functionality.
 //! Handles setup of JobItem in fitting context.
@@ -42,6 +43,11 @@ BA_CORE_API_ void setupJobItemForFit(JobItem* jobItem, const RealDataItem* realD
 
 //! Copy RealDataItem to jobItem intended for fitting.
 BA_CORE_API_ void copyRealDataItem(JobItem* jobItem, const RealDataItem* realDataItem);
+
+//! Determines parenting JobItem of a given SessionItem. Returns nullptr, if there
+//! is no parent of JobItem type
+
+BA_CORE_API_ const JobItem* findJobItem(const SessionItem* item);
 }
 
 #endif // JOBMODELFUNCTIONS_H

--- a/GUI/coregui/Models/LayerItem.cpp
+++ b/GUI/coregui/Models/LayerItem.cpp
@@ -57,6 +57,16 @@ LayerItem::LayerItem()
 
 }
 
+QVector<SessionItem*> LayerItem::materialPropertyItems()
+{
+    QVector<SessionItem*> result;
+    if (auto property = getItem(LayerItem::P_MATERIAL))
+        result.push_back(property);
+    for (auto layout : getItems(LayerItem::T_LAYOUTS))
+        result.append(MaterialItemUtils::materialPropertyItems(layout));
+    return result;
+}
+
 void LayerItem::updateAppearance(SessionItem* new_parent)
 {
     if (!new_parent) {

--- a/GUI/coregui/Models/LayerItem.h
+++ b/GUI/coregui/Models/LayerItem.h
@@ -27,6 +27,8 @@ public:
     static const QString T_LAYOUTS;
     LayerItem();
 
+    QVector<SessionItem*> materialPropertyItems();
+
 private:
     void updateAppearance(SessionItem* new_parent);
 };

--- a/GUI/coregui/Models/MaterialItemContainer.cpp
+++ b/GUI/coregui/Models/MaterialItemContainer.cpp
@@ -1,0 +1,53 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Models/MaterialItemContainer.cpp
+//! @brief     Implements class MaterialItemContainer
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#include "MaterialItemContainer.h"
+#include "GUIHelpers.h"
+#include "MaterialItem.h"
+#include "SessionModel.h"
+
+const QString MaterialItemContainer::T_MATERIALS = "MaterialVector";
+
+MaterialItemContainer::MaterialItemContainer()
+    :SessionItem(Constants::MaterialContainerType)
+{
+    setItemName("Materials");
+    registerTag(T_MATERIALS, 0, -1, QStringList{Constants::MaterialType});
+}
+
+MaterialItem* MaterialItemContainer::insertCopy(MaterialItem* material_item)
+{
+    MaterialItem* item_copy =
+        dynamic_cast<MaterialItem*>(model()->copyItem(material_item, this, T_MATERIALS));
+    item_copy->setItemValue(MaterialItem::P_IDENTIFIER, GUIHelpers::createUuid());
+
+    return item_copy;
+}
+
+MaterialItem* MaterialItemContainer::findMaterialById(QString id)
+{
+    return const_cast<MaterialItem*>(
+        static_cast<const MaterialItemContainer*>(this)->findMaterialById(id));
+}
+
+const MaterialItem* MaterialItemContainer::findMaterialById(QString id) const
+{
+    auto materials = getItems(T_MATERIALS);
+    for (auto item: materials) {
+        auto material = dynamic_cast<MaterialItem*>(item);
+        if (material->identifier() == id)
+            return material;
+    }
+    return nullptr;
+}

--- a/GUI/coregui/Models/MaterialItemContainer.h
+++ b/GUI/coregui/Models/MaterialItemContainer.h
@@ -1,0 +1,37 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      GUI/coregui/Models/MaterialItemContainer.h
+//! @brief     Defines class MaterialItemContainer
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#ifndef MATERIALITEMCONTAINER_H
+#define MATERIALITEMCONTAINER_H
+
+#include "SessionItem.h"
+
+class MaterialItem;
+
+class MaterialItemContainer : public SessionItem
+{
+public:
+    static const QString T_MATERIALS;
+
+    MaterialItemContainer();
+
+    //! Copies MaterialItem, inserts it into the container
+    //! and returns a pointer to the copy.
+    MaterialItem* insertCopy(MaterialItem* material_item);
+
+    const MaterialItem* findMaterialById(QString id) const;
+    MaterialItem* findMaterialById(QString id);
+};
+
+#endif // MATERIALITEMCONTAINER_H

--- a/GUI/coregui/Models/MultiLayerItem.cpp
+++ b/GUI/coregui/Models/MultiLayerItem.cpp
@@ -51,6 +51,14 @@ MultiLayerItem::MultiLayerItem()
     });
 }
 
+QVector<SessionItem*> MultiLayerItem::materialPropertyItems()
+{
+    QVector<SessionItem*> result;
+    for (auto layer_item : getItems(T_LAYERS))
+        result.append(static_cast<LayerItem*>(layer_item)->materialPropertyItems());
+    return result;
+}
+
 void MultiLayerItem::updateLayers()
 {
     QVector<SessionItem*> list = getChildrenOfType(Constants::LayerType);

--- a/GUI/coregui/Models/MultiLayerItem.h
+++ b/GUI/coregui/Models/MultiLayerItem.h
@@ -25,6 +25,8 @@ public:
     static const QString T_LAYERS;
     MultiLayerItem();
 
+    QVector<SessionItem*> materialPropertyItems();
+
 private:
     void updateLayers();
 };

--- a/GUI/coregui/Models/ParameterTreeItems.cpp
+++ b/GUI/coregui/Models/ParameterTreeItems.cpp
@@ -17,6 +17,7 @@
 #include "DistributionItems.h"
 #include "FitParameterHelper.h"
 #include "InstrumentItems.h"
+#include "MaterialItem.h"
 #include "ModelPath.h"
 #include "RectangularDetectorItem.h"
 #include "SessionModel.h"
@@ -92,7 +93,10 @@ bool ParameterItem::isFittable() const
                 QString()
             },
             {
-                Constants::DistributionSigmaFactor
+                Constants::DistributionSigmaFactor,
+                Constants::MaterialRefractiveDataType,
+                Constants::MaterialSLDDataType,
+                MaterialItem::P_MAGNETIZATION
             }
         },
         {// Instrument scope

--- a/GUI/coregui/Models/ParameterTreeUtils.cpp
+++ b/GUI/coregui/Models/ParameterTreeUtils.cpp
@@ -61,6 +61,8 @@ void ParameterTreeUtils::createParameterTree(JobItem* jobItem)
     SessionItem* container = jobItem->model()->insertNewItem(Constants::ParameterContainerType,
         jobItem->index(), -1, JobItem::T_PARAMETER_TREE);
 
+    populateParameterContainer(container, jobItem->getItem(JobItem::T_MATERIAL_CONTAINER));
+
     populateParameterContainer(container, jobItem->getItem(JobItem::T_SAMPLE));
 
     populateParameterContainer(container, jobItem->getItem(JobItem::T_INSTRUMENT));

--- a/GUI/coregui/Models/ParticleCoreShellItem.cpp
+++ b/GUI/coregui/Models/ParticleCoreShellItem.cpp
@@ -84,3 +84,15 @@ std::unique_ptr<ParticleCoreShell> ParticleCoreShellItem::createParticleCoreShel
     TransformToDomain::setTransformationInfo(P_coreshell.get(), *this);
     return P_coreshell;
 }
+
+QVector<SessionItem*> ParticleCoreShellItem::materialPropertyItems()
+{
+    QVector<SessionItem*> result;
+    if (auto core = static_cast<ParticleItem*>(getItem(T_CORE)))
+        result.append(core->materialPropertyItems());
+
+    if (auto shell = static_cast<ParticleItem*>(getItem(T_SHELL)))
+        result.append(shell->materialPropertyItems());
+
+    return result;
+}

--- a/GUI/coregui/Models/ParticleCoreShellItem.h
+++ b/GUI/coregui/Models/ParticleCoreShellItem.h
@@ -26,6 +26,7 @@ public:
     const static QString T_SHELL;
     ParticleCoreShellItem();
     std::unique_ptr<ParticleCoreShell> createParticleCoreShell() const;
+    QVector<SessionItem*> materialPropertyItems();
 };
 
 #endif // PARTICLECORESHELLITEM_H

--- a/GUI/coregui/Models/ParticleItem.cpp
+++ b/GUI/coregui/Models/ParticleItem.cpp
@@ -80,6 +80,14 @@ std::unique_ptr<Particle> ParticleItem::createParticle() const
     return P_particle;
 }
 
+QVector<SessionItem*> ParticleItem::materialPropertyItems()
+{
+    auto item = getItem(P_MATERIAL);
+    if (!item)
+        return {};
+    return {item};
+}
+
 //! Updates enabled/disabled for particle position and particle abundance depending on context.
 
 void ParticleItem::updatePropertiesAppearance(SessionItem* newParent)

--- a/GUI/coregui/Models/ParticleItem.h
+++ b/GUI/coregui/Models/ParticleItem.h
@@ -31,6 +31,7 @@ public:
     ParticleItem();
 
     std::unique_ptr<Particle> createParticle() const;
+    QVector<SessionItem*> materialPropertyItems();
 
 private:
     void updatePropertiesAppearance(SessionItem* newParent);

--- a/GUI/coregui/Models/RealDataItem.cpp
+++ b/GUI/coregui/Models/RealDataItem.cpp
@@ -140,11 +140,13 @@ void RealDataItem::setImportData(ImportDataInfo data) {
     const size_t data_rank = data.dataRank();
     initDataItem(data_rank, T_INTENSITY_DATA);
     initDataItem(data_rank, T_NATIVE_DATA);
-    dataItem()->reset(data);
 
     QString units_name = data.unitsLabel();
+    auto output_data = data.intensityData();
+
+    dataItem()->reset(std::move(data));
     getItem(P_NATIVE_UNITS)->setValue(units_name);
-    item<DataItem>(T_NATIVE_DATA).setOutputData(std::move(data).intensityData().release());
+    item<DataItem>(T_NATIVE_DATA).setOutputData(output_data.release());
 }
 
 bool RealDataItem::holdsDimensionalData() const

--- a/GUI/coregui/Models/RealDataItem.cpp
+++ b/GUI/coregui/Models/RealDataItem.cpp
@@ -144,7 +144,7 @@ void RealDataItem::setImportData(ImportDataInfo data) {
 
     QString units_name = data.unitsLabel();
     getItem(P_NATIVE_UNITS)->setValue(units_name);
-    item<DataItem>(T_NATIVE_DATA).setOutputData(data.intensityData().release());
+    item<DataItem>(T_NATIVE_DATA).setOutputData(std::move(data).intensityData().release());
 }
 
 bool RealDataItem::holdsDimensionalData() const

--- a/GUI/coregui/Models/SpecularDataItem.cpp
+++ b/GUI/coregui/Models/SpecularDataItem.cpp
@@ -150,7 +150,9 @@ std::vector<int> SpecularDataItem::shape() const
 
 void SpecularDataItem::reset(const ImportDataInfo& data)
 {
-    DataItem::reset(data);
+    ComboProperty combo = ComboProperty() << data.unitsLabel();
+    setItemValue(SpecularDataItem::P_AXES_UNITS, combo.variant());
+    getItem(SpecularDataItem::P_AXES_UNITS)->setVisible(true);
 
     setXaxisTitle(data.axisLabel(0));
     setYaxisTitle(data.axisLabel(1));

--- a/GUI/coregui/Models/SpecularDataItem.cpp
+++ b/GUI/coregui/Models/SpecularDataItem.cpp
@@ -148,7 +148,7 @@ std::vector<int> SpecularDataItem::shape() const
     return {getNbins()};
 }
 
-void SpecularDataItem::reset(const ImportDataInfo& data)
+void SpecularDataItem::reset(ImportDataInfo data)
 {
     ComboProperty combo = ComboProperty() << data.unitsLabel();
     setItemValue(SpecularDataItem::P_AXES_UNITS, combo.variant());
@@ -156,7 +156,7 @@ void SpecularDataItem::reset(const ImportDataInfo& data)
 
     setXaxisTitle(data.axisLabel(0));
     setYaxisTitle(data.axisLabel(1));
-    setOutputData(data.intensityData().release());
+    setOutputData(std::move(data).intensityData().release());
     setAxesRangeToData();
 }
 

--- a/GUI/coregui/Models/SpecularDataItem.h
+++ b/GUI/coregui/Models/SpecularDataItem.h
@@ -75,7 +75,7 @@ public:
 
     //! Returns data to the state defined by user (imported)
     //! data.
-    void reset(const ImportDataInfo& data) override;
+    void reset(ImportDataInfo data) override;
 
 public slots:
     void setLowerX(double xmin);

--- a/GUI/coregui/Models/TransformToDomain.cpp
+++ b/GUI/coregui/Models/TransformToDomain.cpp
@@ -31,6 +31,8 @@
 #include "InterferenceFunction2DParaCrystal.h"
 #include "InterferenceFunctionItems.h"
 #include "InterferenceFunctionRadialParaCrystal.h"
+#include "JobItem.h"
+#include "JobModelFunctions.h"
 #include "Lattice2DItems.h"
 #include "LayerItem.h"
 #include "LayerRoughnessItems.h"
@@ -65,11 +67,16 @@ void setParameterDistributionToSimulation(const std::string& parameter_name,
                                           const SessionItem* item, Simulation& simulation);
 }
 
-std::unique_ptr<Material> TransformToDomain::createDomainMaterial(const SessionItem& item)
+std::unique_ptr<Material>
+TransformToDomain::createDomainMaterial(const SessionItem& item)
 {
+    auto parent_job = JobModelFunctions::findJobItem(&item);
+    const MaterialItemContainer* container =
+        parent_job ? parent_job->materialContainerItem() : nullptr;
     QString tag = MaterialItemUtils::materialTag(item);
     ExternalProperty property = item.getItemValue(tag).value<ExternalProperty>();
-    return MaterialItemUtils::createDomainMaterial(property);
+    return container ? MaterialItemUtils::createDomainMaterial(property, *container)
+                     : MaterialItemUtils::createDomainMaterial(property);
 }
 
 std::unique_ptr<MultiLayer> TransformToDomain::createMultiLayer(const SessionItem& item)

--- a/GUI/coregui/Models/TransformToDomain.h
+++ b/GUI/coregui/Models/TransformToDomain.h
@@ -27,11 +27,12 @@
 #include "ParticleLayout.h"
 #include <memory>
 
-class GISASSimulation;
-class Simulation;
-class SessionItem;
 class DetectorItem;
+class GISASSimulation;
 class Material;
+class MaterialItemContainer;
+class SessionItem;
+class Simulation;
 
 namespace TransformToDomain
 {

--- a/GUI/coregui/Models/item_constants.h
+++ b/GUI/coregui/Models/item_constants.h
@@ -122,6 +122,7 @@ const ModelType SquareLatticeType = "SquareLattice";
 const ModelType HexagonalLatticeType = "HexagonalLattice";
 
 const ModelType MaterialType = "Material";
+const ModelType MaterialContainerType = "MaterialContainer";
 
 const ModelType MaterialRefractiveDataType = "MaterialRefractiveData";
 const ModelType MaterialSLDDataType = "MaterialSLDData";

--- a/GUI/coregui/Views/MaterialEditor/MaterialItemUtils.cpp
+++ b/GUI/coregui/Views/MaterialEditor/MaterialItemUtils.cpp
@@ -22,6 +22,7 @@
 #include "MaterialDataItems.h"
 #include "MaterialEditorDialog.h"
 #include "MaterialItem.h"
+#include "MaterialItemContainer.h"
 #include "MaterialModel.h"
 #include "MesoCrystalItem.h"
 #include "ParticleCompositionItem.h"
@@ -76,6 +77,18 @@ MaterialItemUtils::createDomainMaterial(const ExternalProperty &material_propert
 {
     MaterialItem* materialItem = findMaterial(material_property);
     return materialItem->createMaterial();
+}
+
+std::unique_ptr<Material>
+MaterialItemUtils::createDomainMaterial(const ExternalProperty& material_property,
+                                        const MaterialItemContainer& container)
+{
+    const MaterialItem* material_item = container.findMaterialById(material_property.identifier());
+    if (!material_item)
+        throw GUIHelpers::Error("MaterialUtils::createDomainMaterial() -> Error. Can't find "
+                                "material with name '"
+                                + material_property.text() + "'.");
+    return material_item->createMaterial();
 }
 
 MaterialItem* MaterialItemUtils::findMaterial(const ExternalProperty& material_property)

--- a/GUI/coregui/Views/MaterialEditor/MaterialItemUtils.cpp
+++ b/GUI/coregui/Views/MaterialEditor/MaterialItemUtils.cpp
@@ -61,18 +61,22 @@ ExternalProperty MaterialItemUtils::defaultMaterialProperty()
 std::unique_ptr<Material>
 MaterialItemUtils::createDomainMaterial(const ExternalProperty &material_property)
 {
+    MaterialItem* materialItem = findMaterial(material_property);
+    return materialItem->createMaterial();
+}
+
+MaterialItem* MaterialItemUtils::findMaterial(const ExternalProperty& material_property)
+{
     if (!AppSvc::materialModel())
-        throw GUIHelpers::Error("MaterialItemUtils::createDomainMaterial() -> Error. "
+        throw GUIHelpers::Error("MaterialItemUtils::findMaterial() -> Error. "
                                 "Attempt to access non-existing material model");
 
-    MaterialItem *materialItem
-        = AppSvc::materialModel()->materialFromIdentifier(material_property.identifier());
+    auto material = AppSvc::materialModel()->materialFromIdentifier(material_property.identifier());
 
-    if(!materialItem)
-        throw GUIHelpers::Error("MaterialUtils::createDomainMaterial() -> Error. Can't create "
+    if(!material)
+        throw GUIHelpers::Error("MaterialUtils::findMaterial() -> Error. Can't find "
                                 "material with name '"+material_property.text()+"'.");
-
-    return materialItem->createMaterial();
+    return material;
 }
 
 //! Returns material tag for given item. Returns empty string, if item doesn't have materials.

--- a/GUI/coregui/Views/MaterialEditor/MaterialItemUtils.h
+++ b/GUI/coregui/Views/MaterialEditor/MaterialItemUtils.h
@@ -48,6 +48,8 @@ BA_CORE_API_ ExternalProperty selectMaterialProperty(const ExternalProperty &pre
 //! Calls color selector dialog.
 BA_CORE_API_ ExternalProperty selectColorProperty(const ExternalProperty &previous=ExternalProperty());
 
+//! Gather material property items from a given item
+BA_CORE_API_ QVector<SessionItem*> materialPropertyItems(SessionItem* item);
 }
 
 

--- a/GUI/coregui/Views/MaterialEditor/MaterialItemUtils.h
+++ b/GUI/coregui/Views/MaterialEditor/MaterialItemUtils.h
@@ -28,8 +28,10 @@ namespace MaterialItemUtils
 
 BA_CORE_API_ QColor suggestMaterialColor(const QString &name);
 BA_CORE_API_ ExternalProperty defaultMaterialProperty();
-BA_CORE_API_ std::unique_ptr<Material> createDomainMaterial(
-        const ExternalProperty &material_property);
+
+BA_CORE_API_ std::unique_ptr<Material>
+createDomainMaterial(const ExternalProperty& material_property);
+BA_CORE_API_ MaterialItem* findMaterial(const ExternalProperty& material_property);
 
 BA_CORE_API_ QString materialTag(const SessionItem &item);
 BA_CORE_API_ QStringList materialRelatedModelTypes();

--- a/GUI/coregui/Views/MaterialEditor/MaterialItemUtils.h
+++ b/GUI/coregui/Views/MaterialEditor/MaterialItemUtils.h
@@ -22,6 +22,7 @@
 #include <memory>
 
 class Material;
+class MaterialItemContainer;
 
 namespace MaterialItemUtils
 {
@@ -31,6 +32,9 @@ BA_CORE_API_ ExternalProperty defaultMaterialProperty();
 
 BA_CORE_API_ std::unique_ptr<Material>
 createDomainMaterial(const ExternalProperty& material_property);
+BA_CORE_API_ std::unique_ptr<Material>
+createDomainMaterial(const ExternalProperty& material_property,
+                     const MaterialItemContainer& container);
 BA_CORE_API_ MaterialItem* findMaterial(const ExternalProperty& material_property);
 
 BA_CORE_API_ QString materialTag(const SessionItem &item);

--- a/GUI/coregui/utils/ImportDataInfo.cpp
+++ b/GUI/coregui/utils/ImportDataInfo.cpp
@@ -45,7 +45,9 @@ ImportDataInfo::ImportDataInfo(ImportDataInfo&& other)
 }
 
 ImportDataInfo::ImportDataInfo(std::unique_ptr<OutputData<double>> data, AxesUnits units)
-    : m_data(std::move(data))
+    : m_data(units == AxesUnits::NBINS && data
+                 ? ImportDataUtils::CreateSimplifiedOutputData(*data)
+                 : std::move(data))
     , m_units(units)
 {
     checkValidity();
@@ -65,12 +67,16 @@ ImportDataInfo::operator bool() const
     return static_cast<bool>(m_data);
 }
 
-std::unique_ptr<OutputData<double> > ImportDataInfo::intensityData() const
+std::unique_ptr<OutputData<double> > ImportDataInfo::intensityData() const &
 {
     if (!m_data)
         return nullptr;
-    return m_units == AxesUnits::NBINS ? ImportDataUtils::CreateSimplifiedOutputData(*m_data)
-                                       : std::unique_ptr<OutputData<double>>(m_data->clone());
+    return std::unique_ptr<OutputData<double>>(m_data->clone());
+}
+
+std::unique_ptr<OutputData<double> > ImportDataInfo::intensityData() &&
+{
+    return std::move(m_data);
 }
 
 size_t ImportDataInfo::dataRank() const

--- a/GUI/coregui/utils/ImportDataInfo.h
+++ b/GUI/coregui/utils/ImportDataInfo.h
@@ -35,7 +35,8 @@ public:
 
     operator bool() const;
 
-    std::unique_ptr<OutputData<double>> intensityData() const;
+    std::unique_ptr<OutputData<double>> intensityData() const &;
+    std::unique_ptr<OutputData<double>> intensityData() &&;
     size_t dataRank() const;
     QString unitsLabel() const;
     QString axisLabel(size_t axis_index) const;


### PR DESCRIPTION
First three commits represent a minor speed up in handling user non-uniform data (not related to the issue, but it would be too much to make a separate pull-request for them).
All the others are related to handling materials in JobItem and representing them in
real time tree view.