### PR TITLE
Feature #2285 - Name layers in GUI by their material name

### DIFF
--- a/GUI/coregui/Views/SampleDesigner/ILayerView.cpp
+++ b/GUI/coregui/Views/SampleDesigner/ILayerView.cpp
@@ -56,6 +56,7 @@ void ILayerView::onPropertyChange(const QString &propertyName)
         updateHeight();
     } else if (propertyName == LayerItem::P_MATERIAL) {
         updateColor();
+        updateLabel();
     }
 
     IView::onPropertyChange(propertyName);
@@ -85,6 +86,40 @@ void ILayerView::updateColor()
         }
     }
 }
+
+void ILayerView::updateLabel()
+{
+    if(getInputPorts().size() < 1)
+        return;
+
+    NodeEditorPort *port = getInputPorts()[0];
+
+    QString material = "" ;
+    if(m_item->isTag(LayerItem::P_MATERIAL)){
+        QVariant v = m_item->getItemValue(LayerItem::P_MATERIAL);
+        if (v.isValid()) {
+            ExternalProperty mp = v.value<ExternalProperty>();
+            material = mp.text();
+        }
+    }
+
+/* Thickness and roughness can be added, but the length of the string
+ * becomes prohibitive.
+    QString thickness = "" ;
+    if(m_item->isTag(LayerItem::P_THICKNESS))
+        thickness = m_item->getItemValue(LayerItem::P_THICKNESS).toString();
+
+    QString roughness = "" ;
+    if(m_item->isTag(LayerItem::P_ROUGHNESS)){
+        QVariant x = m_item->getItemValue(LayerItem::P_ROUGHNESS);
+        {...}
+    }
+*/
+    QString infoToDisplay = material;
+    port->setLabel(infoToDisplay);
+}
+
+
 
 //! Detects movement of the ILayerView and sends possible drop areas to GraphicsScene
 //! for visualization.
@@ -179,6 +214,7 @@ void ILayerView::update_appearance()
 {
     updateHeight();
     updateColor();
+    updateLabel();
     ConnectableView::update_appearance();
 }
 

--- a/GUI/coregui/Views/SampleDesigner/ILayerView.h
+++ b/GUI/coregui/Views/SampleDesigner/ILayerView.h
@@ -35,6 +35,8 @@ public:
 
     virtual QString getLabel() const { return QString(); }
 
+    void updateLabel();
+
 protected:
     QVariant itemChange(GraphicsItemChange change, const QVariant &value);
     void mousePressEvent(QGraphicsSceneMouseEvent *event);

--- a/GUI/coregui/Views/SampleDesigner/NodeEditorPort.cpp
+++ b/GUI/coregui/Views/SampleDesigner/NodeEditorPort.cpp
@@ -22,7 +22,7 @@ NodeEditorPort::NodeEditorPort(QGraphicsItem *parent, const QString &name,
                                NodeEditorPort::EPortDirection direction,
                                NodeEditorPort::EPortType port_type)
     : QGraphicsPathItem(parent), m_name(name), m_direction(direction), m_port_type(port_type),
-      m_radius(5), m_margin(2)
+      m_radius(5), m_margin(2), m_label(nullptr)
 {
     m_color = getPortTypeColor(port_type);
 
@@ -36,17 +36,7 @@ NodeEditorPort::NodeEditorPort(QGraphicsItem *parent, const QString &name,
     setFlag(QGraphicsItem::ItemSendsScenePositionChanges);
 
     if (!m_name.isEmpty()) {
-        QGraphicsTextItem *label = new QGraphicsTextItem(this);
-        label->setPlainText(m_name);
-        QFont serifFont("Monospace", DesignerHelper::getPortFontSize(), QFont::Normal);
-        label->setFont(serifFont);
-
-        if (isOutput()) {
-            label->setPos(-m_radius - m_margin - label->boundingRect().width(),
-                          -label->boundingRect().height() / 2);
-        } else {
-            label->setPos(m_radius + m_margin, -label->boundingRect().height() / 2);
-        }
+        setLabel(m_name);
     }
 }
 
@@ -117,3 +107,21 @@ QVariant NodeEditorPort::itemChange(GraphicsItemChange change, const QVariant &v
     }
     return value;
 }
+
+void NodeEditorPort::setLabel(QString name)
+{
+    if(!m_label)
+        m_label = new QGraphicsTextItem(this);
+    m_label->setPlainText(name);
+    QFont serifFont("Monospace", DesignerHelper::getPortFontSize(), QFont::Normal);
+    m_label->setFont(serifFont);
+
+    if (isOutput()) {
+        m_label->setPos(-m_radius - m_margin - m_label->boundingRect().width(),
+                      -m_label->boundingRect().height() / 2);
+    } else {
+        m_label->setPos(m_radius + m_margin, -m_label->boundingRect().height() / 2);
+    }
+}
+
+

--- a/GUI/coregui/Views/SampleDesigner/NodeEditorPort.h
+++ b/GUI/coregui/Views/SampleDesigner/NodeEditorPort.h
@@ -62,6 +62,8 @@ public:
 
     static QColor getPortTypeColor(NodeEditorPort::EPortType port_type);
 
+    void setLabel(QString name);
+
 protected:
     QVariant itemChange(GraphicsItemChange change, const QVariant &value);
 
@@ -73,6 +75,7 @@ private:
     int m_radius;
     int m_margin;
     QVector<NodeEditorConnection *> m_connections;
+    QGraphicsTextItem *m_label;
 };
 
 inline const QString &NodeEditorPort::portName() const


### PR DESCRIPTION
This Pull Request implements Feature #2285 - Name layers in GUI by their material name (http://apps.jcns.fz-juelich.de/redmine/issues/2285):

> The material name could also appear in the layer representation in the sample designer.