### PR TITLE
Self-consistence test machinery and check for reflectometry on sliced sample

### DIFF
--- a/Core/StandardSamples/SampleBuilderFactory.cpp
+++ b/Core/StandardSamples/SampleBuilderFactory.cpp
@@ -40,6 +40,7 @@
 #include "TransformationsBuilder.h"
 #include "TwoDimLatticeBuilder.h"
 #include "TwoLayerRoughnessBuilder.h"
+#include "SlicedCylindersBuilder.h"
 #include "SlicedParticleBuilder.h"
 #include "ResonatorBuilder.h"
 
@@ -323,11 +324,21 @@ SampleBuilderFactory::SampleBuilderFactory()
                  "Alternating homogeneous layers of Ti and Ni on silicone substrate "
                  "(wavelength-independent).");
 
-    registerItem(
-        "ResonatorBuilder",
-        create_new<ResonatorBuilder>,
-        "Multilayer with bi-layer sequence for OffSpec testing.");
+    registerItem("ResonatorBuilder",
+                 create_new<ResonatorBuilder>,
+                 "Multilayer with bi-layer sequence for OffSpec testing.");
 
+    registerItem("SlicedCylindersBuilder",
+                 create_new<SlicedCylindersBuilder>,
+                 "Multilayer with cylinders on substrate (sliced)");
+
+    registerItem("SLDSlicedCylindersBuilder",
+                 create_new<SLDSlicedCylindersBuilder>,
+                 "Multilayer with cylinders on substrate (sliced, using sld-based materials)");
+
+    registerItem("AveragedSlicedCylindersBuilder",
+                 create_new<AveragedSlicedCylindersBuilder>,
+                 "Manually sliced multilayer with cylinders on substrate (sld-based materials)");
 }
 
 //! Retrieves a SampleBuilder from the registry, does the build, and returns the result.

--- a/Core/StandardSamples/SlicedCylindersBuilder.cpp
+++ b/Core/StandardSamples/SlicedCylindersBuilder.cpp
@@ -1,0 +1,137 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Core/StandardSamples/CylindersBuilder.h
+//! @brief     Implements classes for testing slicing machinery.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#include "SlicedCylindersBuilder.h"
+#include "FormFactorCylinder.h"
+#include "Layer.h"
+#include "MaterialFactoryFuncs.h"
+#include "MathConstants.h"
+#include "MultiLayer.h"
+#include "Particle.h"
+#include "ParticleLayout.h"
+#include "Units.h"
+
+namespace {
+//! Returns SLD input (in inverse square Angstroms) for MaterialBySLD from _delta_ and _beta_,
+//! i.e. the input for HomogeneousMaterial.
+complex_t getSLDFromN(double wavelength, double delta, double beta);
+complex_t averageSLD(complex_t sld_p, complex_t sld_l, double eff_vol);
+}
+
+SlicedCylindersBuilder::SlicedCylindersBuilder()
+    : m_height(5*Units::nanometer)
+    , m_radius(5*Units::nanometer)
+    , m_wavelength(0.154) // nm
+    , m_n_slices(3)
+{}
+
+MultiLayer* SlicedCylindersBuilder::buildSample() const
+{
+    MultiLayer* multi_layer = new MultiLayer();
+
+    Material air_material = HomogeneousMaterial("Air", 0.0, 0.0);
+    Material substrate_material = HomogeneousMaterial("Substrate", 6e-6, 2e-8);
+    Material particle_material = HomogeneousMaterial("Particle", 6e-4, 2e-8);
+
+    Layer air_layer(air_material);
+    Layer substrate_layer(substrate_material);
+
+    FormFactorCylinder ff_cylinder(m_radius, m_height);
+
+    Particle particle(particle_material, ff_cylinder);
+    ParticleLayout particle_layout(particle);
+
+    air_layer.addLayout(particle_layout);
+    air_layer.setNumberOfSlices(m_n_slices);
+
+    multi_layer->addLayer(air_layer);
+    multi_layer->addLayer(substrate_layer);
+
+    return multi_layer;
+}
+
+SLDSlicedCylindersBuilder::SLDSlicedCylindersBuilder()
+    : SlicedCylindersBuilder()
+{}
+
+MultiLayer* SLDSlicedCylindersBuilder::buildSample() const
+{
+    MultiLayer* multi_layer = new MultiLayer();
+
+    Material air_material = MaterialBySLD("Air", 0.0, 0.0);
+    complex_t sub_sld = getSLDFromN(m_wavelength, 6e-6, 2e-8);
+    Material substrate_material = MaterialBySLD("Substrate", sub_sld.real(), sub_sld.imag());
+    complex_t par_sld = getSLDFromN(m_wavelength, 6e-4, 2e-8);
+    Material particle_material = MaterialBySLD("Particle", par_sld.real(), par_sld.imag());
+
+    Layer air_layer(air_material);
+    Layer substrate_layer(substrate_material);
+
+    FormFactorCylinder ff_cylinder(m_radius, m_height);
+
+    Particle particle(particle_material, ff_cylinder);
+    ParticleLayout particle_layout(particle);
+
+    air_layer.addLayout(particle_layout);
+    air_layer.setNumberOfSlices(m_n_slices);
+
+    multi_layer->addLayer(air_layer);
+    multi_layer->addLayer(substrate_layer);
+
+    return multi_layer;
+}
+
+AveragedSlicedCylindersBuilder::AveragedSlicedCylindersBuilder()
+    : SlicedCylindersBuilder()
+    , m_par_surf_density(ParticleLayout().totalParticleSurfaceDensity())
+{}
+
+MultiLayer* AveragedSlicedCylindersBuilder::buildSample() const
+{
+    MultiLayer* multi_layer = new MultiLayer();
+
+    complex_t air_sld{0.0, 0.0};
+    Material air_material = MaterialBySLD("Air", air_sld.real(), air_sld.imag());
+    complex_t sub_sld = getSLDFromN(m_wavelength, 6e-6, 2e-8);
+    Material substrate_material = MaterialBySLD("Substrate", sub_sld.real(), sub_sld.imag());
+
+    double eff_vol = m_par_surf_density * M_PI * m_radius * m_radius;
+    complex_t par_sld = getSLDFromN(m_wavelength, 6e-4, 2e-8);
+    complex_t avr_sld = averageSLD(par_sld, air_sld, eff_vol);
+    Material avr_material = MaterialBySLD("Avr", avr_sld.real(), avr_sld.imag());
+
+    Layer air_layer(air_material);
+    Layer avr_layer(avr_material, m_height / m_n_slices);
+    Layer substrate_layer(substrate_material);
+
+    multi_layer->addLayer(air_layer);
+    for (size_t i = 0; i < m_n_slices; ++i)
+        multi_layer->addLayer(avr_layer);
+    multi_layer->addLayer(substrate_layer);
+
+    return multi_layer;
+}
+
+namespace {
+complex_t getSLDFromN(double wavelength, double delta, double beta)
+{
+    complex_t result {2 * delta - delta * delta + beta * beta, 2 * beta - 2 * delta * beta};
+    return result * M_PI / (wavelength * wavelength) * (Units::angstrom * Units::angstrom);
+}
+
+complex_t averageSLD(complex_t sld_p, complex_t sld_l, double eff_vol)
+{
+    return sld_l + eff_vol * (sld_p - sld_l);
+}
+}

--- a/Core/StandardSamples/SlicedCylindersBuilder.h
+++ b/Core/StandardSamples/SlicedCylindersBuilder.h
@@ -1,0 +1,62 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Core/StandardSamples/CylindersBuilder.h
+//! @brief     Defines classes for testing slicing machinery.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#ifndef SLICEDCYLINDERSBUILDER_H
+#define SLICEDCYLINDERSBUILDER_H
+
+#include "IMultiLayerBuilder.h"
+
+//! Builds sample: cylinders on a silicon substrate
+//! @ingroup standard_samples
+
+class BA_CORE_API_ SlicedCylindersBuilder : public IMultiLayerBuilder
+{
+public:
+    SlicedCylindersBuilder();
+    MultiLayer* buildSample() const override;
+
+protected:
+    double m_height;
+    double m_radius;
+    double m_wavelength;
+    unsigned m_n_slices;
+};
+
+//! Provides exactly the same sample as SlicedCylindersBuilder, but with
+//! sld-based materials. Assumed wavelength is 1.54 Angstrom.
+//! @ingroup standard_samples
+
+class BA_CORE_API_ SLDSlicedCylindersBuilder : public SlicedCylindersBuilder
+{
+public:
+    SLDSlicedCylindersBuilder();
+    MultiLayer* buildSample() const override;
+};
+
+//! Provides exactly the same sample as SLDSlicedCylindersBuilder, but with
+//! cylinders represented as homogeneous layers. SLD-based materials used.
+//! Assumed wavelength is 1.54 Angstrom.
+//! @ingroup standard_samples
+
+class BA_CORE_API_ AveragedSlicedCylindersBuilder : public SlicedCylindersBuilder
+{
+public:
+    AveragedSlicedCylindersBuilder();
+    MultiLayer* buildSample() const override;
+
+private:
+    double m_par_surf_density;
+};
+
+#endif // SLICEDCYLINDERSBUILDER_H

--- a/Core/StandardSamples/StandardSimulations.cpp
+++ b/Core/StandardSamples/StandardSimulations.cpp
@@ -388,6 +388,7 @@ SpecularSimulation* StandardSimulations::BasicSpecular()
 
     std::unique_ptr<SpecularSimulation> result(new SpecularSimulation());
     result->setBeamParameters(wavelength, number_of_bins, min_angle, max_angle);
+    result->getOptions().setUseAvgMaterials(true);
     return result.release();
 }
 

--- a/Tests/Functional/Core/CMakeLists.txt
+++ b/Tests/Functional/Core/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 # add standard and special tests
 add_subdirectory(CoreStandardTest)
+add_subdirectory(SelfConsistenceTest)
 add_subdirectory(CoreSpecial)
 
 # build MPI test executable

--- a/Tests/Functional/Core/SelfConsistenceTest/CMakeLists.txt
+++ b/Tests/Functional/Core/SelfConsistenceTest/CMakeLists.txt
@@ -1,0 +1,18 @@
+############################################################################
+# Tests/Functional/Core/SelfConsistenceTest/CMakeLists.txt
+############################################################################
+
+set(test TestSelfConsistence)
+
+# CoreStandardTest cases:
+set(test_cases)
+
+file(GLOB source_files "*.cpp")
+file(GLOB include_files "*.h")
+
+add_executable(${test} ${include_files} ${source_files})
+target_link_libraries(${test} BornAgainCore BornAgainTestMachinery)
+foreach(test_case ${test_cases})
+    add_test(${test}/${test_case}
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${test} ${test_case})
+endforeach()

--- a/Tests/Functional/Core/SelfConsistenceTest/CMakeLists.txt
+++ b/Tests/Functional/Core/SelfConsistenceTest/CMakeLists.txt
@@ -5,7 +5,9 @@
 set(test TestSelfConsistence)
 
 # CoreStandardTest cases:
-set(test_cases)
+set(test_cases
+    SpecularWithSlicing
+    )
 
 file(GLOB source_files "*.cpp")
 file(GLOB include_files "*.h")

--- a/Tests/Functional/Core/SelfConsistenceTest/SelfConsistenceTest.cpp
+++ b/Tests/Functional/Core/SelfConsistenceTest/SelfConsistenceTest.cpp
@@ -1,0 +1,85 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Tests/Functional/SelfConsistenceTest/SelfConsistenceTest.cpp
+//! @brief     Implements class SelfConsistenceTest.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#include "SelfConsistenceTest.h"
+#include "BATesting.h"
+#include "FileSystemUtils.h"
+#include "IntensityDataIOFactory.h"
+#include "Simulation.h"
+#include "TestUtils.h"
+
+namespace {
+std::string composeName(std::string d_name, std::string test_name, size_t index);
+}
+
+SelfConsistenceTest::SelfConsistenceTest(const std::string& name, const std::string& description,
+                                         std::vector<std::unique_ptr<Simulation>> simulations,
+                                         double threshold)
+    : IFunctionalTest(name, description)
+    , m_simulations(std::move(simulations))
+    , m_threshold(threshold)
+{
+    if (m_simulations.size() < 2)
+        throw std::runtime_error("Error in SelfConsistenceTest::SelfConsistenceTest: not enough "
+                                 "simulations to compare.");
+}
+
+SelfConsistenceTest::~SelfConsistenceTest() = default;
+
+bool SelfConsistenceTest::runTest()
+{
+    // Run simulation.
+    std::vector<std::unique_ptr<OutputData<double>>> results;
+    for (auto& simulation: m_simulations)
+    {
+        simulation->runSimulation();
+        auto sim_result = simulation->result();
+        results.push_back(std::unique_ptr<OutputData<double>>(sim_result.data()));
+    }
+
+    // Compare with reference if available.
+    bool success = true;
+    for (size_t i = 1, size = results.size(); i < size; ++i) {
+        const bool outcome = TestUtils::isTheSame(*results[i], *results[0], m_threshold);
+        if (!outcome) { // compose message and save results
+            std::stringstream ss;
+            ss << "Comparison between the following simulations failed:\n";
+            ss << "\t1st simulation index: " << "0\n";
+            ss << "\t2nd simulation index: " << i << "\n";
+            ss << "Results are stored in\n";
+            const std::string output_dname = BATesting::SelfConsistenceOutputDir();
+            FileSystemUtils::createDirectories(output_dname);
+            for (size_t index: {size_t(0), i}) {
+                const std::string fname = composeName(output_dname, getName(), index);
+                IntensityDataIOFactory::writeOutputData(*results[index], fname);
+                ss << fname << "\n";
+            }
+            std::cout << ss.str();
+        }
+        success = success && outcome;
+    }
+
+    if (!success)
+        std::cout << "Test " << getName() <<" failed." << std::endl;
+    return success;
+}
+
+namespace {
+std::string composeName(std::string d_name, std::string test_name, size_t index)
+{
+    std::stringstream ss;
+    ss << index;
+    return FileSystemUtils::jointPath(d_name, test_name + ss.str() + ".int.gz");
+}
+}

--- a/Tests/Functional/Core/SelfConsistenceTest/SelfConsistenceTest.h
+++ b/Tests/Functional/Core/SelfConsistenceTest/SelfConsistenceTest.h
@@ -1,0 +1,41 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Tests/Functional/SelfConsistenceTest/SelfConsistenceTest.h
+//! @brief     Defines class SelfConsistenceTest.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#ifndef CORESELFCONSISTENCYTEST_H
+#define CORESELFCONSISTENCYTEST_H
+
+#include "IFunctionalTest.h"
+#include <memory>
+#include <vector>
+
+class Simulation;
+
+//! A functional test of BornAgain/Core.
+//! Performs given simulations and compares their results with each other.
+
+class SelfConsistenceTest : public IFunctionalTest
+{
+public:
+    SelfConsistenceTest(const std::string& name, const std::string& description,
+                        std::vector<std::unique_ptr<Simulation>> simulations, double threshold);
+    ~SelfConsistenceTest() override;
+
+    bool runTest() override;
+
+private:
+    std::vector<std::unique_ptr<Simulation>> m_simulations;
+    double m_threshold;
+};
+
+#endif // CORESELFCONSISTENCYTEST_H

--- a/Tests/Functional/Core/SelfConsistenceTest/SelfConsistenceTestService.cpp
+++ b/Tests/Functional/Core/SelfConsistenceTest/SelfConsistenceTestService.cpp
@@ -1,0 +1,42 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Tests/Functional/SelfConsistenceTest/SelfConsistenceTestService.cpp
+//! @brief     Implements class SelfConsistenceTestService.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#include "SelfConsistenceTestService.h"
+#include "SelfConsistenceTest.h"
+#include "SampleBuilderFactory.h"
+#include "Simulation.h"
+#include "SimulationFactory.h"
+#include "TestUtils.h"
+
+using sim_ptr = std::unique_ptr<Simulation>;
+using builder_ptr = std::unique_ptr<IMultiLayerBuilder>;
+
+bool SelfConsistenceTestService::execute(int argc, char** argv)
+{
+    StandardTestInfo info = TestUtils::testInfo(argc, argv);
+    if (info.m_test_name.empty())
+        return false;
+
+    std::vector<sim_ptr> simulations;
+    for (size_t i = 0, size = info.size(); i < size; ++i) {
+        builder_ptr builder(SampleBuilderFactory().createItem(info.m_sample_builder_names[i]));
+        sim_ptr simulation(SimulationFactory().createItem(info.m_simulation_names[i]));
+        simulation->setSampleBuilder(std::move(builder));
+        simulations.push_back(std::move(simulation));
+    }
+
+    auto test = std::make_unique<SelfConsistenceTest>(info.m_test_name, info.m_test_description,
+                                                      std::move(simulations), info.m_threshold);
+    return test->execute();
+}

--- a/Tests/Functional/Core/SelfConsistenceTest/SelfConsistenceTestService.h
+++ b/Tests/Functional/Core/SelfConsistenceTest/SelfConsistenceTestService.h
@@ -1,0 +1,28 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Tests/Functional/SelfConsistenceTest/SelfConsistenceTestService.h
+//! @brief     Defines class SelfConsistenceTestService.
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#ifndef SELFCONSISTENCETESTSERVICE_H
+#define SELFCONSISTENCETESTSERVICE_H
+
+//! @class SelfConsistenceTestService
+//! @brief Contains static method to run self-consistence functional test from standalone
+//! executable.
+
+class SelfConsistenceTestService
+{
+public:
+    static bool execute(int argc, char** argv);
+};
+
+#endif // SELFCONSISTENCETESTSERVICE_H

--- a/Tests/Functional/Core/SelfConsistenceTest/main.cpp
+++ b/Tests/Functional/Core/SelfConsistenceTest/main.cpp
@@ -1,0 +1,22 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Tests/Functional/Core/CoreStandardTest/main.cpp
+//! @brief     Implements program CoreStandardTest to run core functional tests
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#include "SelfConsistenceTestService.h"
+
+//! Runs CoreStandardTest on a standard simulation indicated by argv[1].
+
+int main(int argc, char** argv)
+{
+    return SelfConsistenceTestService::execute(argc, argv) ? 0 : 1;
+}

--- a/Tests/Functional/TestMachinery/StandardTestCatalogue.cpp
+++ b/Tests/Functional/TestMachinery/StandardTestCatalogue.cpp
@@ -464,6 +464,20 @@ void StandardTestCatalogue::add(const std::string& test_name, const std::string&
                                               sample_builder_name, threshold);
 }
 
+void StandardTestCatalogue::add(const std::string& test_name, const std::string& test_description,
+                                std::initializer_list<std::string> simulation_names,
+                                std::initializer_list<std::string> sample_builder_names,
+                                double threshold)
+{
+    if (contains(test_name))
+        throw std::runtime_error("StandardTestCatalogue::add() -> Error. "
+                                 "Existing item '"+test_name+"'");
+
+    m_catalogue[test_name] =
+        StandardTestInfo(test_name, test_description, std::move(simulation_names),
+                         std::move(sample_builder_names), threshold);
+}
+
 //! Returns test info for given test name.
 
 StandardTestInfo StandardTestCatalogue::testInfo(const std::string& test_name)

--- a/Tests/Functional/TestMachinery/StandardTestCatalogue.cpp
+++ b/Tests/Functional/TestMachinery/StandardTestCatalogue.cpp
@@ -433,6 +433,12 @@ StandardTestCatalogue::StandardTestCatalogue()
         "HomogeneousMultilayerBuilder",
         1e-10);
 
+    add("SpecularWithSlicing",
+        "Compares manual/automatic slicing in a sample with cylinders",
+        {"BasicSpecular", "BasicSpecular", "BasicSpecular"},
+        {"SlicedCylindersBuilder", "SLDSlicedCylindersBuilder", "AveragedSlicedCylindersBuilder"},
+        1e-10);
+
     // off-specular simulation
 
     add("OffSpecularResonator",

--- a/Tests/Functional/TestMachinery/StandardTestCatalogue.h
+++ b/Tests/Functional/TestMachinery/StandardTestCatalogue.h
@@ -39,6 +39,10 @@ private:
              const std::string& simulation_name, const std::string& sample_builder_name,
              double threshold);
 
+    void add(const std::string& test_name, const std::string& test_description,
+             std::initializer_list<std::string> simulation_names,
+             std::initializer_list<std::string> sample_builder_name, double threshold);
+
     std::map<std::string, StandardTestInfo> m_catalogue;
 };
 

--- a/Tests/Functional/TestMachinery/StandardTestInfo.cpp
+++ b/Tests/Functional/TestMachinery/StandardTestInfo.cpp
@@ -35,8 +35,8 @@ StandardTestInfo::StandardTestInfo(const std::string& test_name,
 
 StandardTestInfo::StandardTestInfo(const std::string& test_name,
                  const std::string& test_description,
-                 std::vector<std::string> simulation_names,
-                 std::vector<std::string> sample_builder_names,
+                 std::initializer_list<std::string> simulation_names,
+                 std::initializer_list<std::string> sample_builder_names,
                  double threshold)
     : m_test_name(test_name)
     , m_test_description(test_description)

--- a/Tests/Functional/TestMachinery/StandardTestInfo.cpp
+++ b/Tests/Functional/TestMachinery/StandardTestInfo.cpp
@@ -13,6 +13,7 @@
 // ************************************************************************** //
 
 #include "StandardTestInfo.h"
+#include <stdexcept>
 
 StandardTestInfo::StandardTestInfo()
     : m_threshold(0.0)
@@ -26,8 +27,29 @@ StandardTestInfo::StandardTestInfo(const std::string& test_name,
                        double threshold)
     : m_test_name(test_name)
     , m_test_description(test_description)
-    , m_simulation_name(simulation_name)
-    , m_sample_builder_name(sample_builder_name)
+    , m_simulation_name({simulation_name})
+    , m_sample_builder_name({sample_builder_name})
     , m_threshold(threshold)
 {
+}
+
+StandardTestInfo::StandardTestInfo(const std::string& test_name,
+                 const std::string& test_description,
+                 std::vector<std::string> simulation_names,
+                 std::vector<std::string> sample_builder_names,
+                 double threshold)
+    : m_test_name(test_name)
+    , m_test_description(test_description)
+    , m_simulation_name(std::move(simulation_names))
+    , m_sample_builder_name(std::move(sample_builder_names))
+    , m_threshold(threshold)
+{
+    if (m_simulation_name.size() != m_sample_builder_name.size())
+        throw std::runtime_error("Error in StandardTestInfo::size(): inconsistent sizes of "
+                                 "simulation and builder name vectors");
+}
+
+size_t StandardTestInfo::size() const
+{
+    return m_simulation_name.size();
 }

--- a/Tests/Functional/TestMachinery/StandardTestInfo.cpp
+++ b/Tests/Functional/TestMachinery/StandardTestInfo.cpp
@@ -27,8 +27,8 @@ StandardTestInfo::StandardTestInfo(const std::string& test_name,
                        double threshold)
     : m_test_name(test_name)
     , m_test_description(test_description)
-    , m_simulation_name({simulation_name})
-    , m_sample_builder_name({sample_builder_name})
+    , m_simulation_names({simulation_name})
+    , m_sample_builder_names({sample_builder_name})
     , m_threshold(threshold)
 {
 }
@@ -40,16 +40,16 @@ StandardTestInfo::StandardTestInfo(const std::string& test_name,
                  double threshold)
     : m_test_name(test_name)
     , m_test_description(test_description)
-    , m_simulation_name(std::move(simulation_names))
-    , m_sample_builder_name(std::move(sample_builder_names))
+    , m_simulation_names(std::move(simulation_names))
+    , m_sample_builder_names(std::move(sample_builder_names))
     , m_threshold(threshold)
 {
-    if (m_simulation_name.size() != m_sample_builder_name.size())
+    if (m_simulation_names.size() != m_sample_builder_names.size())
         throw std::runtime_error("Error in StandardTestInfo::size(): inconsistent sizes of "
                                  "simulation and builder name vectors");
 }
 
 size_t StandardTestInfo::size() const
 {
-    return m_simulation_name.size();
+    return m_simulation_names.size();
 }

--- a/Tests/Functional/TestMachinery/StandardTestInfo.h
+++ b/Tests/Functional/TestMachinery/StandardTestInfo.h
@@ -34,8 +34,8 @@ public:
                      double threshold);
     StandardTestInfo(const std::string& test_name,
                      const std::string& test_description,
-                     std::vector<std::string> simulation_names,
-                     std::vector<std::string> sample_builder_names,
+                     std::initializer_list<std::string> simulation_names,
+                     std::initializer_list<std::string> sample_builder_names,
                      double threshold);
 
     size_t size() const;

--- a/Tests/Functional/TestMachinery/StandardTestInfo.h
+++ b/Tests/Functional/TestMachinery/StandardTestInfo.h
@@ -17,6 +17,7 @@
 
 #include "WinDllMacros.h"
 #include <string>
+#include <vector>
 
 //! @class StandardTestInfo
 //! @ingroup standard_samples
@@ -31,11 +32,18 @@ public:
                      const std::string& simulation_name,
                      const std::string& sample_builder_name,
                      double threshold);
+    StandardTestInfo(const std::string& test_name,
+                     const std::string& test_description,
+                     std::vector<std::string> simulation_names,
+                     std::vector<std::string> sample_builder_names,
+                     double threshold);
+
+    size_t size() const;
 
     std::string m_test_name;
     std::string m_test_description;
-    std::string m_simulation_name;
-    std::string m_sample_builder_name;
+    std::vector<std::string> m_simulation_name;
+    std::vector<std::string> m_sample_builder_name;
     double m_threshold;
 };
 

--- a/Tests/Functional/TestMachinery/StandardTestInfo.h
+++ b/Tests/Functional/TestMachinery/StandardTestInfo.h
@@ -42,8 +42,8 @@ public:
 
     std::string m_test_name;
     std::string m_test_description;
-    std::vector<std::string> m_simulation_name;
-    std::vector<std::string> m_sample_builder_name;
+    std::vector<std::string> m_simulation_names;
+    std::vector<std::string> m_sample_builder_names;
     double m_threshold;
 };
 

--- a/Tests/Functional/TestMachinery/StandardTestService.cpp
+++ b/Tests/Functional/TestMachinery/StandardTestService.cpp
@@ -48,15 +48,19 @@ bool StandardTestServiceBase::execute(int argc, char** argv)
     if (info.m_test_name.empty())
         return false;
 
+    if (info.size() != 1)
+        throw std::runtime_error("Error in StandardTestServiceBase::execute: the size of provided "
+                                 "test info should be exactly 1");
+
     std::unique_ptr<IMultiLayerBuilder> builder(
-                SampleBuilderFactory().createItem(info.m_sample_builder_name) );
+                SampleBuilderFactory().createItem(info.m_sample_builder_name.front()));
 
     size_t n_subtests = builder->size();
     int number_of_failed_tests = 0;
 
     for(size_t sample_index=0; sample_index<builder->size(); ++sample_index) {
         std::unique_ptr<Simulation> simulation(
-                    SimulationFactory().createItem(info.m_simulation_name));
+                    SimulationFactory().createItem(info.m_simulation_name.front()));
 
         std::unique_ptr<MultiLayer> sample(builder->createSample(sample_index));
         simulation->setSample(*sample);

--- a/Tests/Functional/TestMachinery/StandardTestService.cpp
+++ b/Tests/Functional/TestMachinery/StandardTestService.cpp
@@ -53,14 +53,14 @@ bool StandardTestServiceBase::execute(int argc, char** argv)
                                  "test info should be exactly 1");
 
     std::unique_ptr<IMultiLayerBuilder> builder(
-                SampleBuilderFactory().createItem(info.m_sample_builder_name.front()));
+                SampleBuilderFactory().createItem(info.m_sample_builder_names.front()));
 
     size_t n_subtests = builder->size();
     int number_of_failed_tests = 0;
 
     for(size_t sample_index=0; sample_index<builder->size(); ++sample_index) {
         std::unique_ptr<Simulation> simulation(
-                    SimulationFactory().createItem(info.m_simulation_name.front()));
+                    SimulationFactory().createItem(info.m_simulation_names.front()));
 
         std::unique_ptr<MultiLayer> sample(builder->createSample(sample_index));
         simulation->setSample(*sample);

--- a/Tests/Functional/TestMachinery/StandardTestService.h
+++ b/Tests/Functional/TestMachinery/StandardTestService.h
@@ -48,15 +48,9 @@ class StandardTestService : public StandardTestServiceBase
 {
 
 private:
-    virtual IFunctionalTest* createTest(const std::string& name, const std::string& description,
-                                        const Simulation&  simulation,
-                                        double threshold)
+    IFunctionalTest* createTest(const std::string& name, const std::string& description,
+                                const Simulation& simulation, double threshold) override
     {
-        return createStandardTest(name, description, simulation, threshold);
-    }
-
-    T* createStandardTest(const std::string& name, const std::string& description,
-                          const Simulation&  simulation, double threshold) {
         return new T(name, description, simulation, threshold);
     }
 };

--- a/cmake/bornagain/scripts/BATesting.h.in
+++ b/cmake/bornagain/scripts/BATesting.h.in
@@ -28,6 +28,7 @@ inline std::string CoreReferenceDir() { return "@TEST_REFERENCE_DIR@/Core"; }
 
 inline std::string TestOutputDir() { return "@TEST_OUTPUT_DIR@"; }
 inline std::string CoreOutputDir() { return "@TEST_OUTPUT_DIR@/Functional/Core"; }
+inline std::string SelfConsistenceOutputDir() { return "@TEST_OUTPUT_DIR@/Functional/SelfConsistence"; }
 inline std::string GUIOutputDir() { return "@TEST_OUTPUT_DIR@/Functional/GUI"; }
 inline std::string PyStandardOutputDir() { return "@TEST_OUTPUT_DIR@/Functional/Python/PyStandard"; }
 


### PR DESCRIPTION
* a new type of functional tests `SelfConsistenceTest` introduced: it allows comparing several simulations without reference data.
* test for reflectometry data from a sliced sample was implemented as an example of such test