### PR TITLE
Fixes for issues #2235 and #2217

### DIFF
--- a/GUI/coregui/Models/BeamDistributionItem.cpp
+++ b/GUI/coregui/Models/BeamDistributionItem.cpp
@@ -84,7 +84,10 @@ void BeamDistributionItem::initDistributionItem(bool show_mean)
 
     if (!distributionNone)
         return;
+
     const RealLimits limits = distributionNone->getItem(DistributionNoneItem::P_MEAN)->limits();
+    const QString editor_type =
+        distributionNone->getItem(DistributionNoneItem::P_MEAN)->editorType();
 
     for (auto item : groupItem->getItems(GroupItem::T_ITEMS)) {
         DistributionItem* distrItem = dynamic_cast<DistributionItem*>(item);
@@ -95,6 +98,10 @@ void BeamDistributionItem::initDistributionItem(bool show_mean)
 
         distrItem->init_parameters(
             distributionNone->getItemValue(DistributionNoneItem::P_MEAN).toDouble(), limits);
+        if (auto symmetric_distr = dynamic_cast<SymmetricDistributionItem*>(distrItem))
+            symmetric_distr->getItem(SymmetricDistributionItem::P_MEAN)
+                ->setEditorType(editor_type)
+                .setLimits(limits);
 
         // hiding limits from the editor
         if (distrItem->isTag(DistributionItem::P_LIMITS))

--- a/GUI/coregui/Models/BeamItems.cpp
+++ b/GUI/coregui/Models/BeamItems.cpp
@@ -192,6 +192,14 @@ void SpecularBeamItem::updateFileName(const QString& filename)
     item<SpecularBeamInclinationItem>(BeamItem::P_INCLINATION_ANGLE).updateFileName(filename);
 }
 
+void SpecularBeamItem::updateToData(const IAxis& axis, QString units)
+{
+    auto axis_group = inclinationAxisGroup();
+    axis_group->setCurrentType(Constants::PointwiseAxisType);
+    auto axis_item = static_cast<PointwiseAxisItem*>(axis_group->currentItem());
+    axis_item->init(axis, units);
+}
+
 // GISAS beam item
 /* ------------------------------------------------------------------------- */
 

--- a/GUI/coregui/Models/BeamItems.cpp
+++ b/GUI/coregui/Models/BeamItems.cpp
@@ -22,6 +22,7 @@
 #include "FootprintItems.h"
 #include "GroupItem.h"
 #include "GUIHelpers.h"
+#include "IAxis.h"
 #include "ParameterTranslators.h"
 #include "PointwiseAxisItem.h"
 #include "SessionItemUtils.h"
@@ -194,6 +195,13 @@ void SpecularBeamItem::updateFileName(const QString& filename)
 
 void SpecularBeamItem::updateToData(const IAxis& axis, QString units)
 {
+    if (units == Constants::UnitsNbins) {
+        inclinationAxisGroup()->setCurrentType(Constants::BasicAxisType);
+        auto axis_item = currentInclinationAxisItem();
+        axis_item->setItemValue(BasicAxisItem::P_NBINS, static_cast<int>(axis.size()));
+        return;
+    }
+
     auto axis_group = inclinationAxisGroup();
     axis_group->setCurrentType(Constants::PointwiseAxisType);
     auto axis_item = static_cast<PointwiseAxisItem*>(axis_group->currentItem());

--- a/GUI/coregui/Models/BeamItems.h
+++ b/GUI/coregui/Models/BeamItems.h
@@ -21,6 +21,7 @@ class BasicAxisItem;
 class Beam;
 class FootprintItem;
 class GroupItem;
+class IAxis;
 
 class BA_CORE_API_ BeamItem : public SessionItem
 {
@@ -70,6 +71,7 @@ public:
     FootprintItem* currentFootprintItem() const;
 
     void updateFileName(const QString& filename);
+    void updateToData(const IAxis& axis, QString units);
 };
 
 class BA_CORE_API_ GISASBeamItem : public BeamItem

--- a/GUI/coregui/Models/BeamWavelengthItem.cpp
+++ b/GUI/coregui/Models/BeamWavelengthItem.cpp
@@ -43,3 +43,12 @@ SpecularBeamWavelengthItem::SpecularBeamWavelengthItem()
     : BeamWavelengthItem(Constants::SpecularBeamWavelengthType,
                          Constants::SymmetricDistributionGroup)
 {}
+
+void SpecularBeamWavelengthItem::setToRange(const RealLimits& limits)
+{
+    SessionItem* valueItem =
+        getGroupItem(P_DISTRIBUTION)->getItem(SymmetricDistributionItem::P_MEAN);
+    if (!limits.isInRange(wavelength()))
+        valueItem->setValue(limits.hasUpperLimit() ? limits.upperLimit() : limits.lowerLimit());
+    valueItem->setLimits(limits);
+}

--- a/GUI/coregui/Models/BeamWavelengthItem.cpp
+++ b/GUI/coregui/Models/BeamWavelengthItem.cpp
@@ -14,6 +14,10 @@
 
 #include "BeamWavelengthItem.h"
 
+namespace {
+const double default_wl = 0.1;
+}
+
 BeamWavelengthItem::BeamWavelengthItem(const QString& model_type,const QString& distribution_group)
     : BeamDistributionItem(model_type, m_show_mean)
 {
@@ -22,7 +26,8 @@ BeamWavelengthItem::BeamWavelengthItem(const QString& model_type,const QString& 
     SessionItem *valueItem = getGroupItem(P_DISTRIBUTION)->getItem(DistributionNoneItem::P_MEAN);
     valueItem->setLimits(RealLimits::positive());
     valueItem->setDecimals(4);
-    valueItem->setValue(0.1);
+    valueItem->setValue(default_wl);
+    valueItem->setEditorType(Constants::ScientificSpinBoxType);
 
     initDistributionItem(m_show_mean);
 }

--- a/GUI/coregui/Models/BeamWavelengthItem.h
+++ b/GUI/coregui/Models/BeamWavelengthItem.h
@@ -33,6 +33,7 @@ class BA_CORE_API_ SpecularBeamWavelengthItem : public BeamWavelengthItem
 {
 public:
     SpecularBeamWavelengthItem();
+    void setToRange(const RealLimits& limits);
 };
 
 #endif // BEAMWAVELENGTHITEM_H

--- a/GUI/coregui/Models/DepthProbeInstrumentItem.cpp
+++ b/GUI/coregui/Models/DepthProbeInstrumentItem.cpp
@@ -62,9 +62,9 @@ std::vector<int> DepthProbeInstrumentItem::shape() const
     throw std::runtime_error("DepthProbeInstrumentItem::shape()");
 }
 
-void DepthProbeInstrumentItem::setShape(const std::vector<int>&)
+void DepthProbeInstrumentItem::updateToRealData(const RealDataItem*)
 {
-    throw std::runtime_error("DepthProbeInstrumentItem::setShape()");
+    throw std::runtime_error("DepthProbeInstrumentItem::updateToRealData()");
 }
 
 std::unique_ptr<DepthProbeSimulation> DepthProbeInstrumentItem::createSimulation() const

--- a/GUI/coregui/Models/DepthProbeInstrumentItem.h
+++ b/GUI/coregui/Models/DepthProbeInstrumentItem.h
@@ -33,7 +33,7 @@ public:
 
     std::unique_ptr<Instrument> createInstrument() const override;
     std::vector<int> shape() const override;
-    void setShape(const std::vector<int>&) override;
+    void updateToRealData(const RealDataItem* item) override;
 
     // FIXME switch to base Simulation class after InstrumentItem refactoring and
     // after Simulation gets createUnitConverter method

--- a/GUI/coregui/Models/InstrumentItems.cpp
+++ b/GUI/coregui/Models/InstrumentItems.cpp
@@ -76,7 +76,7 @@ void InstrumentItem::updateToRealData(const RealDataItem *item)
     setShape(item->shape());
 }
 
-bool InstrumentItem::alignedWith(const RealDataItem* item)
+bool InstrumentItem::alignedWith(const RealDataItem* item) const
 {
     return shape() == item->shape();
 }
@@ -161,7 +161,7 @@ void SpecularInstrumentItem::updateToRealData(const RealDataItem* item)
     }
 }
 
-bool SpecularInstrumentItem::alignedWith(const RealDataItem* item)
+bool SpecularInstrumentItem::alignedWith(const RealDataItem* item) const
 {
     const QString native_units = item->getItemValue(RealDataItem::P_NATIVE_UNITS).toString();
     if (native_units == Constants::UnitsNbins) {

--- a/GUI/coregui/Models/InstrumentItems.cpp
+++ b/GUI/coregui/Models/InstrumentItems.cpp
@@ -150,15 +150,13 @@ void SpecularInstrumentItem::updateToRealData(const RealDataItem* item)
     if (item->getItemValue(RealDataItem::P_NATIVE_UNITS).toString() == Constants::UnitsNbins) {
         beamItem()->inclinationAxisGroup()->setCurrentType(Constants::BasicAxisType);
         setShape(item->shape());
-    } else {
-        QString units = item->getItemValue(RealDataItem::P_NATIVE_UNITS).toString();
-        const auto& data = item->nativeData()->getOutputData()->getAxis(0);
-
-        auto axis_group = beamItem()->inclinationAxisGroup();
-        axis_group->setCurrentType(Constants::PointwiseAxisType);
-        auto axis = dynamic_cast<PointwiseAxisItem*>(axis_group->currentItem());
-        axis->init(data, units);
+        return;
     }
+
+    // the case of dimensional units in user data
+    QString units = item->getItemValue(RealDataItem::P_NATIVE_UNITS).toString();
+    const auto& data = item->nativeData()->getOutputData()->getAxis(0);
+    beamItem()->updateToData(data, units);
 }
 
 bool SpecularInstrumentItem::alignedWith(const RealDataItem* item) const

--- a/GUI/coregui/Models/InstrumentItems.cpp
+++ b/GUI/coregui/Models/InstrumentItems.cpp
@@ -71,11 +71,6 @@ GroupItem* InstrumentItem::backgroundGroup()
     return &item<GroupItem>(P_BACKGROUND);
 }
 
-void InstrumentItem::updateToRealData(const RealDataItem *item)
-{
-    setShape(item->shape());
-}
-
 bool InstrumentItem::alignedWith(const RealDataItem* item) const
 {
     return shape() == item->shape();
@@ -134,15 +129,6 @@ std::vector<int> SpecularInstrumentItem::shape() const
 {
     const auto axis_item = beamItem()->currentInclinationAxisItem();
     return {axis_item->getItemValue(BasicAxisItem::P_NBINS).toInt()};
-}
-
-void SpecularInstrumentItem::setShape(const std::vector<int>& data_shape)
-{
-    if (shape().size() != data_shape.size())
-        throw GUIHelpers::Error("Error in SpecularInstrumentItem::setShape: The type of "
-                                "instrument is incompatible with passed data shape.");
-    auto axis_item = beamItem()->currentInclinationAxisItem();
-    axis_item->setItemValue(BasicAxisItem::P_NBINS, data_shape[0]);
 }
 
 void SpecularInstrumentItem::updateToRealData(const RealDataItem* item)
@@ -254,10 +240,14 @@ std::vector<int> GISASInstrumentItem::shape() const
     return {detector_item->xSize(), detector_item->ySize()};
 }
 
-void GISASInstrumentItem::setShape(const std::vector<int>& data_shape)
+void GISASInstrumentItem::updateToRealData(const RealDataItem* item)
 {
+    if (!item)
+        return;
+
+    const auto data_shape = item->shape();
     if (shape().size() != data_shape.size())
-        throw GUIHelpers::Error("Error in GISASInstrumentItem::setShape: The type of "
+        throw GUIHelpers::Error("Error in GISASInstrumentItem::updateToRealData: The type of "
                                 "instrument is incompatible with passed data shape.");
     detectorItem()->setXSize(data_shape[0]);
     detectorItem()->setYSize(data_shape[1]);
@@ -278,10 +268,14 @@ std::vector<int> OffSpecInstrumentItem::shape() const
     return {x_size, detector_item->ySize()};
 }
 
-void OffSpecInstrumentItem::setShape(const std::vector<int>& data_shape)
+void OffSpecInstrumentItem::updateToRealData(const RealDataItem* item)
 {
+    if (!item)
+        return;
+
+    const auto data_shape = item->shape();
     if (shape().size() != data_shape.size())
-        throw GUIHelpers::Error("Error in OffSpecInstrumentItem::setShape: The type of "
+        throw GUIHelpers::Error("Error in OffSpecInstrumentItem::updateToRealData: The type of "
                                 "instrument is incompatible with passed data shape.");
     getItem(OffSpecInstrumentItem::P_ALPHA_AXIS)
         ->setItemValue(BasicAxisItem::P_NBINS, data_shape[0]);

--- a/GUI/coregui/Models/InstrumentItems.cpp
+++ b/GUI/coregui/Models/InstrumentItems.cpp
@@ -147,13 +147,10 @@ void SpecularInstrumentItem::setShape(const std::vector<int>& data_shape)
 
 void SpecularInstrumentItem::updateToRealData(const RealDataItem* item)
 {
-    if (item->getItemValue(RealDataItem::P_NATIVE_UNITS).toString() == Constants::UnitsNbins) {
-        beamItem()->inclinationAxisGroup()->setCurrentType(Constants::BasicAxisType);
-        setShape(item->shape());
-        return;
-    }
+    if (shape().size() != item->shape().size())
+        throw GUIHelpers::Error("Error in SpecularInstrumentItem::updateToRealData: The type "
+                                "of instrument is incompatible with passed data shape.");
 
-    // the case of dimensional units in user data
     QString units = item->getItemValue(RealDataItem::P_NATIVE_UNITS).toString();
     const auto& data = item->nativeData()->getOutputData()->getAxis(0);
     beamItem()->updateToData(data, units);

--- a/GUI/coregui/Models/InstrumentItems.h
+++ b/GUI/coregui/Models/InstrumentItems.h
@@ -41,7 +41,6 @@ public:
 
     virtual std::unique_ptr<Instrument> createInstrument() const = 0;
     virtual std::vector<int> shape() const = 0;
-    virtual void setShape(const std::vector<int>& shape) = 0;
     virtual void clearMasks() {}
     virtual void importMasks(const MaskContainerItem*) {}
     virtual void updateToRealData(const RealDataItem* item);
@@ -52,6 +51,8 @@ protected:
 
     void initBeamGroup(const QString& beam_model);
     void initBackgroundGroup();
+
+    virtual void setShape(const std::vector<int>& shape) = 0;
 };
 
 class BA_CORE_API_ SpecularInstrumentItem : public InstrumentItem
@@ -64,11 +65,13 @@ public:
 
     std::unique_ptr<Instrument> createInstrument() const override;
     std::vector<int> shape() const override;
-    void setShape(const std::vector<int>& shape) override;
     void updateToRealData(const RealDataItem* item) override;
     bool alignedWith(const RealDataItem* item) const override;
 
     std::unique_ptr<IUnitConverter> createUnitConverter() const;
+
+protected:
+    void setShape(const std::vector<int>& shape) override;
 };
 
 class BA_CORE_API_ Instrument2DItem : public InstrumentItem
@@ -97,6 +100,8 @@ class BA_CORE_API_ GISASInstrumentItem : public Instrument2DItem
 public:
     GISASInstrumentItem();
     std::vector<int> shape() const override;
+
+protected:
     void setShape(const std::vector<int>& data_shape) override;
 };
 
@@ -107,6 +112,8 @@ public:
 
     OffSpecInstrumentItem();
     std::vector<int> shape() const override;
+
+protected:
     void setShape(const std::vector<int>& data_shape) override;
 };
 

--- a/GUI/coregui/Models/InstrumentItems.h
+++ b/GUI/coregui/Models/InstrumentItems.h
@@ -43,7 +43,7 @@ public:
     virtual std::vector<int> shape() const = 0;
     virtual void clearMasks() {}
     virtual void importMasks(const MaskContainerItem*) {}
-    virtual void updateToRealData(const RealDataItem* item);
+    virtual void updateToRealData(const RealDataItem* item) = 0;
     virtual bool alignedWith(const RealDataItem* item) const;
 
 protected:
@@ -51,8 +51,6 @@ protected:
 
     void initBeamGroup(const QString& beam_model);
     void initBackgroundGroup();
-
-    virtual void setShape(const std::vector<int>& shape) = 0;
 };
 
 class BA_CORE_API_ SpecularInstrumentItem : public InstrumentItem
@@ -69,9 +67,6 @@ public:
     bool alignedWith(const RealDataItem* item) const override;
 
     std::unique_ptr<IUnitConverter> createUnitConverter() const;
-
-protected:
-    void setShape(const std::vector<int>& shape) override;
 };
 
 class BA_CORE_API_ Instrument2DItem : public InstrumentItem
@@ -100,9 +95,7 @@ class BA_CORE_API_ GISASInstrumentItem : public Instrument2DItem
 public:
     GISASInstrumentItem();
     std::vector<int> shape() const override;
-
-protected:
-    void setShape(const std::vector<int>& data_shape) override;
+    void updateToRealData(const RealDataItem* item) override;
 };
 
 class BA_CORE_API_ OffSpecInstrumentItem : public Instrument2DItem
@@ -112,9 +105,7 @@ public:
 
     OffSpecInstrumentItem();
     std::vector<int> shape() const override;
-
-protected:
-    void setShape(const std::vector<int>& data_shape) override;
+    void updateToRealData(const RealDataItem* item) override;
 };
 
 #endif // INSTRUMENTITEMS_H

--- a/GUI/coregui/Models/InstrumentItems.h
+++ b/GUI/coregui/Models/InstrumentItems.h
@@ -45,7 +45,7 @@ public:
     virtual void clearMasks() {}
     virtual void importMasks(const MaskContainerItem*) {}
     virtual void updateToRealData(const RealDataItem* item);
-    virtual bool alignedWith(const RealDataItem* item);
+    virtual bool alignedWith(const RealDataItem* item) const;
 
 protected:
     explicit InstrumentItem(const QString& modelType);
@@ -66,7 +66,7 @@ public:
     std::vector<int> shape() const override;
     void setShape(const std::vector<int>& shape) override;
     void updateToRealData(const RealDataItem* item) override;
-    bool alignedWith(const RealDataItem* item) override;
+    bool alignedWith(const RealDataItem* item) const override;
 
     std::unique_ptr<IUnitConverter> createUnitConverter() const;
 };

--- a/GUI/coregui/Views/SimulationWidgets/SimulationSetupAssistant.cpp
+++ b/GUI/coregui/Views/SimulationWidgets/SimulationSetupAssistant.cpp
@@ -38,7 +38,7 @@ bool SimulationSetupAssistant::isValidSimulationSetup(const MultiLayerItem *mult
     checkFittingSetup(instrumentItem, realData);
 
     if(!m_isValid)
-        QMessageBox::warning(0, QStringLiteral("Can't run the job"), composeMessage());
+        QMessageBox::warning(nullptr, QStringLiteral("Can't run the job"), composeMessage());
 
     return m_isValid;
 }
@@ -77,13 +77,12 @@ void SimulationSetupAssistant::checkInstrumentItem(const InstrumentItem* instrum
 void SimulationSetupAssistant::checkFittingSetup(const InstrumentItem* instrumentItem,
                                                  const RealDataItem* realData)
 {
-    if (!realData
-        || instrumentItem->getItemValue(InstrumentItem::P_IDENTIFIER).toString()
-               == realData->getItemValue(RealDataItem::P_INSTRUMENT_ID).toString())
+    if (!realData || instrumentItem->alignedWith(realData))
         return;
 
     m_isValid = false;
-    m_messages.append("The RealData was not linked to the instrument");
+    m_messages.append("The experimental data does not fit in the selected instrument. Try linking "
+                      "them in Import Tab.");
 }
 
 //! Composes the error message for message box.


### PR DESCRIPTION
1. Silent linking if instrument complies with real data
2. Prevent user from typing in out-of-range values for wavelength in instrument tab
3. Setting wavelength to a reasonable value in instrument tab if real data with q-coordinate is linked to an instrument.
4. Removed `InstrumentItem::setShape` method in favor of `InstrumentItem::updateToRealData`.

Some of the changes should be treated in a more generic fashion:
1. Replace `DoubleEditor` with `ScientificSpinBox`, which can handle limited values in a better way (`RealLimits::positive` in particular). In this PR it is used only for wavelength in specular instrument. 

2. Take care of setting proper limits to children if distribution item is changed. Now it is done only for `SymmetricDistributionItem::P_MEAN` (which should be actually removed in the future).