### PR TITLE
Provide proper behaviour for Simulation::intensityMapSize

### DIFF
--- a/Core/Simulation/DepthProbeSimulation.cpp
+++ b/Core/Simulation/DepthProbeSimulation.cpp
@@ -102,7 +102,7 @@ const IAxis* DepthProbeSimulation::getZAxis() const
 
 size_t DepthProbeSimulation::intensityMapSize() const
 {
-    if (!m_z_axis || m_alpha_axis)
+    if (!m_z_axis || !m_alpha_axis)
         throw std::runtime_error("Error in DepthProbeSimulation::intensityMapSize: attempt to "
                                  "access non-initialized data.");
     return m_z_axis->size() * m_alpha_axis->size();

--- a/Core/Simulation/DepthProbeSimulation.cpp
+++ b/Core/Simulation/DepthProbeSimulation.cpp
@@ -100,6 +100,14 @@ const IAxis* DepthProbeSimulation::getZAxis() const
     return m_z_axis.get();
 }
 
+size_t DepthProbeSimulation::intensityMapSize() const
+{
+    if (!m_z_axis || m_alpha_axis)
+        throw std::runtime_error("Error in DepthProbeSimulation::intensityMapSize: attempt to "
+                                 "access non-initialized data.");
+    return m_z_axis->size() * m_alpha_axis->size();
+}
+
 std::unique_ptr<IUnitConverter> DepthProbeSimulation::createUnitConverter() const
 {
     return std::make_unique<DepthProbeConverter>(m_instrument.getBeam(), *m_alpha_axis, *m_z_axis);

--- a/Core/Simulation/DepthProbeSimulation.h
+++ b/Core/Simulation/DepthProbeSimulation.h
@@ -48,7 +48,7 @@ public:
     const IAxis* getZAxis() const;
 
     //! Returns the total number of the intensity values in the simulation result
-    size_t intensityMapSize() const override { return numberOfSimulationElements(); }
+    size_t intensityMapSize() const override;
 
 #ifndef SWIG
     std::unique_ptr<IUnitConverter> createUnitConverter() const;

--- a/Core/Simulation/GISASSimulation.cpp
+++ b/Core/Simulation/GISASSimulation.cpp
@@ -70,6 +70,17 @@ void GISASSimulation::setBeamParameters(double wavelength, double alpha_i, doubl
     m_instrument.setBeamParameters(wavelength, alpha_i, phi_i);
 }
 
+size_t GISASSimulation::intensityMapSize() const
+{
+    auto detector = getInstrument().getDetector();
+    if (!detector)
+        throw std::runtime_error(
+            "Error in GISASSimulation::intensityMapSize: attempt to access non-initialized data.");
+    size_t result = 0;
+    detector->iterate([&result](IDetector::const_iterator) { ++result;}, true);
+    return result;
+}
+
 GISASSimulation::GISASSimulation(const GISASSimulation& other)
     : Simulation2D(other)
 {

--- a/Core/Simulation/GISASSimulation.h
+++ b/Core/Simulation/GISASSimulation.h
@@ -47,6 +47,9 @@ public:
     //! Sets beam parameters from here (forwarded to Instrument)
     void setBeamParameters(double wavelength, double alpha_i, double phi_i);
 
+    //! Returns the total number of the intensity values in the simulation result
+    size_t intensityMapSize() const override;
+
 private:
     GISASSimulation(const GISASSimulation& other);
 

--- a/Core/Simulation/OffSpecSimulation.cpp
+++ b/Core/Simulation/OffSpecSimulation.cpp
@@ -93,6 +93,12 @@ std::unique_ptr<IUnitConverter> OffSpecSimulation::createUnitConverter() const
                                                   getInstrument().getBeam(), *axis);
 }
 
+size_t OffSpecSimulation::intensityMapSize() const
+{
+    checkInitialization();
+    return mP_alpha_i_axis->size() * m_instrument.getDetectorAxis(1).size();
+}
+
 OffSpecSimulation::OffSpecSimulation(const OffSpecSimulation& other)
     : Simulation2D(other)
 {

--- a/Core/Simulation/OffSpecSimulation.h
+++ b/Core/Simulation/OffSpecSimulation.h
@@ -53,6 +53,9 @@ public:
     std::unique_ptr<IUnitConverter> createUnitConverter() const;
 #endif
 
+    //! Returns the total number of the intensity values in the simulation result
+    size_t intensityMapSize() const override;
+
 private:
     OffSpecSimulation(const OffSpecSimulation& other);
 

--- a/Core/Simulation/Simulation2D.h
+++ b/Core/Simulation/Simulation2D.h
@@ -61,9 +61,6 @@ public:
     //! Sets rectangular region of interest with lower left and upper right corners defined.
     void setRegionOfInterest(double xlow, double ylow, double xup, double yup);
 
-    //! Returns the total number of the intensity values in the simulation result
-    size_t intensityMapSize() const override { return numberOfSimulationElements(); }
-
 protected:
     Simulation2D(const Simulation2D& other);
 

--- a/auto/Wrap/libBornAgainCore.py
+++ b/auto/Wrap/libBornAgainCore.py
@@ -16923,11 +16923,6 @@ class Simulation2D(Simulation):
         """
         return _libBornAgainCore.Simulation2D_setRegionOfInterest(self, xlow, ylow, xup, yup)
 
-
-    def intensityMapSize(self):
-        """intensityMapSize(Simulation2D self) -> size_t"""
-        return _libBornAgainCore.Simulation2D_intensityMapSize(self)
-
 Simulation2D_swigregister = _libBornAgainCore.Simulation2D_swigregister
 Simulation2D_swigregister(Simulation2D)
 
@@ -17218,6 +17213,11 @@ class GISASSimulation(Simulation2D):
 
         """
         return _libBornAgainCore.GISASSimulation_setBeamParameters(self, wavelength, alpha_i, phi_i)
+
+
+    def intensityMapSize(self):
+        """intensityMapSize(GISASSimulation self) -> size_t"""
+        return _libBornAgainCore.GISASSimulation_intensityMapSize(self)
 
 GISASSimulation_swigregister = _libBornAgainCore.GISASSimulation_swigregister
 GISASSimulation_swigregister(GISASSimulation)
@@ -25793,6 +25793,11 @@ class OffSpecSimulation(Simulation2D):
 
         """
         return _libBornAgainCore.OffSpecSimulation_beamAxis(self)
+
+
+    def intensityMapSize(self):
+        """intensityMapSize(OffSpecSimulation self) -> size_t"""
+        return _libBornAgainCore.OffSpecSimulation_intensityMapSize(self)
 
 OffSpecSimulation_swigregister = _libBornAgainCore.OffSpecSimulation_swigregister
 OffSpecSimulation_swigregister(OffSpecSimulation)


### PR DESCRIPTION
Previously it was returning the number of simulation elements for all simulations except for specular one. It is erroneous for off-spec and depth probe. In the case of GISAS it neglected masked areas.