### PR TITLE
GUI: rename 'Import' button to 'Data'

### DIFF
--- a/GUI/coregui/mainwindow/mainwindow.cpp
+++ b/GUI/coregui/mainwindow/mainwindow.cpp
@@ -218,7 +218,7 @@ void MainWindow::initViews()
     m_tabWidget->setTabToolTip(SAMPLE, QStringLiteral("Build the sample"));
 
     m_tabWidget->insertTab(IMPORT, m_importDataView, QIcon(":/images/main_importview.svg"),
-                           "Import");
+                           "Data");
     m_tabWidget->setTabToolTip(IMPORT, QStringLiteral("Import intensity data to fit"));
 
     m_tabWidget->insertTab(SIMULATION, m_simulationView, QIcon(":/images/main_simulationview.svg"),


### PR DESCRIPTION
 - This Pull Request implements Feature #2365 (http://apps.jcns.fz-juelich.de/redmine/issues/2365):
>This button gives access to the "Import 2D" and "Import 1D"
buttons, but also to the imported data display. Therefore,
"Data" is the more comprehensive name.