### PR TITLE
Fix Bug 2370 [Reflectometry] - Crash for non-sensible values of theta.

### DIFF
--- a/Core/Instrument/AngularSpecScan.cpp
+++ b/Core/Instrument/AngularSpecScan.cpp
@@ -22,6 +22,7 @@
 #include "RealLimits.h"
 #include "ScanResolution.h"
 #include "SpecularSimulationElement.h"
+#include "Units.h"
 
 namespace {
 std::vector<std::vector<double>>
@@ -170,6 +171,17 @@ void AngularSpecScan::setAbsoluteAngularResolution(const RangedDistribution& dis
     std::unique_ptr<ScanResolution> resolution(
         ScanResolution::scanAbsoluteResolution(distr, std_dev));
     setAngleResolution(*resolution);
+}
+
+bool AngularSpecScan::isWithinValidRange() const
+{
+    double min = coordinateAxis()->getMin();
+    double max =  coordinateAxis()->getMax();
+
+    if (min < 0.0 || max >= 90)
+        return false;
+
+    return true;
 }
 
 std::vector<double> AngularSpecScan::footprint(size_t start, size_t n_elements) const

--- a/Core/Instrument/AngularSpecScan.cpp
+++ b/Core/Instrument/AngularSpecScan.cpp
@@ -178,7 +178,7 @@ bool AngularSpecScan::isWithinValidRange() const
     double min = coordinateAxis()->getMin();
     double max =  coordinateAxis()->getMax();
 
-    if (min < 0.0 || max >= 90)
+    if (min < 0.0 || Units::rad2deg(max) >= 90)
         return false;
 
     return true;

--- a/Core/Instrument/AngularSpecScan.h
+++ b/Core/Instrument/AngularSpecScan.h
@@ -67,6 +67,11 @@ public:
     // TODO: remove these getters after transition to the new resolution machinery is finished
     const ScanResolution* wavelengthResolution() const { return m_wl_resolution.get(); }
     const ScanResolution* angleResolution() const { return m_inc_resolution.get(); }
+
+    //! Checks whether the coordinate range is Within valid limits.
+    //! In particular, if the scan angle lays between 0 and 90 degrees.
+    bool isWithinValidRange() const override;
+
 #endif // SWIG
 
     //! Sets footprint correction factor

--- a/Core/Instrument/ISpecularScan.h
+++ b/Core/Instrument/ISpecularScan.h
@@ -57,6 +57,9 @@ public:
 
     //! Print scan definition in python format
     virtual std::string print() const = 0;
+
+    //! Checks whether the coordinates of the scan are within the validity range.
+    virtual bool isWithinValidRange() const = 0;
 #endif //SWIG
 
     SPECULAR_DATA_TYPE dataType() const {return m_data_type;}

--- a/Core/Instrument/QSpecScan.cpp
+++ b/Core/Instrument/QSpecScan.cpp
@@ -194,3 +194,11 @@ std::vector<std::vector<ParameterSample> > QSpecScan::applyQResolution() const
         m_q_res_cache = m_resolution->generateSamples(m_qs->getBinCenters());
     return m_q_res_cache;
 }
+
+bool QSpecScan::isWithinValidRange() const
+{
+    if (coordinateAxis()->getMin() < 0.0)
+        return false;
+
+    return true;
+}

--- a/Core/Instrument/QSpecScan.h
+++ b/Core/Instrument/QSpecScan.h
@@ -64,6 +64,10 @@ public:
 
     //! Print scan definition in python format
     std::string print() const override;
+
+    //! Checks whether the coordinate range is Within valid limits.
+    //! In particular, if the scan is non-negataive.
+    bool isWithinValidRange() const override;
 #endif //SWIG
 
     //! Sets q resolution values via ScanResolution object.

--- a/Core/Simulation/SpecularSimulation.cpp
+++ b/Core/Simulation/SpecularSimulation.cpp
@@ -93,9 +93,10 @@ SimulationResult SpecularSimulation::result() const
 void SpecularSimulation::setScan(const ISpecularScan& scan)
 {
     // TODO: move inside AngularSpecScan when pointwise resolution is implemented
-    if (scan.coordinateAxis()->getMin() < 0.0)
+    if (!scan.isWithinValidRange())
         throw std::runtime_error(
-            "Error in SpecularSimulation::setScan: minimum value on coordinate axis is negative.");
+            "Error in SpecularSimulation::setScan: invalid coordinate axis; Coordinataes must be positive.\n"
+            "In case of angular coordinates, they must also be smaller than 90 degrees.");
 
     m_data_handler.reset(scan.clone());
 

--- a/Tests/UnitTests/Core/Fresnel/SpecularSimulationTest.cpp
+++ b/Tests/UnitTests/Core/Fresnel/SpecularSimulationTest.cpp
@@ -89,15 +89,13 @@ TEST_F(SpecularSimulationTest, CloneOfEmpty)
 TEST_F(SpecularSimulationTest, SetAngularScan)
 {
     SpecularSimulation sim;
-
-    AngularSpecScan scan(1.0, std::vector<double>{1.0, 3.0});
+    AngularSpecScan scan(1.0, std::vector<double>{1.0 * Units::deg, 3.0 * Units::deg});
     sim.setScan(scan);
-
     const auto& beam = sim.getInstrument().getBeam();
 
     EXPECT_EQ(2u, sim.coordinateAxis()->size());
-    EXPECT_EQ(1.0, sim.coordinateAxis()->getMin());
-    EXPECT_EQ(3.0, sim.coordinateAxis()->getMax());
+    EXPECT_EQ(1.0 * Units::deg, sim.coordinateAxis()->getMin());
+    EXPECT_EQ(3.0 * Units::deg, sim.coordinateAxis()->getMax());
     EXPECT_EQ(1.0, beam.getIntensity());
     EXPECT_EQ(1.0, beam.getWavelength());
     EXPECT_EQ(0.0, beam.getAlpha());


### PR DESCRIPTION
This Pull Request fixes bug 2370 (http://apps.jcns.fz-juelich.de/redmine/issues/2370):

> To reproduce:
> 
> 1. Instrument view: Choose the Specular Instrument; In the Beam Parameters section --> Inclination Angles [deg] --> Min = 0.0, Max = 91 (i.e. a non-sensible value).
> 2. Sample View: Create any Multilayer sample (I chose the example "Multilayer With Correlated Roughness").
> 3. Simulation View: Hit "Run Simulation".
> 4. Jobs View: The figure shows a plot "alpha_i [deg] vs Signal [a.u.]"; hit "Properties" on top of the plot; on the pane that appears at the right, change axes units to q-space or to radians.
> 5. Don't call it a crash; call it a shortcut for closing the application without being asked whether to save the changes :)
> 
> Possible ways to go (in no particular order):
> 
> A. Impose that the value inserted in (1) is smaller than 90.
> B. Trust that users won't ever set such large values, as they don't make sense anyway.
> C. The error thrown is a std::runtime_error; what(): Error in UnitConverter1D: input axis range is out of bounds . Catch it and give feedback to users through a message box.
> 
> I'd personally go for A.

The fix was done following a logic already present inside BornAgain: Let users write any value inside the Instrument View, but do not run the simulation if the values entered do not make sense. Instead, communicate this information in the small bottom left dock inside the Jobs View.