### PR TITLE
Fix Bug 2370 [Reflectometry] - Crash for non-sensible values of theta.

### DIFF
--- a/GUI/coregui/Models/SpecularBeamInclinationItem.cpp
+++ b/GUI/coregui/Models/SpecularBeamInclinationItem.cpp
@@ -98,6 +98,8 @@ void setAxisPresentationDefaults(SessionItem* axis_item, const QString& type)
     axis_item->getItem(BasicAxisItem::P_NBINS)->setToolTip("Number of points in scan");
     axis_item->getItem(BasicAxisItem::P_MIN)->setToolTip("Starting value [deg]");
     axis_item->getItem(BasicAxisItem::P_MAX)->setToolTip("Ending value [deg]");
+    axis_item->getItem(BasicAxisItem::P_MIN)->setLimits(RealLimits::limited(0.,90.));
+    axis_item->getItem(BasicAxisItem::P_MAX)->setLimits(RealLimits::limited(0.,90.));
 
     if (type == Constants::BasicAxisType) {
         axis_item->setItemValue(BasicAxisItem::P_MIN, 0.0);

--- a/Tests/UnitTests/Core/Fresnel/SpecularSimulationTest.cpp
+++ b/Tests/UnitTests/Core/Fresnel/SpecularSimulationTest.cpp
@@ -89,15 +89,13 @@ TEST_F(SpecularSimulationTest, CloneOfEmpty)
 TEST_F(SpecularSimulationTest, SetAngularScan)
 {
     SpecularSimulation sim;
-
-    AngularSpecScan scan(1.0, std::vector<double>{1.0, 3.0});
+    AngularSpecScan scan(1.0, std::vector<double>{1.0 * Units::deg, 3.0 * Units::deg});
     sim.setScan(scan);
-
     const auto& beam = sim.getInstrument().getBeam();
 
     EXPECT_EQ(2u, sim.coordinateAxis()->size());
-    EXPECT_EQ(1.0, sim.coordinateAxis()->getMin());
-    EXPECT_EQ(3.0, sim.coordinateAxis()->getMax());
+    EXPECT_EQ(1.0 * Units::deg, sim.coordinateAxis()->getMin());
+    EXPECT_EQ(3.0 * Units::deg, sim.coordinateAxis()->getMax());
     EXPECT_EQ(1.0, beam.getIntensity());
     EXPECT_EQ(1.0, beam.getWavelength());
     EXPECT_EQ(0.0, beam.getAlpha());


### PR DESCRIPTION
This Pull Request fixes bug 2370 (http://apps.jcns.fz-juelich.de/redmine/issues/2370):

> To reproduce:
> 
> 1. Instrument view: Choose the Specular Instrument; In the Beam Parameters section --> Inclination Angles [deg] --> Min = 0.0, Max = 91 (i.e. a non-sensible value).
> 2. Sample View: Create any Multilayer sample (I chose the example "Multilayer With Correlated Roughness").
> 3. Simulation View: Hit "Run Simulation".
> 4. Jobs View: The figure shows a plot "alpha_i [deg] vs Signal [a.u.]"; hit "Properties" on top of the plot; on the pane that appears at the right, change axes units to q-space or to radians.
> 5. Don't call it a crash; call it a shortcut for closing the application without being asked whether to save the changes :)
> 
> Possible ways to go (in no particular order):
> 
> A. Impose that the value inserted in (1) is smaller than 90.
> B. Trust that users won't ever set such large values, as they don't make sense anyway.
> C. The error thrown is a std::runtime_error; what(): Error in UnitConverter1D: input axis range is out of bounds . Catch it and give feedback to users through a message box.
> 
> I'd personally go for A.

Users are now prevented from feeding non-sensibe min and max values of theta in the GUI.