### PR TITLE
Forbid limits in fit parameters for Levenberg Marquardt algorithm

### DIFF
--- a/Core/Fitting/FitObjective.cpp
+++ b/Core/Fitting/FitObjective.cpp
@@ -79,11 +79,9 @@ std::vector<double> FitObjective::evaluate_residuals(const Fit::Parameters& para
 
     std::vector<double> result;
 
-    std::vector<double> weights;
-    weights.resize(numberOfFitElements(), 1.0); // FIXME make correct weights
-
     for(size_t i = 0; i<m_simulation_array.size(); ++i)
-        result.push_back(residual(m_simulation_array[i], m_experimental_array[i], weights[i]));
+        result.push_back(residual(m_simulation_array[i], m_experimental_array[i],
+                                  m_weights_array[i]));
 
     double chi2 = evaluate_chi2(result, params);
 
@@ -109,6 +107,11 @@ std::vector<double> FitObjective::experimental_array() const
 std::vector<double> FitObjective::simulation_array() const
 {
     return m_simulation_array;
+}
+
+std::vector<double> FitObjective::weights_array() const
+{
+    return m_weights_array;
 }
 
 SimulationResult FitObjective::simulationResult(size_t i_item) const
@@ -200,11 +203,13 @@ void FitObjective::run_simulations(const Fit::Parameters& params)
 
     m_simulation_array.clear();
     m_experimental_array.clear();
+    m_weights_array.clear();
 
     for (auto obj : m_fit_objects) {
         obj->runSimulation(params);
         insert_to(m_simulation_array, obj->simulation_array());
         insert_to(m_experimental_array, obj->experimental_array());
+        insert_to(m_weights_array, obj->weights_array());
     }
 }
 

--- a/Core/Fitting/FitObjective.h
+++ b/Core/Fitting/FitObjective.h
@@ -70,6 +70,9 @@ public:
     //! Data from different datasets merged together.
     std::vector<double> simulation_array() const;
 
+    //! Returns one dimensional array representing weights of bin intensity for residuals.
+    std::vector<double> weights_array() const;
+
     //! Returns simulation result.
     //! @param i_item: the index of fit pair
     SimulationResult simulationResult(size_t i_item = 0) const;
@@ -123,6 +126,7 @@ private:
 
     std::vector<double> m_experimental_array;
     std::vector<double> m_simulation_array;
+    std::vector<double> m_weights_array;
 
     SafePointerVector<SimDataPair> m_fit_objects;
     double m_total_weight;

--- a/Core/Fitting/SimDataPair.cpp
+++ b/Core/Fitting/SimDataPair.cpp
@@ -134,6 +134,11 @@ std::vector<double> SimDataPair::simulation_array() const
     return m_simulation_array;
 }
 
+std::vector<double> SimDataPair::weights_array() const
+{
+    return m_weights_array;
+}
+
 //! Creates new simulation for given set of fit parameters.
 //! If it is first call, save number of fit elements (supposed to stay the same during the fit),
 //! and converts raw user data to SimulationResult.
@@ -149,9 +154,13 @@ void SimDataPair::create_simulation(const Fit::Parameters& params)
         m_experimental_array.clear();
         m_experimental_array.reserve(numberOfFitElements());
 
+        m_weights_array.clear();
+        m_weights_array.reserve(numberOfFitElements());
+
         auto detector = m_simulation->getInstrument().getDetector();
         detector->iterate([&](IDetector::const_iterator it){
             m_experimental_array.push_back(m_experimental_data[it.roiIndex()]);
+            m_weights_array.push_back(m_weight);
         });
     }
 }

--- a/Core/Fitting/SimDataPair.h
+++ b/Core/Fitting/SimDataPair.h
@@ -49,6 +49,8 @@ public:
 
     std::vector<double> simulation_array() const;
 
+    std::vector<double> weights_array() const;
+
 private:
     void create_simulation(const Fit::Parameters& params);
 
@@ -63,6 +65,8 @@ private:
     std::vector<double> m_simulation_array;
     //!< Experimental data in the form of flat array (masked areas excluded, ROI only).
     std::vector<double> m_experimental_array;
+    //!< Weight of detector bin in residual calculations
+    std::vector<double> m_weights_array;
 
     //!< Simulation builder from the user to construct simulation for given set of parameters.
     simulation_builder_t m_simulation_builder;

--- a/Core/StandardSamples/SimulationFactory.cpp
+++ b/Core/StandardSamples/SimulationFactory.cpp
@@ -158,4 +158,9 @@ SimulationFactory::SimulationFactory()
     registerItem("BasicDepthProbe",
                  StandardSimulations::BasicDepthProbe,
                  "Basic 20x20 depth probe simulation with [0, 1] deg angle and [-100, 100] z span");
+
+    registerItem("MiniGISASFit",
+                 StandardSimulations::MiniGISASFit,
+                 "GISAS simulation with small 25x25 detector and phi[-2,2], theta[0,2]. "
+                 "Beam intensity is set");
 }

--- a/Core/StandardSamples/StandardSimulations.cpp
+++ b/Core/StandardSamples/StandardSimulations.cpp
@@ -488,3 +488,15 @@ DepthProbeSimulation* StandardSimulations::BasicDepthProbe()
 
     return result.release();
 }
+
+//! Simulation with fitting.
+//! Beam intensity set to provide reasonably large values in detector channels.
+GISASSimulation* StandardSimulations::MiniGISASFit()
+{
+    GISASSimulation* result = new GISASSimulation();
+    result->setDetectorParameters(25, -2.0*Units::degree, 2.0*Units::degree,
+                                  25, 0.0*Units::degree, 2.0*Units::degree);
+    result->setBeamParameters(1.0*Units::angstrom, 0.2*Units::degree, 0.0*Units::degree);
+    result->setBeamIntensity(1e6);
+    return result;
+}

--- a/Core/StandardSamples/StandardSimulations.h
+++ b/Core/StandardSamples/StandardSimulations.h
@@ -54,6 +54,7 @@ BA_CORE_API_ GISASSimulation* MiniGISASMonteCarlo();
 BA_CORE_API_ GISASSimulation* SphericalDetWithRoi();
 BA_CORE_API_ GISASSimulation* RectDetWithRoi();
 BA_CORE_API_ GISASSimulation* ConstantBackgroundGISAS();
+BA_CORE_API_ GISASSimulation* MiniGISASFit();
 
 // Specular simulation tests:
 BA_CORE_API_ SpecularSimulation* BasicSpecular();

--- a/Fit/RootAdapter/GSLLevenbergMarquardtMinimizer.cpp
+++ b/Fit/RootAdapter/GSLLevenbergMarquardtMinimizer.cpp
@@ -16,6 +16,8 @@
 #include "GSLMultiMinimizer.h"
 #include "MinimizerUtils.h"
 #include "StringUtils.h"
+#include "AttLimits.h"
+#include <stdexcept>
 
 #ifdef _WIN32
 #pragma warning(push)
@@ -110,4 +112,13 @@ void GSLLevenbergMarquardtMinimizer::propagateOptions()
 const RootMinimizerAdapter::root_minimizer_t* GSLLevenbergMarquardtMinimizer::rootMinimizer() const
 {
     return m_gsl_minimizer.get();
+}
+
+void GSLLevenbergMarquardtMinimizer::setParameter(unsigned int index, const Fit::Parameter& par)
+{
+    auto limits = par.limits();
+    if (!limits.isLimitless() )
+        throw std::runtime_error("GSLLMA minimizer can't handle limited parameters."
+                                 "Please make them free");
+    RootMinimizerAdapter::setParameter(index, par);
 }

--- a/Fit/RootAdapter/GSLLevenbergMarquardtMinimizer.cpp
+++ b/Fit/RootAdapter/GSLLevenbergMarquardtMinimizer.cpp
@@ -117,7 +117,7 @@ const RootMinimizerAdapter::root_minimizer_t* GSLLevenbergMarquardtMinimizer::ro
 void GSLLevenbergMarquardtMinimizer::setParameter(unsigned int index, const Fit::Parameter& par)
 {
     auto limits = par.limits();
-    if (!limits.isLimitless() )
+    if (!limits.isLimitless() && !limits.isFixed() )
         throw std::runtime_error("GSLLMA minimizer can't handle limited parameters."
                                  "Please make them free");
     RootMinimizerAdapter::setParameter(index, par);

--- a/Fit/RootAdapter/GSLLevenbergMarquardtMinimizer.h
+++ b/Fit/RootAdapter/GSLLevenbergMarquardtMinimizer.h
@@ -51,6 +51,7 @@ protected:
     virtual bool isGradientBasedAgorithm() override;
     void propagateOptions() override;
     const root_minimizer_t* rootMinimizer() const override;
+    void setParameter(unsigned int index, const Fit::Parameter& par) override;
 
 private:
     std::unique_ptr<ROOT::Math::GSLNLSMinimizer> m_gsl_minimizer;

--- a/Fit/RootAdapter/RootMinimizerAdapter.h
+++ b/Fit/RootAdapter/RootMinimizerAdapter.h
@@ -35,7 +35,7 @@ class BA_CORE_API_ RootMinimizerAdapter : public IMinimizer
 public:
     typedef ROOT::Math::Minimizer root_minimizer_t;
 
-    virtual ~RootMinimizerAdapter();
+    virtual ~RootMinimizerAdapter() override;
 
     Fit::MinimizerResult minimize_scalar(fcn_scalar_t fcn, Fit::Parameters parameters) override;
     Fit::MinimizerResult minimize_residual(fcn_residual_t fcn, Fit::Parameters parameters) override;

--- a/GUI/coregui/Views/FitWidgets/FitObjectiveBuilder.cpp
+++ b/GUI/coregui/Views/FitWidgets/FitObjectiveBuilder.cpp
@@ -42,8 +42,9 @@ FitObjectiveBuilder::~FitObjectiveBuilder() = default;
 void FitObjectiveBuilder::runFit()
 {
     m_fit_objective = createFitObjective();
-    fcn_scalar_t scalar_func = [&](const Fit::Parameters& params) {
-        return m_fit_objective->evaluate(params);
+
+    fcn_residual_t residual_func = [&](const Fit::Parameters& params) {
+        return m_fit_objective->evaluate_residuals(params);
     };
 
     if (m_observer) {
@@ -56,7 +57,7 @@ void FitObjectiveBuilder::runFit()
     Fit::Minimizer minimizer;
     minimizer.setMinimizer(createMinimizer().release());
 
-    auto result = minimizer.minimize(scalar_func, createParameters());
+    auto result = minimizer.minimize(residual_func, createParameters());
     m_fit_objective->finalize(result);
 }
 

--- a/Tests/Functional/Fit/FitObjective/AdjustMinimizerPlan.cpp
+++ b/Tests/Functional/Fit/FitObjective/AdjustMinimizerPlan.cpp
@@ -30,7 +30,7 @@ AdjustMinimizerPlan::AdjustMinimizerPlan()
     : FitPlan("AdjustMinimizerPlan")
 {
     setBuilderName("CylindersInBABuilder");
-    setSimulationName("MiniGISAS");
+    setSimulationName("MiniGISASFit");
     addParameter(Parameter("height", 2.0*nm, AttLimits::limited(0.01, 30.0), 0.05), 5.0*nm);
     addParameter(Parameter("radius", 10.0*nm, AttLimits::limited(0.01, 30.0), 0.05), 5.0*nm);
 }

--- a/Tests/Functional/Fit/FitObjective/CMakeLists.txt
+++ b/Tests/Functional/Fit/FitObjective/CMakeLists.txt
@@ -2,6 +2,7 @@ set(test TestFitObjective)
 
 set(test_cases
     MigradCylindersInBA
+    MigradResidualCylindersInBA
     SpecularFitTest
     MultipleSpecFittingTest    
     FumuliCylindersInBA

--- a/Tests/Functional/Fit/FitObjective/CMakeLists.txt
+++ b/Tests/Functional/Fit/FitObjective/CMakeLists.txt
@@ -3,7 +3,17 @@ set(test TestFitObjective)
 set(test_cases
     MigradCylindersInBA
     SpecularFitTest
-    MultipleSpecFittingTest
+    MultipleSpecFittingTest    
+    FumuliCylindersInBA
+    LevenbergMarquardtCylindersInBA
+    MultiPatternFit
+    RectDetectorFit
+    # --- slow, but still converging ---
+    # SimAnCylindersInBA
+    # GeneticCylindersInBA
+    # SteepestDescentCylindersInBA
+    # AdjustMinimizerFit
+    # BfgsCylindersInBA
 )
 
 include_directories(${RootMinimizers_INCLUDE_DIRS})

--- a/Tests/Functional/Fit/FitObjective/FitObjectiveTestCases.cpp
+++ b/Tests/Functional/Fit/FitObjective/FitObjectiveTestCases.cpp
@@ -17,6 +17,9 @@
 MigradCylindersInBA::MigradCylindersInBA()
     : FitObjectiveTest("Minuit2", "Migrad", "CylindersInBAPlan") {}
 
+MigradResidualCylindersInBA::MigradResidualCylindersInBA()
+    : FitObjectiveTest("Minuit2", "Migrad", "CylindersInBAResidualPlan") {}
+
 BfgsCylindersInBA::BfgsCylindersInBA()
     : FitObjectiveTest("GSLMultiMin", "BFGS2", "CylindersInBAEasyPlan") {}
 

--- a/Tests/Functional/Fit/FitObjective/FitObjectiveTestCases.cpp
+++ b/Tests/Functional/Fit/FitObjective/FitObjectiveTestCases.cpp
@@ -54,7 +54,7 @@ AdjustMinimizerFit::AdjustMinimizerFit()
     : FitObjectiveTest("Genetic", "", "AdjustMinimizerPlan") {}
 
 MultiPatternFit::MultiPatternFit()
-    : FitObjectiveTest("GSLLMA", "", "MultiPatternPlan") {}
+    : FitObjectiveTest("Minuit2", "Fumili", "MultiPatternPlan") {}
 
 SpecularFitTest::SpecularFitTest()
     : FitObjectiveTest("Minuit2", "Migrad", "SpecularPlan") {}

--- a/Tests/Functional/Fit/FitObjective/FitObjectiveTestCases.cpp
+++ b/Tests/Functional/Fit/FitObjective/FitObjectiveTestCases.cpp
@@ -18,10 +18,10 @@ MigradCylindersInBA::MigradCylindersInBA()
     : FitObjectiveTest("Minuit2", "Migrad", "CylindersInBAPlan") {}
 
 BfgsCylindersInBA::BfgsCylindersInBA()
-    : FitObjectiveTest("GSLMultiMin", "BFGS", "CylindersInBAPlan") {}
+    : FitObjectiveTest("GSLMultiMin", "BFGS2", "CylindersInBAEasyPlan") {}
 
 SteepestDescentCylindersInBA::SteepestDescentCylindersInBA()
-    : FitObjectiveTest("GSLMultiMin", "SteepestDescent", "CylindersInBAPlan") {}
+    : FitObjectiveTest("GSLMultiMin", "SteepestDescent", "CylindersInBAEasyPlan") {}
 
 FumuliCylindersInBA::FumuliCylindersInBA()
     : FitObjectiveTest("Minuit2", "Fumili", "CylindersInBAResidualPlan") {}
@@ -42,7 +42,10 @@ GeneticCylindersInBA::GeneticCylindersInBA()
 }
 
 RectDetectorFit::RectDetectorFit()
-    : FitObjectiveTest("Minuit2", "Migrad", "RectDetPlan") {}
+    : FitObjectiveTest("Minuit2", "Migrad", "RectDetPlan")
+{
+    setMinimizerOptions("Strategy=2");
+}
 
 AdjustMinimizerFit::AdjustMinimizerFit()
     : FitObjectiveTest("Genetic", "", "AdjustMinimizerPlan") {}

--- a/Tests/Functional/Fit/FitObjective/FitObjectiveTestCases.h
+++ b/Tests/Functional/Fit/FitObjective/FitObjectiveTestCases.h
@@ -25,6 +25,12 @@ public:
     MigradCylindersInBA();
 };
 
+class MigradResidualCylindersInBA : public FitObjectiveTest
+{
+public:
+    MigradResidualCylindersInBA();
+};
+
 class BfgsCylindersInBA : public FitObjectiveTest
 {
 public:

--- a/Tests/Functional/Fit/FitObjective/FitObjectiveTestFactory.cpp
+++ b/Tests/Functional/Fit/FitObjective/FitObjectiveTestFactory.cpp
@@ -19,6 +19,8 @@ FitObjectiveTestFactory::FitObjectiveTestFactory()
 {
     registerItem("MigradCylindersInBA", create_new<MigradCylindersInBA>,
                  "Minuit + CylindersInBA");
+    registerItem("MigradResidualCylindersInBA", create_new<MigradResidualCylindersInBA>,
+                 "Minuit + ResidualCylindersInBA");
     registerItem("BfgsCylindersInBA", create_new<BfgsCylindersInBA>,
                  "BFGS + CylindersInBA");
     registerItem("SteepestDescentCylindersInBA", create_new<SteepestDescentCylindersInBA>,

--- a/Tests/Functional/Fit/FitObjective/FitPlanCases.cpp
+++ b/Tests/Functional/Fit/FitObjective/FitPlanCases.cpp
@@ -60,8 +60,8 @@ CylindersInBAResidualPlan::CylindersInBAResidualPlan()
 {
     setBuilderName("CylindersInBABuilder");
     setSimulationName("MiniGISAS");
-    addParameter(Parameter("height", 4.5*nm, AttLimits::lowerLimited(0.01), 0.01), 5.0*nm);
-    addParameter(Parameter("radius", 5.5*nm, AttLimits::lowerLimited(0.01), 0.01), 5.0*nm);
+    addParameter(Parameter("height", 4.5*nm, AttLimits::limitless(), 0.01), 5.0*nm);
+    addParameter(Parameter("radius", 5.5*nm, AttLimits::limitless(), 0.01), 5.0*nm);
 }
 
 // ----------------------------------------------------------------------------

--- a/Tests/Functional/Fit/FitObjective/FitPlanCases.cpp
+++ b/Tests/Functional/Fit/FitObjective/FitPlanCases.cpp
@@ -44,14 +44,14 @@ CylindersInBAPlan::CylindersInBAPlan()
 }
 
 CylindersInBAEasyPlan::CylindersInBAEasyPlan()
-    : FitPlan("CylindersInBAPlan")
+    : FitPlan("CylindersInBAEasyPlan")
 {
     setBuilderName("CylindersInBABuilder");
-    setSimulationName("MiniGISAS");
+    setSimulationName("MiniGISASFit");
     const double tolerance = 0.1;
-    addParameter(Parameter("height", 4.5*nm, AttLimits::limited(4.0, 6.0), 0.01),
+    addParameter(Parameter("height", 4.5*nm, AttLimits::limited(4.0, 6.0), 0.1),
                  5.0*nm, tolerance);
-    addParameter(Parameter("radius", 5.5*nm, AttLimits::limited(4.0, 6.0), 0.01),
+    addParameter(Parameter("radius", 5.5*nm, AttLimits::limited(4.0, 6.0), 0.1),
                  5.0*nm, tolerance);
 }
 
@@ -70,8 +70,8 @@ RectDetPlan::RectDetPlan()
     : FitPlan("RectDetPlan")
 {
     setBuilderName("CylindersInBABuilder");
-    addParameter(Parameter("height", 4.5*nm, AttLimits::lowerLimited(0.01), 0.01), 5.0*nm);
-    addParameter(Parameter("radius", 5.5*nm, AttLimits::lowerLimited(0.01), 0.01), 5.0*nm);
+    addParameter(Parameter("height", 4.5*nm, AttLimits::limited(4.0, 6.0), 0.01), 5.0*nm);
+    addParameter(Parameter("radius", 5.5*nm, AttLimits::limited(4.0, 6.0), 0.01), 5.0*nm);
 }
 
 RectDetPlan::~RectDetPlan() = default;
@@ -87,8 +87,8 @@ std::unique_ptr<Simulation> RectDetPlan::createSimulation(const Parameters&) con
 
     result->setBeamParameters(1.0*Units::angstrom, 0.2*Units::degree, 0.0*Units::degree);
     result->setDetector(detector);
-    result->setRegionOfInterest(6.0, 6.0, 14.0, 12.0);
-    result->addMask(Rectangle(8.0, 8.0, 10.0, 10.0), true);
+    result->setRegionOfInterest(5.0, 6.0, 15.0, 12.0);
+    result->addMask(Rectangle(0.0, 0.0, 2.0, 2.0), true);
     return std::unique_ptr<Simulation>(result.release());
 }
 

--- a/Tests/Functional/Fit/Minimizer/FunctionTestPlanCases.cpp
+++ b/Tests/Functional/Fit/Minimizer/FunctionTestPlanCases.cpp
@@ -77,6 +77,15 @@ DecayingSinPlan::DecayingSinPlan()
     addParameter(Parameter("decay", 0.1, AttLimits::nonnegative()), 0.05);
 }
 
+DecayingSinPlanV2::DecayingSinPlanV2()
+    : ResidualTestPlan("DecayingSinPlanV2", TestFunctions::DecayingSin)
+{
+    addParameter(Parameter("amp", 1.0, AttLimits::limitless()), 2.0);
+    addParameter(Parameter("frequency", 1.0, AttLimits::limitless()), 2.0);
+    addParameter(Parameter("phase", 1.0, AttLimits::fixed()), 1.0);
+    addParameter(Parameter("decay", 0.05, AttLimits::fixed()), 0.05);
+}
+
 TestMinimizerPlan::TestMinimizerPlan()
     : ScalarTestPlan("TestMinimizerPlan", TestFunctions::RosenBrock, 0.0)
 {

--- a/Tests/Functional/Fit/Minimizer/FunctionTestPlanCases.h
+++ b/Tests/Functional/Fit/Minimizer/FunctionTestPlanCases.h
@@ -61,6 +61,14 @@ public:
     DecayingSinPlan();
 };
 
+//! Same as DecayingSinPlan with fewer fit parameters
+
+class DecayingSinPlanV2 : public ResidualTestPlan
+{
+public:
+    DecayingSinPlanV2();
+};
+
 //! Special plan to test TestMinimizer.
 
 class TestMinimizerPlan : public ScalarTestPlan

--- a/Tests/Functional/Fit/Minimizer/FunctionTestPlanFactory.cpp
+++ b/Tests/Functional/Fit/Minimizer/FunctionTestPlanFactory.cpp
@@ -22,5 +22,6 @@ FunctionTestPlanFactory::FunctionTestPlanFactory()
     registerItem("WoodFourPlan", create_new<WoodFourPlan>);
     registerItem("EasyWoodFourPlan", create_new<EasyWoodFourPlan>);
     registerItem("DecayingSinPlan", create_new<DecayingSinPlan>);
+    registerItem("DecayingSinPlanV2", create_new<DecayingSinPlanV2>);
     registerItem("TestMinimizerPlan", create_new<TestMinimizerPlan>);
 }

--- a/Tests/Functional/Fit/Minimizer/MinimizerTestCases.cpp
+++ b/Tests/Functional/Fit/Minimizer/MinimizerTestCases.cpp
@@ -78,7 +78,7 @@ FumiliTestV3::FumiliTestV3()
 }
 
 LevenbergMarquardtV3::LevenbergMarquardtV3()
-    : MinimizerTest("GSLLMA", "Default", "DecayingSinPlan") {}
+    : MinimizerTest("GSLLMA", "Default", "DecayingSinPlanV2") {}
 
 
 TestMinimizerV1::TestMinimizerV1()

--- a/Tests/Functional/Fit/Minimizer/MinimizerTestFactory.cpp
+++ b/Tests/Functional/Fit/Minimizer/MinimizerTestFactory.cpp
@@ -63,7 +63,7 @@ MinimizerTestFactory::MinimizerTestFactory()
                  "Minuit + Fumili + DecayingSinPlan");
 
     registerItem("LevenbergMarquardtV3", create_new<LevenbergMarquardtV3>,
-                 "LevenbergMarquardt + DecayingSinPlan");
+                 "LevenbergMarquardt + DecayingSinPlanV2");
 
     registerItem("TestMinimizerV1", create_new<TestMinimizerV1>,
                  "Test minimizer");

--- a/Tests/Functional/TestMachinery/MinimizerTestPlan.cpp
+++ b/Tests/Functional/TestMachinery/MinimizerTestPlan.cpp
@@ -67,12 +67,16 @@ bool MinimizerTestPlan::valuesAsExpected(const std::vector<double>& values) cons
     std::ostringstream text;
     for (const auto& plan : m_parameter_plan) {
         double diff = Numeric::get_relative_difference(values[index], plan.expectedValue());
+
+        bool diff_ok(true);
         if (diff > plan.tolerance())
-            success = false;
+            diff_ok = false;
 
         text << plan.fitParameter().name() << " found:" << values[index]
              << " expected:" << plan.expectedValue() << " diff:" << diff << " "
-             << (success ? "OK" : "FAILED") << "\n";
+             << (diff_ok ? "OK" : "FAILED") << "\n";
+
+        success &= diff_ok;
 
         ++index;
     }

--- a/auto/Wrap/libBornAgainCore.py
+++ b/auto/Wrap/libBornAgainCore.py
@@ -6461,6 +6461,11 @@ class FitObjective(_object):
         return _libBornAgainCore.FitObjective_simulation_array(self)
 
 
+    def weights_array(self):
+        """weights_array(FitObjective self) -> vdouble1d_t"""
+        return _libBornAgainCore.FitObjective_weights_array(self)
+
+
     def simulationResult(self, i_item=0):
         """
         simulationResult(FitObjective self, size_t i_item=0) -> SimulationResult


### PR DESCRIPTION
+ Enable Fumili and Levenberg Marquardt in GUI
+ Disable possibility to have fit parameter limits for Levenberg Marquardt (ROOT wrapper around GSL is buggy)
+ Repair fit weights for multiple dataset scenario
