### PR TITLE
Plotting routines accept **kwargs

### DIFF
--- a/Examples/python/simulation/ex01_BasicParticles/AllFormFactorsAvailable.py
+++ b/Examples/python/simulation/ex01_BasicParticles/AllFormFactorsAvailable.py
@@ -97,7 +97,8 @@ def run_simulation():
         plt.subplot(5, 5, nplot+1)
         plt.subplots_adjust(wspace=0.3, hspace=0.3)
 
-        ba.plot_colormap(result, xlabel="", ylabel="", zlabel="")
+        ba.plot_colormap(result, xlabel="", ylabel="", zlabel="", 
+                         cmap='jet', aspect='auto')
 
         plt.tick_params(axis='both', which='major', labelsize=8)
         plt.tick_params(axis='both', which='minor', labelsize=6)

--- a/Examples/python/simulation/ex01_BasicParticles/CylindersAndPrisms.py
+++ b/Examples/python/simulation/ex01_BasicParticles/CylindersAndPrisms.py
@@ -59,4 +59,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex01_BasicParticles/CylindersInBA.py
+++ b/Examples/python/simulation/ex01_BasicParticles/CylindersInBA.py
@@ -51,4 +51,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex01_BasicParticles/CylindersInDWBA.py
+++ b/Examples/python/simulation/ex01_BasicParticles/CylindersInDWBA.py
@@ -53,4 +53,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex01_BasicParticles/CylindersWithSizeDistribution.py
+++ b/Examples/python/simulation/ex01_BasicParticles/CylindersWithSizeDistribution.py
@@ -67,4 +67,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex01_BasicParticles/RotatedPyramids.py
+++ b/Examples/python/simulation/ex01_BasicParticles/RotatedPyramids.py
@@ -55,4 +55,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex01_BasicParticles/TwoTypesOfCylindersWithSizeDistribution.py
+++ b/Examples/python/simulation/ex01_BasicParticles/TwoTypesOfCylindersWithSizeDistribution.py
@@ -84,4 +84,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex02_LayeredStructures/BuriedParticles.py
+++ b/Examples/python/simulation/ex02_LayeredStructures/BuriedParticles.py
@@ -58,4 +58,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex02_LayeredStructures/CorrelatedRoughness.py
+++ b/Examples/python/simulation/ex02_LayeredStructures/CorrelatedRoughness.py
@@ -68,4 +68,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex03_InterferenceFunctions/ApproximationDA.py
+++ b/Examples/python/simulation/ex03_InterferenceFunctions/ApproximationDA.py
@@ -70,4 +70,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex03_InterferenceFunctions/ApproximationLMA.py
+++ b/Examples/python/simulation/ex03_InterferenceFunctions/ApproximationLMA.py
@@ -79,4 +79,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex03_InterferenceFunctions/ApproximationSSCA.py
+++ b/Examples/python/simulation/ex03_InterferenceFunctions/ApproximationSSCA.py
@@ -71,4 +71,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex03_InterferenceFunctions/CosineRipplesAtRectLattice.py
+++ b/Examples/python/simulation/ex03_InterferenceFunctions/CosineRipplesAtRectLattice.py
@@ -64,4 +64,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex03_InterferenceFunctions/Interference1DLattice.py
+++ b/Examples/python/simulation/ex03_InterferenceFunctions/Interference1DLattice.py
@@ -70,4 +70,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result, 1e-03)
+    ba.plot_simulation_result(result, intensity_min=1e-03, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex03_InterferenceFunctions/Interference1DRadialParaCrystal.py
+++ b/Examples/python/simulation/ex03_InterferenceFunctions/Interference1DRadialParaCrystal.py
@@ -65,4 +65,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex03_InterferenceFunctions/Interference2DCenteredSquareLattice.py
+++ b/Examples/python/simulation/ex03_InterferenceFunctions/Interference2DCenteredSquareLattice.py
@@ -69,4 +69,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex03_InterferenceFunctions/Interference2DLatticeSumOfRotated.py
+++ b/Examples/python/simulation/ex03_InterferenceFunctions/Interference2DLatticeSumOfRotated.py
@@ -72,4 +72,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex03_InterferenceFunctions/Interference2DParaCrystal.py
+++ b/Examples/python/simulation/ex03_InterferenceFunctions/Interference2DParaCrystal.py
@@ -65,4 +65,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex03_InterferenceFunctions/Interference2DRotatedSquareLattice.py
+++ b/Examples/python/simulation/ex03_InterferenceFunctions/Interference2DRotatedSquareLattice.py
@@ -64,4 +64,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex03_InterferenceFunctions/Interference2DSquareFiniteLattice.py
+++ b/Examples/python/simulation/ex03_InterferenceFunctions/Interference2DSquareFiniteLattice.py
@@ -62,4 +62,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex03_InterferenceFunctions/Interference2DSquareLattice.py
+++ b/Examples/python/simulation/ex03_InterferenceFunctions/Interference2DSquareLattice.py
@@ -63,4 +63,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex03_InterferenceFunctions/RectangularGrating.py
+++ b/Examples/python/simulation/ex03_InterferenceFunctions/RectangularGrating.py
@@ -77,4 +77,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex03_InterferenceFunctions/SpheresAtHexLattice.py
+++ b/Examples/python/simulation/ex03_InterferenceFunctions/SpheresAtHexLattice.py
@@ -57,4 +57,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex03_InterferenceFunctions/TriangularRipple.py
+++ b/Examples/python/simulation/ex03_InterferenceFunctions/TriangularRipple.py
@@ -65,4 +65,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex04_ComplexShapes/BiMaterialCylinders.py
+++ b/Examples/python/simulation/ex04_ComplexShapes/BiMaterialCylinders.py
@@ -83,4 +83,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex04_ComplexShapes/CoreShellNanoparticles.py
+++ b/Examples/python/simulation/ex04_ComplexShapes/CoreShellNanoparticles.py
@@ -59,4 +59,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex04_ComplexShapes/CustomFormFactor.py
+++ b/Examples/python/simulation/ex04_ComplexShapes/CustomFormFactor.py
@@ -95,4 +95,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex04_ComplexShapes/HexagonalLatticesWithBasis.py
+++ b/Examples/python/simulation/ex04_ComplexShapes/HexagonalLatticesWithBasis.py
@@ -64,4 +64,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex04_ComplexShapes/LargeParticlesFormFactor.py
+++ b/Examples/python/simulation/ex04_ComplexShapes/LargeParticlesFormFactor.py
@@ -94,7 +94,7 @@ def run_simulation():
 
         zmin = condition['zmin']
         zmax = condition['zmax']
-        ba.plot_colormap(result, zmin=zmin, zmax=zmax)
+        ba.plot_colormap(result, zmin=zmin, zmax=zmax, cmap='jet', aspect='auto')
 
         plt.text(0.0, 2.1, conditions[i_plot]['title'],
                  horizontalalignment='center', verticalalignment='center',

--- a/Examples/python/simulation/ex04_ComplexShapes/MesoCrystal.py
+++ b/Examples/python/simulation/ex04_ComplexShapes/MesoCrystal.py
@@ -67,4 +67,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex04_ComplexShapes/ParticlesCrossingInterface.py
+++ b/Examples/python/simulation/ex04_ComplexShapes/ParticlesCrossingInterface.py
@@ -84,4 +84,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex05_BeamAndDetector/BeamDivergence.py
+++ b/Examples/python/simulation/ex05_BeamAndDetector/BeamDivergence.py
@@ -62,4 +62,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex05_BeamAndDetector/ConstantBackground.py
+++ b/Examples/python/simulation/ex05_BeamAndDetector/ConstantBackground.py
@@ -58,4 +58,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex05_BeamAndDetector/DetectorResolutionFunction.py
+++ b/Examples/python/simulation/ex05_BeamAndDetector/DetectorResolutionFunction.py
@@ -56,4 +56,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex05_BeamAndDetector/OffSpecularSimulation.py
+++ b/Examples/python/simulation/ex05_BeamAndDetector/OffSpecularSimulation.py
@@ -73,4 +73,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result, intensity_min=1.0)
+    ba.plot_simulation_result(result, intensity_min=1.0, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex05_BeamAndDetector/RectangularDetector.py
+++ b/Examples/python/simulation/ex05_BeamAndDetector/RectangularDetector.py
@@ -86,12 +86,13 @@ def plot(results):
     plt.subplot(1, 3, 1)
     ba.plot_colormap(results['spherical'], title="Spherical detector",
                      xlabel=r'$\phi_f ^{\circ}$', ylabel=r'$\alpha_f ^{\circ}$',
-                     zlabel="")
+                     zlabel="", cmap='jet', aspect='auto')
 
     # showing  result of rectangular detector simulation
     plt.subplot(1, 3, 2)
     ba.plot_colormap(results['rectangular'], title="Rectangular detector",
-                     xlabel='X, mm', ylabel='Y, mm', zlabel="")
+                     xlabel='X, mm', ylabel='Y, mm', zlabel="",
+                     cmap='jet', aspect='auto')
 
     # show relative difference between two plots (sph[i]-rect[i])/rect[i]
     # for every detector pixel
@@ -99,7 +100,8 @@ def plot(results):
     rect_array = results['rectangular'].array()
     rel_diff = 2.0 * numpy.abs(sph_array - rect_array)/(sph_array + rect_array)
     plt.subplot(1, 3, 3)
-    im = plt.imshow(rel_diff, norm=colors.LogNorm(1e-6, 1.0), aspect='auto')
+    im = plt.imshow(rel_diff, norm=colors.LogNorm(1e-6, 1.0), 
+                    aspect='auto', cmap='jet')
     cb = plt.colorbar(im, pad=0.025)
     plt.xlabel('X, bins', fontsize=14)
     plt.ylabel('Y, bins', fontsize=14)

--- a/Examples/python/simulation/ex05_BeamAndDetector/ResonatorOffSpecSetup.py
+++ b/Examples/python/simulation/ex05_BeamAndDetector/ResonatorOffSpecSetup.py
@@ -92,4 +92,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result, intensity_min=1e-03)
+    ba.plot_simulation_result(result, intensity_min=1e-03, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex06_Reflectometry/BasicSpecularSimulation.py
+++ b/Examples/python/simulation/ex06_Reflectometry/BasicSpecularSimulation.py
@@ -58,4 +58,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     results = run_simulation()
-    ba.plot_simulation_result(results)
+    ba.plot_simulation_result(results, c='k')

--- a/Examples/python/simulation/ex06_Reflectometry/BeamAngularDivergence.py
+++ b/Examples/python/simulation/ex06_Reflectometry/BeamAngularDivergence.py
@@ -104,7 +104,7 @@ def plot(results):
     """
     from matplotlib import pyplot as plt
 
-    ba.plot_simulation_result(results, postpone_show=True)
+    ba.plot_simulation_result(results, postpone_show=True, c='gray', linestyle="--")
 
     genx_axis, genx_values = create_real_data()
 

--- a/Examples/python/simulation/ex06_Reflectometry/BeamFullDivergence.py
+++ b/Examples/python/simulation/ex06_Reflectometry/BeamFullDivergence.py
@@ -83,4 +83,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     results = run_simulation()
-    ba.plot_simulation_result(results)
+    ba.plot_simulation_result(results, c='b')

--- a/Examples/python/simulation/ex07_Miscellaneous/AccessingSimulationResults.py
+++ b/Examples/python/simulation/ex07_Miscellaneous/AccessingSimulationResults.py
@@ -7,6 +7,7 @@ import random
 import bornagain as ba
 from bornagain import deg, angstrom, nm
 from matplotlib import pyplot as plt
+from matplotlib import rcParams
 
 
 def get_sample():
@@ -63,7 +64,8 @@ def get_noisy_image(hist):
 def plot_histogram(hist, zmin=None, zmax=None):
     ba.plot_histogram(hist, xlabel=r'$\varphi_f ^{\circ}$',
                       ylabel=r'$\alpha_f ^{\circ}$',
-                      zlabel="", zmin=zmin, zmax=zmax)
+                      zlabel="", zmin=zmin, zmax=zmax,
+                      cmap='jet', aspect='auto')
 
 
 def get_relative_difference(hist):
@@ -111,7 +113,6 @@ def plot(hist):
     Runs different plotting functions one by one
     to demonstrate trivial data presentation tasks.
     """
-
     plt.figure(figsize=(12.80, 10.24))
 
     plt.subplot(2, 2, 1)

--- a/Examples/python/simulation/ex07_Miscellaneous/AxesInDifferentUnits.py
+++ b/Examples/python/simulation/ex07_Miscellaneous/AxesInDifferentUnits.py
@@ -5,6 +5,7 @@ axes in different units (nbins, mm, degs and QyQz).
 import bornagain as ba
 from bornagain import deg, angstrom, nm
 from matplotlib import pyplot as plt
+from matplotlib import rcParams
 
 
 def get_sample():
@@ -76,6 +77,10 @@ def plot(result):
     """
     Plots simulation results for different detectors.
     """
+    # set plotting parameters
+    rcParams['image.cmap'] = 'jet'
+    rcParams['image.aspect'] = 'auto'
+    
     fig = plt.figure(figsize=(12.80, 10.24))
 
     plt.subplot(2, 2, 1)

--- a/Examples/python/simulation/ex07_Miscellaneous/BoxesWithSpecularPeak.py
+++ b/Examples/python/simulation/ex07_Miscellaneous/BoxesWithSpecularPeak.py
@@ -62,4 +62,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex07_Miscellaneous/CylindersInAverageLayer.py
+++ b/Examples/python/simulation/ex07_Miscellaneous/CylindersInAverageLayer.py
@@ -64,4 +64,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex07_Miscellaneous/DepthProbe.py
+++ b/Examples/python/simulation/ex07_Miscellaneous/DepthProbe.py
@@ -111,4 +111,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex07_Miscellaneous/FindPeaks.py
+++ b/Examples/python/simulation/ex07_Miscellaneous/FindPeaks.py
@@ -78,7 +78,7 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation().histogram2d()
-    ba.plot_histogram(result)
+    ba.plot_histogram(result, cmap='jet', aspect='auto')
 
     peaks = ba.FindPeaks(result, 2, "nomarkov", 0.001)
     xpeaks = [peak[0] for peak in peaks]

--- a/Examples/python/simulation/ex07_Miscellaneous/HalfSpheresInAverageTopLayer.py
+++ b/Examples/python/simulation/ex07_Miscellaneous/HalfSpheresInAverageTopLayer.py
@@ -67,4 +67,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex07_Miscellaneous/MagneticSpheres.py
+++ b/Examples/python/simulation/ex07_Miscellaneous/MagneticSpheres.py
@@ -68,4 +68,4 @@ def run_simulation():
 
 if __name__ == '__main__':
     result = run_simulation()
-    ba.plot_simulation_result(result)
+    ba.plot_simulation_result(result, cmap='jet', aspect='auto')

--- a/Examples/python/simulation/ex07_Miscellaneous/SimulationParameters.py
+++ b/Examples/python/simulation/ex07_Miscellaneous/SimulationParameters.py
@@ -108,7 +108,7 @@ def plot(results):
 
     for nplot, hist in results.items():
         plt.subplot(2, 2, nplot+1)
-        ba.plot_colormap(hist, zlabel="")
+        ba.plot_colormap(hist, zlabel="", cmap='jet', aspect='auto')
     plt.tight_layout()
     plt.show()
 

--- a/Wrap/python/plot_utils.py
+++ b/Wrap/python/plot_utils.py
@@ -84,13 +84,12 @@ def get_axes_labels(result, units):
 
 
 def plot_array(array, zmin=None, zmax=None, xlabel=None, ylabel=None, zlabel=None,
-               title=None, axes_limits=None, aspect=None, **kwargs):
+               title=None, axes_limits=None, **kwargs):
     """
     Plots numpy array as a colormap in log scale.
     """
 
     zlabel = "Intensity" if zlabel is None else zlabel
-    aspect = 'auto' if aspect is None else aspect
 
     zmax = np.amax(array) if zmax is None else zmax
     zmin = 1e-6*zmax if zmin is None else zmin
@@ -100,7 +99,7 @@ def plot_array(array, zmin=None, zmax=None, xlabel=None, ylabel=None, zlabel=Non
     else:
         norm = colors.LogNorm(zmin, zmax)
 
-    im = plt.imshow(array, norm=norm, extent=axes_limits, aspect=aspect, **kwargs)
+    im = plt.imshow(array, norm=norm, extent=axes_limits, **kwargs)
     cb = plt.colorbar(im, pad=0.025)
 
     if xlabel:
@@ -117,13 +116,12 @@ def plot_array(array, zmin=None, zmax=None, xlabel=None, ylabel=None, zlabel=Non
 
 
 def plot_histogram(hist, zmin=None, zmax=None, xlabel=None, ylabel=None, zlabel=None,
-                  title=None, aspect=None, **kwargs):
+                  title=None, **kwargs):
     """
     Plots intensity data as color map
     :param intensity: Histogram2D object obtained from GISASSimulation
     :param zmin: Min value on amplitude's color bar
     :param zmax: Max value on amplitude's color bar
-    :param aspect: 'auto' (default) or 'equal'
     """
 
     if not xlabel:
@@ -136,12 +134,12 @@ def plot_histogram(hist, zmin=None, zmax=None, xlabel=None, ylabel=None, zlabel=
                    hist.getYmin(), hist.getYmax()]
 
     plot_array(hist.array(), zmin=zmin, zmax=zmax, xlabel=xlabel, ylabel=ylabel,
-               zlabel=zlabel, title=title, axes_limits=axes_limits, aspect=aspect, **kwargs)
+               zlabel=zlabel, title=title, axes_limits=axes_limits, **kwargs)
 
 
 def plot_colormap(result, zmin=None, zmax=None, units=ba.AxesUnits.DEFAULT,
                   xlabel=None, ylabel=None, zlabel=None,
-                  title=None, aspect=None, **kwargs):
+                  title=None, **kwargs):
     """
     Plots intensity data as color map
     :param result: SimulationResult from GISAS/OffSpecSimulation
@@ -155,7 +153,7 @@ def plot_colormap(result, zmin=None, zmax=None, units=ba.AxesUnits.DEFAULT,
     ylabel = axes_labels[1] if ylabel is None else ylabel
 
     plot_array(result.array(), zmin=zmin, zmax=zmax, xlabel=xlabel, ylabel=ylabel,
-               zlabel=zlabel, title=title, axes_limits=axes_limits, aspect=aspect, **kwargs)
+               zlabel=zlabel, title=title, axes_limits=axes_limits, **kwargs)
 
 
 def plot_specular_simulation_result(result, ymin=None, ymax=None, units=ba.AxesUnits.DEFAULT,
@@ -191,7 +189,7 @@ def plot_specular_simulation_result(result, ymin=None, ymax=None, units=ba.AxesU
 
 
 def plot_simulation_result(result, intensity_min=None, intensity_max=None, units=ba.AxesUnits.DEFAULT,
-                           xlabel=None, ylabel=None, postpone_show=False, title=None, aspect=None, **kwargs):
+                           xlabel=None, ylabel=None, postpone_show=False, title=None, **kwargs):
     """
     Draws simulation result and (optionally) shows the plot.
     :param result_: SimulationResult object obtained from GISAS/OffSpec/SpecularSimulation
@@ -199,13 +197,12 @@ def plot_simulation_result(result, intensity_min=None, intensity_max=None, units
     :param intensity_max: Max value on amplitude's axis or color bar
     :param units: units for plot axes
     :param postpone_show: postpone showing the plot for later tuning (False by default)
-    :param aspect: aspect ratio, 'auto' (default) or 'equal'
     """
     if len(result.array().shape) == 1:  # 1D data, specular simulation assumed
         plot_specular_simulation_result(result, intensity_min, intensity_max, units, **kwargs)
     else:
         plot_colormap(result, intensity_min, intensity_max, units, xlabel, ylabel,
-                      title=title, aspect=aspect, **kwargs)
+                      title=title, **kwargs)
     plt.tight_layout()
     if not postpone_show:
         plt.show()

--- a/Wrap/python/plot_utils.py
+++ b/Wrap/python/plot_utils.py
@@ -84,7 +84,7 @@ def get_axes_labels(result, units):
 
 
 def plot_array(array, zmin=None, zmax=None, xlabel=None, ylabel=None, zlabel=None,
-               title=None, axes_limits=None, aspect=None):
+               title=None, axes_limits=None, aspect=None, **kwargs):
     """
     Plots numpy array as a colormap in log scale.
     """
@@ -100,7 +100,7 @@ def plot_array(array, zmin=None, zmax=None, xlabel=None, ylabel=None, zlabel=Non
     else:
         norm = colors.LogNorm(zmin, zmax)
 
-    im = plt.imshow(array, norm=norm, extent=axes_limits, aspect=aspect)
+    im = plt.imshow(array, norm=norm, extent=axes_limits, aspect=aspect, **kwargs)
     cb = plt.colorbar(im, pad=0.025)
 
     if xlabel:
@@ -117,7 +117,7 @@ def plot_array(array, zmin=None, zmax=None, xlabel=None, ylabel=None, zlabel=Non
 
 
 def plot_histogram(hist, zmin=None, zmax=None, xlabel=None, ylabel=None, zlabel=None,
-                  title=None, aspect=None):
+                  title=None, aspect=None, **kwargs):
     """
     Plots intensity data as color map
     :param intensity: Histogram2D object obtained from GISASSimulation
@@ -136,12 +136,12 @@ def plot_histogram(hist, zmin=None, zmax=None, xlabel=None, ylabel=None, zlabel=
                    hist.getYmin(), hist.getYmax()]
 
     plot_array(hist.array(), zmin=zmin, zmax=zmax, xlabel=xlabel, ylabel=ylabel,
-               zlabel=zlabel, title=title, axes_limits=axes_limits, aspect=aspect)
+               zlabel=zlabel, title=title, axes_limits=axes_limits, aspect=aspect, **kwargs)
 
 
 def plot_colormap(result, zmin=None, zmax=None, units=ba.AxesUnits.DEFAULT,
                   xlabel=None, ylabel=None, zlabel=None,
-                  title=None, aspect=None):
+                  title=None, aspect=None, **kwargs):
     """
     Plots intensity data as color map
     :param result: SimulationResult from GISAS/OffSpecSimulation
@@ -155,11 +155,11 @@ def plot_colormap(result, zmin=None, zmax=None, units=ba.AxesUnits.DEFAULT,
     ylabel = axes_labels[1] if ylabel is None else ylabel
 
     plot_array(result.array(), zmin=zmin, zmax=zmax, xlabel=xlabel, ylabel=ylabel,
-               zlabel=zlabel, title=title, axes_limits=axes_limits, aspect=aspect)
+               zlabel=zlabel, title=title, axes_limits=axes_limits, aspect=aspect, **kwargs)
 
 
 def plot_specular_simulation_result(result, ymin=None, ymax=None, units=ba.AxesUnits.DEFAULT,
-              xlabel=None, ylabel=None, title=None):
+              xlabel=None, ylabel=None, title=None, **kwargs):
     """
     Plots intensity data for specular simulation result
     :param result: SimulationResult from SpecularSimulation
@@ -176,7 +176,7 @@ def plot_specular_simulation_result(result, ymin=None, ymax=None, units=ba.AxesU
     xlabel = get_axes_labels(result, units)[0] if xlabel is None else xlabel
     ylabel = "Intensity" if ylabel is None else ylabel
 
-    plt.semilogy(x_axis, intensity)
+    plt.semilogy(x_axis, intensity, **kwargs)
 
     plt.ylim([ymin, ymax])
 
@@ -191,7 +191,7 @@ def plot_specular_simulation_result(result, ymin=None, ymax=None, units=ba.AxesU
 
 
 def plot_simulation_result(result, intensity_min=None, intensity_max=None, units=ba.AxesUnits.DEFAULT,
-                           xlabel=None, ylabel=None, postpone_show=False, title=None, aspect=None):
+                           xlabel=None, ylabel=None, postpone_show=False, title=None, aspect=None, **kwargs):
     """
     Draws simulation result and (optionally) shows the plot.
     :param result_: SimulationResult object obtained from GISAS/OffSpec/SpecularSimulation
@@ -202,10 +202,10 @@ def plot_simulation_result(result, intensity_min=None, intensity_max=None, units
     :param aspect: aspect ratio, 'auto' (default) or 'equal'
     """
     if len(result.array().shape) == 1:  # 1D data, specular simulation assumed
-        plot_specular_simulation_result(result, intensity_min, intensity_max, units)
+        plot_specular_simulation_result(result, intensity_min, intensity_max, units, **kwargs)
     else:
         plot_colormap(result, intensity_min, intensity_max, units, xlabel, ylabel,
-                      title=title, aspect=aspect)
+                      title=title, aspect=aspect, **kwargs)
     plt.tight_layout()
     if not postpone_show:
         plt.show()


### PR DESCRIPTION
Plotting routines now accept `**kwargs`. 
Removed option `aspect='auto'`. Now aspect ratio will be taken from `**kwargs` or from `matplotlibrc`. 
Plotting routines now accept all options supported by matplotlib `imshow` and `semilog`.