### PR TITLE
Treat evey file as ASCII unless it has a specific BA recognized extension.

### DIFF
--- a/Core/InputOutput/DataFormatUtils.cpp
+++ b/Core/InputOutput/DataFormatUtils.cpp
@@ -41,7 +41,6 @@ const std::vector<std::pair<std::string, createAxisFun>> type_map = {
 const std::string GzipExtension = ".gz";
 const std::string BzipExtension = ".bz2";
 const std::string IntExtension = ".int";
-const std::string TxtExtension = ".txt";
 const std::string TiffExtension = ".tif";
 const std::string TiffExtension2 = ".tiff";
 }
@@ -77,25 +76,9 @@ std::string DataFormatUtils::GetFileMainExtension(const std::string& name)
     return FileSystemUtils::extension(stripped_name);
 }
 
-bool DataFormatUtils::isBinaryFile(const std::string& file_name)
-{
-    // all compressed files are always binary.
-    if(isCompressed(file_name)) return true;
-    // uncompressed "int" or "txt" files are ascii
-    if(isIntFile(file_name)) return false;
-    if(isTxtFile(file_name)) return false;
-    // the rest (e.g. tif) is also binary
-    return true;
-}
-
 bool DataFormatUtils::isIntFile(const std::string& file_name)
 {
     return GetFileMainExtension(file_name) == IntExtension;
-}
-
-bool DataFormatUtils::isTxtFile(const std::string& file_name)
-{
-    return GetFileMainExtension(file_name) == TxtExtension;
 }
 
 bool DataFormatUtils::isTiffFile(const std::string& file_name)

--- a/Core/InputOutput/DataFormatUtils.h
+++ b/Core/InputOutput/DataFormatUtils.h
@@ -38,14 +38,8 @@ BA_CORE_API_ bool isBZipped(const std::string& name);
 //! Returns file extension after stripping '.gz' if any
 BA_CORE_API_ std::string GetFileMainExtension(const std::string& name);
 
-//! returns true if file name corresponds to a binary file
-BA_CORE_API_ bool isBinaryFile(const std::string& file_name);
-
 //! returns true if file name corresponds to BornAgain native format (compressed or not)
 BA_CORE_API_ bool isIntFile(const std::string& file_name);
-
-//! returns true if file name corresponds to simple numpy-style ASCII file
-BA_CORE_API_ bool isTxtFile(const std::string& file_name);
 
 //! returns true if file name corresponds to tiff file (can be also compressed)
 BA_CORE_API_ bool isTiffFile(const std::string& file_name);

--- a/Core/InputOutput/OutputDataReadFactory.cpp
+++ b/Core/InputOutput/OutputDataReadFactory.cpp
@@ -30,21 +30,19 @@ OutputDataReader* OutputDataReadFactory::getReflectometryReader(const std::strin
     return result;
 }
 
-
 IOutputDataReadStrategy* OutputDataReadFactory::getReadStrategy(const std::string& file_name)
 {
     IOutputDataReadStrategy* result(nullptr);
     if(DataFormatUtils::isIntFile(file_name))
         result = new OutputDataReadINTStrategy();
-    else if(DataFormatUtils::isTxtFile(file_name))
-        result = new OutputDataReadNumpyTXTStrategy();
 #ifdef BORNAGAIN_TIFF_SUPPORT
     else if(DataFormatUtils::isTiffFile(file_name))
        result = new OutputDataReadTiffStrategy();
 #endif // BORNAGAIN_TIFF_SUPPORT
     else
-        throw Exceptions::LogicErrorException(
-            "OutputDataReadFactory::getReader() -> Error. Don't know how to read file '"
-            + file_name+"'");
+        //Try to read ASCII by default. Binary maps to ASCII.
+        //If the file is not actually a matrix of numbers,
+        //the error will be thrown during the reading.
+        result = new OutputDataReadNumpyTXTStrategy();
     return result;
 }

--- a/Core/InputOutput/OutputDataReadStrategy.cpp
+++ b/Core/InputOutput/OutputDataReadStrategy.cpp
@@ -119,13 +119,20 @@ OutputData<double>* OutputDataReadNumpyTXTStrategy::readOutputData(std::istream&
     std::string line;
     std::vector<std::vector<double>> data;
 
+    //Read numbers from input stream:
     while( std::getline(input_stream, line) ) {
-        if(line.empty() || line[0] == '#')
+        if(line.empty() || !isdigit(line[0]))
             continue;
-        std::vector<double> data_in_row = DataFormatUtils::parse_doubles(line);
-        data.push_back(data_in_row);
+
+        try {
+            std::vector<double> dataInRow = DataFormatUtils::parse_doubles(line);
+            data.push_back(dataInRow);
+        } catch (...) {
+            continue;
+        }
     }
-    // validating
+
+   // validating
     size_t nrows = data.size();
     size_t ncols(0);
     if(nrows) ncols = data[0].size();

--- a/Core/InputOutput/OutputDataReadStrategy.cpp
+++ b/Core/InputOutput/OutputDataReadStrategy.cpp
@@ -22,12 +22,31 @@
 #include <stdexcept> // need overlooked by g++ 5.4
 #include <map>
 
+namespace{
+inline std::string trim(const std::string& str,
+                        const std::string& whitespace = " \t")
+{
+    const auto strBegin = str.find_first_not_of(whitespace);
+
+    if (strBegin == std::string::npos)
+        return "";
+
+    const auto strEnd = str.find_last_not_of(whitespace);
+    const auto strRange = strEnd - strBegin + 1;
+
+    return str.substr(strBegin, strRange);
+}
+}
+
+
+
 OutputData<double>* OutputDataReadINTStrategy::readOutputData(std::istream& input_stream)
 {
     OutputData<double>* result = new OutputData<double>;
     std::string line;
 
     while( std::getline(input_stream, line) ) {
+        line = trim(line);
         if (line.find("axis") != std::string::npos) {
             std::unique_ptr<IAxis> axis = DataFormatUtils::createAxis(input_stream);
             result->addAxis(*axis);
@@ -51,6 +70,7 @@ OutputData<double>* OutputDataReadReflectometryStrategy::readOutputData(std::ist
 
     //Read numbers from file:
     while( std::getline(fin, line) ) {
+        line = trim(line);
         try {
             std::vector<double> rowVec = DataFormatUtils::parse_doubles(line);
             vecVec.push_back(rowVec);
@@ -112,8 +132,6 @@ OutputData<double>* OutputDataReadReflectometryStrategy::readOutputData(std::ist
     return oData;
 }
 
-
-
 OutputData<double>* OutputDataReadNumpyTXTStrategy::readOutputData(std::istream& input_stream)
 {
     std::string line;
@@ -121,6 +139,7 @@ OutputData<double>* OutputDataReadNumpyTXTStrategy::readOutputData(std::istream&
 
     //Read numbers from input stream:
     while( std::getline(input_stream, line) ) {
+        line = trim(line);
         if(line.empty() || !isdigit(line[0]))
             continue;
 

--- a/Core/InputOutput/OutputDataReader.cpp
+++ b/Core/InputOutput/OutputDataReader.cpp
@@ -37,7 +37,7 @@ OutputData<double>* OutputDataReader::getOutputData()
 
     std::ifstream fin;
     std::ios_base::openmode openmode = std::ios::in;
-    if (DataFormatUtils::isBinaryFile(m_file_name))
+    if(isTiffFile(m_file_name) || isCompressed(m_file_name))
         openmode = std::ios::in | std::ios_base::binary;
 
     fin.open(m_file_name.c_str(), openmode );

--- a/Core/InputOutput/OutputDataWriteFactory.cpp
+++ b/Core/InputOutput/OutputDataWriteFactory.cpp
@@ -25,14 +25,11 @@ OutputDataWriter *OutputDataWriteFactory::getWriter(const std::string &file_name
 
 IOutputDataWriteStrategy *OutputDataWriteFactory::getWriteStrategy(const std::string &file_name)
 {
-    IOutputDataWriteStrategy *result(0);
+    IOutputDataWriteStrategy *result(nullptr);
     if(DataFormatUtils::isIntFile(file_name)) {
         result = new OutputDataWriteINTStrategy();
     }
 
-    else if(DataFormatUtils::isTxtFile(file_name)) {
-        result = new OutputDataWriteNumpyTXTStrategy();
-    }
 
 #ifdef BORNAGAIN_TIFF_SUPPORT
     else if(DataFormatUtils::isTiffFile(file_name)) {
@@ -40,10 +37,10 @@ IOutputDataWriteStrategy *OutputDataWriteFactory::getWriteStrategy(const std::st
     }
 #endif // BORNAGAIN_TIFF_SUPPORT
 
-    else {
-        throw Exceptions::LogicErrorException("OutputDataWriteFactory::getWriter() -> Error. "
-                "Don't know how to write file '" + file_name+std::string("'"));
+    else{
+        result = new OutputDataWriteNumpyTXTStrategy();
     }
+
 
     return result;
 }

--- a/Core/InputOutput/OutputDataWriter.cpp
+++ b/Core/InputOutput/OutputDataWriter.cpp
@@ -32,13 +32,15 @@ OutputDataWriter::OutputDataWriter(const std::string& file_name)
 
 void OutputDataWriter::writeOutputData(const OutputData<double>& data)
 {
+    using namespace DataFormatUtils;
     if(!m_write_strategy)
         throw Exceptions::NullPointerException("OutputDataWriter::getOutputData() ->"
                                                " Error! No read strategy defined");
     std::ofstream fout;
     std::ios_base::openmode openmode = std::ios::out;
-    if(DataFormatUtils::isBinaryFile(m_file_name))
+    if(isTiffFile(m_file_name) || isCompressed(m_file_name))
         openmode = std::ios::out | std::ios_base::binary;
+
 
     fout.open(m_file_name.c_str(), openmode );
     if(!fout.is_open())


### PR DESCRIPTION
This pull request addresses Feature #2311 issue (http://apps.jcns.fz-juelich.de/redmine/issues/2311):

> Situation: [A user] brings *.dat file from experiment which contains simple 2D ascii map.
BornAgain refuses to read it. If we rename file to *.txt it reads it without problems.

> GUI allows for importing data matrix from text files with .txt extension. However, some MLZ instruments save this matrix in the text files with other extensions. For example, KWS3 saves matrix in the text files with extension .det.

> For an average GUI user it is quite some work to rename several tens of files to be able to load them in GUI.

> I think, this constraint should be relaxed. We should not determine the file type by extension.

In this pull request, the logic is changed: Files with extensions other than the BA recognized ones (.int, .tif, .gz, ...) are  treated as ASCII matrices of numbers. Data formats such as .mp3 or .png will still be treated as ASCII and an error will be thrown at the moment of trying to read them.