### PR TITLE
Revert "Translate q values from inv. angstroms into inv. nm in reflectometry import"

### DIFF
--- a/Core/InputOutput/OutputDataReadStrategy.cpp
+++ b/Core/InputOutput/OutputDataReadStrategy.cpp
@@ -18,7 +18,6 @@
 #include "PointwiseAxis.h"
 #include "ArrayUtils.h"
 #include "TiffHandler.h"
-#include "Units.h"
 #include <stdexcept> // need overlooked by g++ 5.4
 #include <map>
 
@@ -123,11 +122,8 @@ OutputData<double>* OutputDataReadReflectometryStrategy::readOutputData(std::ist
         rVec.push_back(it->second);
     }
 
-    // translate q values from inv. angstroms into inv. nm
-    std::transform(qVec.begin(), qVec.end(), qVec.begin(),
-                   [](double val) { return val / Units::angstrom; });
 
-    oData->addAxis(PointwiseAxis("qVector", qVec));
+    oData->addAxis(PointwiseAxis("qVector",qVec));
     oData->setRawDataVector(rVec);
     return oData;
 }


### PR DESCRIPTION
This reverts commit e1555e2026390e87f7e506685b84997d358dfa32.

If we advertise input units just as inverse nm, the import/labels/save become self-consistent.