### PR TITLE
Bug Fix: GUI crashes with masks and 90deg beam inclination

### DIFF
--- a/Core/Instrument/IntensityDataFunctions.cpp
+++ b/Core/Instrument/IntensityDataFunctions.cpp
@@ -26,6 +26,7 @@
 #include "SimulationResult.h"
 #include "UnitConverterUtils.h"
 #include <math.h>
+#include <limits.h>
 
 //! Returns sum of relative differences between each pair of elements:
 //! (a, b) -> 2*abs(a - b)/(|a| + |b|)      ( and zero if  a=b=0 within epsilon )
@@ -173,10 +174,29 @@ IntensityDataFunctions::createClippedDataSet(const OutputData<double>& origin, d
 
 double IntensityDataFunctions::coordinateToBinf(double coordinate, const IAxis& axis)
 {
+    double result(0);
     size_t index = axis.findClosestIndex(coordinate);
     Bin1D bin = axis.getBin(index);
-    double f = (coordinate - bin.m_lower) / bin.getBinSize();
-    return static_cast<double>(index) + f;
+    double binSize = bin.getBinSize();
+
+    double numerator = (coordinate - bin.m_lower);
+    double denominator = binSize;
+
+    double f(0);
+    if(fabs(numerator) <= std::numeric_limits<double>::epsilon()){
+        f = 0;
+    }else if(fabs(denominator) <= std::numeric_limits<double>::epsilon()){
+        throw Exceptions::DivisionByZeroException(
+            "IntensityDataFunctions::coordinateToBinf() -> "
+            "Error! division by zero bin size.");
+    }
+    else{
+        f = numerator / denominator;
+    }
+
+
+    result = static_cast<double>(index) + f;
+    return result;
 }
 
 double IntensityDataFunctions::coordinateFromBinf(double value, const IAxis& axis)

--- a/Core/Vector/BasicVector3D.cpp
+++ b/Core/Vector/BasicVector3D.cpp
@@ -25,10 +25,23 @@ typedef std::complex<double> complex_t;
 BasicVector3D<double> vecOfLambdaAlphaPhi(double _lambda, double _alpha, double _phi)
 {
     double k = M_TWOPI/_lambda;
-    return BasicVector3D<double>(
-        k*std::cos(_alpha) * std::cos(_phi),
-        -k*std::cos(_alpha) * std::sin(_phi),
-        k*std::sin(_alpha) );
+    double vx(0);
+    double vy(0);
+    double vz(0);
+
+    if(fabs(fabs(_alpha) - M_PI_2) < 1.e-14){
+        _alpha = _alpha > 0 ? M_PI_2 - 1.e-14 : - M_PI_2 + 1.e-14;
+    }
+
+    if(fabs(fabs(_phi) - M_PI_2) < 1.e-14){
+        _phi = _phi > 0 ? M_PI_2 - 1.e-14 : - M_PI_2 + 1.e-14;
+    }
+
+    vx = k*std::cos(_alpha) * std::cos(_phi);
+    vy = -k*std::cos(_alpha) * std::sin(_phi);
+    vz = k*std::sin(_alpha);
+
+    return BasicVector3D<double>(vx,vy,vz);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
This pull request fixes the Bug #2347 (http://apps.jcns.fz-juelich.de/redmine/issues/2347):

> Reproduce:
Load bug.pro in attachment
In import view: change units to qspace and back
In instrument view: set background to none

Beware: This pull request uses two tricks that are a bit dirty, namely, 

1. On 0/0 division, return zero, 
2. On cos(+/- 90deg) return cos(+/- (90 - 1e-14) deg)

The more correct approach would be to prevent users to use 90 deg. as beam inclination angle, as the Cartesian-Polar coordinate transformation becomes singular at the poles. The only reason not to take this approach is simply because writing 90deg looks prettier than writing 89.9999. In the end, it depends on how much precision is actually required.