### PR TITLE
Require Python3 throughout, otherwise exit with error message. Remove remnants of "import future".

### DIFF
--- a/Examples/python/simulation/ex07_Miscellaneous/SimulationParameters.py
+++ b/Examples/python/simulation/ex07_Miscellaneous/SimulationParameters.py
@@ -5,7 +5,6 @@ This example shows how to create a simulation with fixed parameters, and then ch
 these parameters on the fly during runtime.
 """
 
-from __future__ import print_function
 import bornagain as ba
 from bornagain import deg, angstrom, nm
 

--- a/Examples/python/utils/show2d.py
+++ b/Examples/python/utils/show2d.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Draws two dimensional numpy array using matplotlib
 # Usage: python show2d.py file_name
 
-from __future__ import print_function
 from pylab import *
 from matplotlib.colors import LogNorm
 import argparse

--- a/Examples/python/utils/show2d_root.py
+++ b/Examples/python/utils/show2d_root.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Draws two dimensional numpy array using ROOT
 # Usage: python show2d.py file_name
 
-from __future__ import print_function
 import argparse
 import os
 import numpy
@@ -63,5 +62,3 @@ if __name__ == '__main__':
     print('Maximum value of data: ', a.flatten().max())
 
     PlotNumpyArrayWithROOT(a, zmin, zmax)
-
-        

--- a/Tests/Functional/Python/PyCore/mesocrystal1.py
+++ b/Tests/Functional/Python/PyCore/mesocrystal1.py
@@ -1,7 +1,6 @@
 # Functional test: functional test: mesocrystal simulation
 #
 
-from __future__ import print_function
 import ctypes, math, numpy, os, sys, time
 
 import utils

--- a/Tests/Functional/Python/PyCore/polmagcylinders1.py
+++ b/Tests/Functional/Python/PyCore/polmagcylinders1.py
@@ -1,6 +1,5 @@
 # Functional test: Magnetic cylinders in DWBA with zero magnetic field
 
-from __future__ import print_function
 import gzip, numpy, os, sys, utils
 import libBornAgainCore as ba
 from libBornAgainCore import nanometer, angstrom, degree

--- a/Tests/Functional/Python/PyCore/polmagcylinders2.py
+++ b/Tests/Functional/Python/PyCore/polmagcylinders2.py
@@ -1,5 +1,5 @@
 # Functional test: Magnetic cylinders in DWBA with zero magnetic field
-from __future__ import print_function
+
 import sys
 import os
 import numpy

--- a/Tests/Functional/Python/PyCore/sliced_composition.py
+++ b/Tests/Functional/Python/PyCore/sliced_composition.py
@@ -3,7 +3,6 @@ Functional test to check slicing mechanism for particle compositions
 when they are crossing an interface.
 """
 
-from __future__ import print_function
 import os, sys, unittest
 
 import utils

--- a/Tests/Functional/Python/PyCore/sliced_spheres.py
+++ b/Tests/Functional/Python/PyCore/sliced_spheres.py
@@ -3,7 +3,6 @@ Functional test to check slicing mechanism for spherical particles
 when they are crossing an interface.
 """
 
-from __future__ import print_function
 import os, sys, unittest
 
 import utils

--- a/Tests/Functional/Python/PyCore/transform_BoxComposition.py
+++ b/Tests/Functional/Python/PyCore/transform_BoxComposition.py
@@ -7,7 +7,6 @@ Composition might be rotated to get reference shape.
 Both, reference box and composition are placed in the center of middle layer of 3 layers system.
 """
 
-from __future__ import print_function
 import os, sys, unittest
 
 import utils

--- a/Tests/Functional/Python/PyCore/transform_CoreShellBox.py
+++ b/Tests/Functional/Python/PyCore/transform_CoreShellBox.py
@@ -6,7 +6,6 @@ which has different dimensions but rotated/translated to be like the reference o
 Particles are placed in the center of middle layer.
 """
 
-from __future__ import print_function
 import os, sys, unittest
 
 import utils

--- a/Tests/Functional/Python/PyCore/transform_box.py
+++ b/Tests/Functional/Python/PyCore/transform_box.py
@@ -4,7 +4,6 @@ FormFactorBox(50, 20, 10), is rotated around Z, then around Y, then shifted up a
 compared with FormFactorBox(10, 50, 20)
 """
 
-from __future__ import print_function
 import os, sys, unittest
 
 import utils

--- a/Tests/Functional/Python/PyCore/transform_cube.py
+++ b/Tests/Functional/Python/PyCore/transform_cube.py
@@ -2,7 +2,6 @@
 Test of rotation/positioning of simple cubic particle. Original particle is compared with the one obtained
 """
 
-from __future__ import print_function
 import os, sys, unittest
 
 import utils

--- a/Tests/PerformanceTests/test_performance.py
+++ b/Tests/PerformanceTests/test_performance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
  # -*- coding: utf-8 -*-
 
 ## ************************************************************************** ##
@@ -17,7 +17,6 @@
 ##
 ## ************************************************************************** ##
 
-from __future__ import print_function
 import datetime
 import sys
 import platform

--- a/Wrap/python/__init__.py.in
+++ b/Wrap/python/__init__.py.in
@@ -1,6 +1,12 @@
 import sys
 import os
 
+if sys.version_info < (3,0):
+    sys.stderr.write("Fatal error: running wrong Python version "
+                     + str(sys.version_info.major) + "." + str(sys.version_info.minor)
+                     + "; Python3 is required.\n")
+    sys.exit(1)
+
 sys.path.append(os.path.abspath(
                 os.path.join(os.path.split(__file__)[0], '@BA_MODULES_IMPORT_PATH@')))
 
@@ -14,4 +20,3 @@ from .libBornAgainCore import *
 # To prevent inclusion of plotting tools during functional tests:
 if not "NOPLOT" in os.environ:
     from .plot_utils import *
-

--- a/Wrap/python/bornagain_python_install.py
+++ b/Wrap/python/bornagain_python_install.py
@@ -3,13 +3,13 @@ Installs BornAgain libraries into user Python (Mac only).
 
 Usage: python bornagain_python_install.py
 
-The script generates BornAgain python package in temporary directory and then 
+The script generates BornAgain python package in temporary directory and then
 installs it into user's Python site_packages.
 
 Requirements: BornAgain.app has to be installed on the system using .dmg installer.
 
 During generation of Python package
-1) The script copies BornAgain libraries from the GUI installation directory (normally 
+1) The script copies BornAgain libraries from the GUI installation directory (normally
    it is /Applications/BornAgain.app) into temporary bundle directory
 2) Adjusts libraries using Mac's install_name_tool to rely on Python's own libpython2.7.dylib.
    The exact site-packages library location is deduced from the interpreter itself.
@@ -19,7 +19,6 @@ During installation of Python package
 1) The script just runs standard 'python setup.py install' command from the temporary bundle directory
 """
 
-from __future__ import print_function
 import os
 import sys
 import sysconfig
@@ -34,14 +33,14 @@ from distutils.sysconfig import get_python_lib
 
 BORNAGAIN_VERSION = "0.0"
 
-def is_python3():
-    if (sys.version_info > (3, 0)):
-        return True
-    else:
-        return False
-
 def python_version_string():
-    return str(sys.version_info[0]) + "." + str(sys.version_info[1])
+    return str(sys.version_info.major) + "." + str(sys.version_info.minor)
+
+if sys.version_info < (3,0):
+    sys.stderr.write("Fatal error: running wrong Python version "
+                     + python_version_string()
+                     + "; Python3 is required.\n")
+    sys.exit(1)
 
 
 def add_rpath(newpath, filename):
@@ -107,16 +106,16 @@ def get_application_dir():
     else:
         script_dir = get_script_path()
         app_dir = os.path.abspath(os.path.join(script_dir, "..", "..", ".."))
-        
+
     # getting version number
     lib_dir = glob.glob( os.path.join(app_dir, "Contents", "lib", "BornAgain-*"))
     if len(lib_dir) != 1:
         exit("Can't find BornAgain libraries in "+app_dir)
-    
+
     BORNAGAIN_VERSION = lib_dir[0].split("BornAgain-")[1]
     return app_dir
 
-    
+
 def create_bundle_temp_dir():
     """
     Creates temporary directory for BornAgain package bundle
@@ -151,7 +150,7 @@ def generate_setup_py(destination_dir):
     Generates setup.py file in BornAgain's bundle directory
     """
     text = '''\
-# BornAgain setup.py to install BornAgain libraries into Python's site-packages             
+# BornAgain setup.py to install BornAgain libraries into Python's site-packages
 # Usage: python setup.py install
 
 import os
@@ -185,12 +184,12 @@ setup(name='bornagain',
 
 def prepare_init_module(app_dir, bundle_dir):
     source_dir = os.path.join(app_dir, "Contents", "libexec")
-    libexec_dir = os.path.join(source_dir, "BornAgain-"+BORNAGAIN_VERSION, "bornagain")    
+    libexec_dir = os.path.join(source_dir, "BornAgain-"+BORNAGAIN_VERSION, "bornagain")
     package_dir = os.path.join(bundle_dir, "bornagain")
     print("--> Copying modules from '{0}' to '{1}'".format(libexec_dir, package_dir))
     shutil.copytree(libexec_dir, package_dir)
     return package_dir
-    
+
 
 def copy_libraries(app_dir, destination_dir):
     """
@@ -242,7 +241,7 @@ def patch_libraries(dir_name):
 
     pass
 
-    
+
 def create_bundle(app_dir):
     """
     Creates ready to install BornAgain Python bundle package
@@ -253,20 +252,20 @@ def create_bundle(app_dir):
     print('-'*80)
 
     print("--> Generating bundle setup files")
-    
+
     generate_setup_py(bundle_dir)
-    
+
     package_dir = prepare_init_module(app_dir, bundle_dir)
-    
+
     library_dir = create_library_dir(package_dir)
     copy_libraries(app_dir, library_dir)
-    
+
     patch_libraries(library_dir)
-    
+
     print("\nBornAgain Python bundle is successfully created in temporary directory '{0}'".format(bundle_dir))
     print("Run 'python setup.py install' from there to install it into your Python's site-packages")
     return bundle_dir
-        
+
 
 def install_bundle(dir_name):
     """
@@ -275,20 +274,20 @@ def install_bundle(dir_name):
     print('-'*80)
     print("Installing bundle in Python site-packages '{0}'".format(get_python_lib()))
     print('-'*80)
-    
+
     os.chdir(bundle_dir)
     sys.argv = ['setup.py', 'install']
     exec_full('setup.py')
     print("\nBornAgain Python bundle is successfully installed in '{0}'".format(get_python_lib()))
     print("Congratulations!")
-    
-    
+
+
 if __name__ == '__main__':
     if not platform.system() == 'Darwin':
         exit("This script is intended for MacOs systems. Exiting...")
-        
+
     app_dir = get_application_dir()
-    
+
     print('-'*80)
     print("Installation of BornAgain-{0} libraries into site-packages of your Python".format(BORNAGAIN_VERSION))
     print('-'*80)
@@ -300,11 +299,7 @@ if __name__ == '__main__':
     print("[1] - Generate bundle and install it into site-packages of your Python.")
     print("[2] - Exit")
 
-    var = 0
-    if is_python3():
-        var = int(input("Enter your choice [1]: ") or "1")
-    else:
-        var = int(raw_input("Enter your choice [1]: ") or "1")
+    var = int(input("Enter your choice [1]: ") or "1")
 
     if var == 0:
         create_bundle(app_dir)
@@ -313,7 +308,3 @@ if __name__ == '__main__':
         install_bundle(bundle_dir)
     else:
         exit("Good bye")
-        
-
-
-

--- a/Wrap/python/plot_utils.py
+++ b/Wrap/python/plot_utils.py
@@ -12,7 +12,7 @@
 #   @authors   J. Fisher, M. Ganeva, G. Pospelov, W. Van Herck, J. Wuttke
 '''
 #  **************************************************************************  #
-from __future__ import print_function
+
 import bornagain as ba
 from bornagain import deg as deg
 try:  # workaround for build servers
@@ -21,7 +21,6 @@ try:  # workaround for build servers
     from matplotlib import gridspec, colors
 except Exception as e:
     print("In plot_utils.py: {:s}".format(str(e)))
-
 
 label_fontsize = 16
 

--- a/Wrap/python/plot_utils.py
+++ b/Wrap/python/plot_utils.py
@@ -190,8 +190,9 @@ def plot_specular_simulation_result(result, ymin=None, ymax=None, units=ba.AxesU
         plt.title(title)
 
 
-def plot_simulation_result(result, intensity_min=None, intensity_max=None, units=ba.AxesUnits.DEFAULT,
-                           xlabel=None, ylabel=None, postpone_show=False, title=None, aspect=None):
+def plot_simulation_result(
+        result, intensity_min=None, intensity_max=None, units=ba.AxesUnits.DEFAULT,
+        xlabel=None, ylabel=None, postpone_show=False, title=None, aspect=None):
     """
     Draws simulation result and (optionally) shows the plot.
     :param result_: SimulationResult object obtained from GISAS/OffSpec/SpecularSimulation

--- a/Wrap/swig/doxy2swig.py
+++ b/Wrap/swig/doxy2swig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Doxygen XML to SWIG docstring converter.
 
 Converts Doxygen generated XML files into a file containing docstrings
@@ -25,7 +25,6 @@ output will be written (the file will be clobbered).
 # This version has been modified by Jonathan Fisher (j.fisher@fz-juelich.de)
 # to be forwards-compatible with Python 3
 
-from __future__ import print_function
 from xml.dom import minidom
 import re
 import textwrap

--- a/Wrap/swig/tweaks.py
+++ b/Wrap/swig/tweaks.py
@@ -1,6 +1,5 @@
 # this script is used to manually tweak swig-generated wrapper
 
-from __future__ import print_function
 import sys
 import os
 import string


### PR DESCRIPTION
Require Python3 throughout, except in purely internal maintenance scripts.

"import bornagain" now fails with clear error message if the Python version is < 3.0.

Removed obsolete "import future" statements.