### PR TITLE
3DView: Provide button to save image

### DIFF
--- a/GUI/ba3d/ba3d/view/buffer.cpp
+++ b/GUI/ba3d/ba3d/view/buffer.cpp
@@ -27,13 +27,13 @@ Buffer::Buffer(Geometry const& geometry) {
     initializeOpenGLFunctions();
 
     auto &mesh  = geometry.m_mesh;
-    vertexCount = mesh.count();
+    m_vertexCount = mesh.count();
 
-    QOpenGLVertexArrayObject::Binder __(&vao);
+    QOpenGLVertexArrayObject::Binder __(&m_vao);
 
-    glBuffer.create();
-    glBuffer.bind();
-    glBuffer.allocate(mesh.constData(), vertexCount * int(sizeof(Geometry::Vert_Normal)));
+    m_glBuffer.create();
+    m_glBuffer.bind();
+    m_glBuffer.allocate(mesh.constData(), m_vertexCount * int(sizeof(Geometry::Vert_Normal)));
 
     glEnableVertexAttribArray(0); // vertices
     glEnableVertexAttribArray(1); // normals
@@ -43,14 +43,14 @@ Buffer::Buffer(Geometry const& geometry) {
 }
 
 void Buffer::draw() {
-    QOpenGLVertexArrayObject::Binder __(&vao);
-    glDrawArrays(GL_TRIANGLES, 0, vertexCount);
+    QOpenGLVertexArrayObject::Binder __(&m_vao);
+    glDrawArrays(GL_TRIANGLES, 0, m_vertexCount);
 }
 
 Buffer3DAxes::Buffer3DAxes() {
     initializeOpenGLFunctions();
 
-     QOpenGLVertexArrayObject::Binder __(&vao3DAxes);
+     QOpenGLVertexArrayObject::Binder __(&m_vao3DAxes);
 
     // vertices (xyz) and colors (rgb) for drawing each line (also arrows) in the 3D axes
     const GLfloat vertices3DAxes[] = {
@@ -88,11 +88,11 @@ Buffer3DAxes::Buffer3DAxes() {
         cz*-0.05f, cz*-0.05f,  cz*0.95f, 0.0f, 0.0f, 1.0f,
     };
 
-    vertexCount3DAxes = 30;
+    m_vertexCount3DAxes = 30;
 
-    glBuffer3DAxes.create();
-    glBuffer3DAxes.bind();
-    glBuffer3DAxes.allocate(vertices3DAxes, int(sizeof (vertices3DAxes)));
+    m_glBuffer3DAxes.create();
+    m_glBuffer3DAxes.bind();
+    m_glBuffer3DAxes.allocate(vertices3DAxes, int(sizeof (vertices3DAxes)));
 
     glEnableVertexAttribArray(0); // 3D axes vertices
     glEnableVertexAttribArray(2); // 3D axes colors
@@ -102,9 +102,9 @@ Buffer3DAxes::Buffer3DAxes() {
 }
 
 void Buffer3DAxes::draw3DAxes() {
-    QOpenGLVertexArrayObject::Binder __(&vao3DAxes);
+    QOpenGLVertexArrayObject::Binder __(&m_vao3DAxes);
     glLineWidth(1.4f);
-    glDrawArrays(GL_LINES, 0, vertexCount3DAxes);
+    glDrawArrays(GL_LINES, 0, m_vertexCount3DAxes);
 }
 
 }  // namespace RealSpace

--- a/GUI/ba3d/ba3d/view/buffer.h
+++ b/GUI/ba3d/ba3d/view/buffer.h
@@ -33,9 +33,9 @@ public:
     void draw();
 
 private:
-    int vertexCount;
-    QOpenGLVertexArrayObject vao;
-    QOpenGLBuffer glBuffer;
+    int m_vertexCount;
+    QOpenGLVertexArrayObject m_vao;
+    QOpenGLBuffer m_glBuffer;
 };
 
 // Buffer for drawing 3D Coordinate Axes on canvas
@@ -46,9 +46,9 @@ public:
     void draw3DAxes();
 
 private:
-    int vertexCount3DAxes;
-    QOpenGLVertexArrayObject vao3DAxes;
-    QOpenGLBuffer glBuffer3DAxes;
+    int m_vertexCount3DAxes;
+    QOpenGLVertexArrayObject m_vao3DAxes;
+    QOpenGLBuffer m_glBuffer3DAxes;
 };
 
 } // namespace RealSpace

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.cpp
@@ -120,6 +120,13 @@ void RealSpaceCanvas::onChangeLayerSizeAction(double layerSizeChangeScale)
     updateScene();
 }
 
+void RealSpaceCanvas::onSavePictureAction()
+{
+    QPixmap pixmap(this->size());
+    this->render(&pixmap, QPoint(), childrenRegion());
+    //pixmap.save("path/to/save/file.png");
+}
+
 void RealSpaceCanvas::onDataChanged(const QModelIndex& index)
 {
     auto item = m_sampleModel->itemForIndex(index);

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.cpp
@@ -12,6 +12,8 @@
 //
 // ************************************************************************** //
 
+#include "AppSvc.h"
+#include "projectmanager.h"
 #include "RealSpaceCanvas.h"
 #include "RealSpaceBuilder.h"
 #include "RealSpaceModel.h"
@@ -20,8 +22,10 @@
 #include "SessionItemUtils.h"
 #include "WarningSign.h"
 #include "FilterPropertyProxy.h"
+#include <QFileDialog>
 #include <QApplication>
 #include <QVBoxLayout>
+#include <QMessageBox>
 
 RealSpaceCanvas::RealSpaceCanvas(QWidget* parent)
     : QWidget(parent), m_sampleModel(nullptr), m_view(new RealSpaceView), m_selectionModel(nullptr),
@@ -123,9 +127,32 @@ void RealSpaceCanvas::onChangeLayerSizeAction(double layerSizeChangeScale)
 void RealSpaceCanvas::onSavePictureAction()
 {
     QPixmap pixmap(this->size());
-    this->render(&pixmap, QPoint(), childrenRegion());
-    //pixmap.save("path/to/save/file.png");
+    render(&pixmap, QPoint(), childrenRegion());
+    savePicture(pixmap);
 }
+
+void RealSpaceCanvas::savePicture(const QPixmap &pixmap)
+{
+    QString dirname = AppSvc::projectManager()->userExportDir();
+    QString defaultExtension = ".png";
+    QString selectedFilter("*"+defaultExtension);
+    QString defaultName = dirname + QString("/untitled");
+    QString fileName =QFileDialog::getSaveFileName(nullptr, "Save 3D real space view", defaultName, selectedFilter);
+    QString nameToSave = fileName.endsWith(defaultExtension) ? fileName : fileName + defaultExtension;
+
+    if(!nameToSave.isEmpty()) {
+        try {
+            pixmap.save(nameToSave);
+        } catch(const std::exception &ex) {
+            QString message = "Attempt to save file with the name '";
+            message.append(nameToSave);
+            message.append("' has failed with following error message\n\n");
+            message.append(QString::fromStdString(ex.what()));
+            QMessageBox::warning(nullptr, "Houston, we have a problem.", message);
+        }
+    }
+}
+
 
 void RealSpaceCanvas::onDataChanged(const QModelIndex& index)
 {

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.h
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.h
@@ -97,6 +97,7 @@ public slots:
     void onTopViewAction();
     void onLockViewAction(bool view_locked);
     void onChangeLayerSizeAction(double layer_size_scale);
+    void onSavePictureAction();
 
 private slots:
     void onDataChanged(const QModelIndex& index);

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.h
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceCanvas.h
@@ -119,6 +119,7 @@ private:
     bool m_view_locked;
     std::unique_ptr<SceneGeometry> m_sceneGeometry;
     WarningSign* m_warningSign;
+    void savePicture(const QPixmap &pixmap);
 };
 
 #endif // REALSPACESCENE_H

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceToolBar.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceToolBar.cpp
@@ -28,9 +28,20 @@ RealSpaceToolBar::RealSpaceToolBar(QWidget* parent)
     : StyledToolBar(parent), m_defaultViewButton(new QToolButton),
       m_sideViewButton(new QToolButton), m_topViewButton(new QToolButton),
       m_lockViewCheckBox(new QCheckBox), m_increaseLayerSizeButton(new QToolButton),
-      m_decreaseLayerSizeButton(new QToolButton)
+      m_decreaseLayerSizeButton(new QToolButton),
+      m_savePictureButton(new QToolButton)
 {
     setMinimumSize(Constants::styled_toolbar_height, Constants::styled_toolbar_height);
+
+    // Save image -- this first so it is available for smaller widget sizes
+    m_savePictureButton->setText("Save Picture");
+    m_savePictureButton->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+    m_savePictureButton->setToolTip("Save 3D real space view as .png file");
+    connect(m_savePictureButton, &QToolButton::clicked, this,
+            [&]() { emit RealSpaceToolBar::savePictureAction(); });
+    addWidget(m_savePictureButton);
+
+    addSeparator();
 
     // Default View
     m_defaultViewButton->setText("Default View");
@@ -93,4 +104,5 @@ RealSpaceToolBar::RealSpaceToolBar(QWidget* parent)
     addWidget(m_decreaseLayerSizeButton);
 
     addSeparator();
+
 }

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceToolBar.h
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceToolBar.h
@@ -35,6 +35,7 @@ signals:
     void topViewAction();
     void lockViewAction(bool);
     void changeLayerSizeAction(double);
+    void savePictureAction();
 
 private:
     QToolButton* m_defaultViewButton;
@@ -44,6 +45,7 @@ private:
 
     QToolButton* m_increaseLayerSizeButton;
     QToolButton* m_decreaseLayerSizeButton;
+    QToolButton* m_savePictureButton;
 };
 
 #endif // REALSPACETOOLBAR_H

--- a/GUI/coregui/Views/RealSpaceWidgets/RealSpaceWidget.cpp
+++ b/GUI/coregui/Views/RealSpaceWidgets/RealSpaceWidget.cpp
@@ -58,6 +58,9 @@ RealSpaceWidget::RealSpaceWidget(SampleModel *sampleModel,
     connect(m_toolBar, &RealSpaceToolBar::changeLayerSizeAction,
             m_canvas, &RealSpaceCanvas::onChangeLayerSizeAction);
 
+    connect(m_toolBar, &RealSpaceToolBar::savePictureAction,
+            m_canvas, &RealSpaceCanvas::onSavePictureAction);
+
 }
 
 void RealSpaceWidget::showEvent(QShowEvent*)

--- a/GUI/coregui/Views/SampleDesigner/SampleViewActions.cpp
+++ b/GUI/coregui/Views/SampleDesigner/SampleViewActions.cpp
@@ -44,5 +44,5 @@ QItemSelectionModel* SampleViewActions::selectionModel()
 
 void SampleViewActions::onToggleRealSpaceView()
 {
-    m_sampleView->docks()->togleDock(SampleViewDocks::REALSPACEPANEL);
+    m_sampleView->docks()->toggleDock(SampleViewDocks::REALSPACEPANEL);
 }

--- a/GUI/coregui/Views/SampleDesigner/SampleViewDocks.cpp
+++ b/GUI/coregui/Views/SampleDesigner/SampleViewDocks.cpp
@@ -85,7 +85,7 @@ void SampleViewDocks::onResetLayout()
     findDock(INFO)->hide();
 }
 
-void SampleViewDocks::togleDock(int id)
+void SampleViewDocks::toggleDock(int id)
 {
     auto dock = findDock(id);
     dock->setHidden(!dock->isHidden());

--- a/GUI/coregui/Views/SampleDesigner/SampleViewDocks.h
+++ b/GUI/coregui/Views/SampleDesigner/SampleViewDocks.h
@@ -45,7 +45,7 @@ public:
 
     void onResetLayout() override;
 
-    void togleDock(int id);
+    void toggleDock(int id);
 
 private:
     SampleDesigner* m_sampleDesigner;


### PR DESCRIPTION
This pull request implements Feature #2294 (http://apps.jcns.fz-juelich.de/redmine/issues/2294):
> Users are happy with 3D-Viewer and want to use images in their publications. For the moment, the only option to save the image of 3D view is to make a screenshot. Button "save image" is required for user convenience.