### PR TITLE
Enable uncertainties and the new objective metrics

### DIFF
--- a/Core/Fitting/FitObjective.cpp
+++ b/Core/Fitting/FitObjective.cpp
@@ -140,29 +140,9 @@ std::vector<double> FitObjective::weights_array() const
     return composeArray(&SimDataPair::user_weights_array);
 }
 
-SimulationResult FitObjective::simulationResult(size_t i_item) const
+const SimDataPair& FitObjective::dataPair(size_t i_item) const
 {
-    return m_fit_objects[check_index(i_item)].simulationResult();
-}
-
-SimulationResult FitObjective::experimentalData(size_t i_item) const
-{
-    return m_fit_objects[check_index(i_item)].experimentalData();
-}
-
-SimulationResult FitObjective::uncertaintyData(size_t i_item) const
-{
-    return m_fit_objects[check_index(i_item)].uncertainties();
-}
-
-SimulationResult FitObjective::relativeDifference(size_t i_item) const
-{
-    return m_fit_objects[check_index(i_item)].relativeDifference();
-}
-
-SimulationResult FitObjective::absoluteDifference(size_t i_item) const
-{
-    return m_fit_objects[check_index(i_item)].absoluteDifference();
+    return m_fit_objects[check_index(i_item)];
 }
 
 void FitObjective::initPrint(int every_nth)

--- a/Core/Fitting/FitObjective.cpp
+++ b/Core/Fitting/FitObjective.cpp
@@ -204,6 +204,12 @@ void FitObjective::setChiSquaredModule(const IChiSquaredModule& module)
     m_metric_module = std::make_unique<ChiModuleWrapper>(std::move(chi_module));
 }
 
+void FitObjective::setObjectiveMetric(const std::string& metric, const std::string& norm)
+{
+    m_metric_module =
+        std::make_unique<ObjectiveMetricWrapper>(ObjectiveMetric::createMetric(metric, norm));
+}
+
 std::vector<double> FitObjective::composeArray(DataPairAccessor getter) const
 {
     const size_t n_objs = m_fit_objects.size();

--- a/Core/Fitting/FitObjective.cpp
+++ b/Core/Fitting/FitObjective.cpp
@@ -83,7 +83,7 @@ void FitObjective::addSimulationAndData(PyBuilderCallback& callback,
                                         const std::vector<double>& data,
                                         double weight)
 {
-    addSimulationAndData(simulationBuilder(callback), *ArrayUtils::createData1D(data), nullptr,
+    addSimulationAndData(simulationBuilder(callback), *ArrayUtils::createData(data), nullptr,
                          weight);
 }
 
@@ -91,7 +91,7 @@ void FitObjective::addSimulationAndData(PyBuilderCallback& callback,
                                         const std::vector<std::vector<double>>& data,
                                         double weight)
 {
-    addSimulationAndData(simulationBuilder(callback), *ArrayUtils::createData2D(data), nullptr,
+    addSimulationAndData(simulationBuilder(callback), *ArrayUtils::createData(data), nullptr,
                          weight);
 }
 

--- a/Core/Fitting/FitObjective.h
+++ b/Core/Fitting/FitObjective.h
@@ -76,25 +76,8 @@ public:
     //! The area outside of the region of interest is not included, masked data is nullified.
     std::vector<double> weights_array() const;
 
-    //! Returns simulation result.
-    //! @param i_item: the index of fit pair
-    SimulationResult simulationResult(size_t i_item = 0) const;
-
-    //! Returns experimental data.
-    //! @param i_item: the index of fit pair
-    SimulationResult experimentalData(size_t i_item = 0) const;
-
-    //! Returns experimental data uncertainties.
-    //! @param i_item: the index of fit pair
-    SimulationResult uncertaintyData(size_t i_item = 0) const;
-
-    //! Returns relative difference between simulation and experimental data.
-    //! @param i_item: the index of fit pair
-    SimulationResult relativeDifference(size_t i_item = 0) const;
-
-    //! Returns absolute value of difference between simulation and experimental data.
-    //! @param i_item: the index of fit pair
-    SimulationResult absoluteDifference(size_t i_item = 0) const;
+    //! Returns a reference to i-th SimDataPair.
+    const SimDataPair& dataPair(size_t i_item = 0) const;
 
     //! Initializes printing to standard output during the fitting.
     //! @param every_nth: Print every n'th iteration.

--- a/Core/Fitting/FitObjective.h
+++ b/Core/Fitting/FitObjective.h
@@ -39,20 +39,38 @@ public:
     FitObjective();
     virtual ~FitObjective();
 
-    //! Constructs simulation/data pair for later fit.
-    //! @param simulation: simulation builder capable of producing simulations
-    //! @param data: experimental data
-    //! @param weight: weight of dataset in chi2 calculations
 #ifndef SWIG
+    //! Constructs simulation/data pair for later fit.
+    //! @param builder: simulation builder capable of producing simulations
+    //! @param data: experimental data array
+    //! @param uncertainties: data uncertainties array
+    //! @param weight: weight of dataset in metric calculations
     void addSimulationAndData(simulation_builder_t builder, const OutputData<double>& data,
                               std::unique_ptr<OutputData<double>> uncertainties,
                               double weight = 1.0);
 #endif
+    //! Constructs simulation/data pair for later fit.
+    //! @param callback: simulation builder capable of producing simulations
+    //! @param data: experimental data array
+    //! @param weight: weight of dataset in metric calculations
     template <class T>
     void addSimulationAndData(PyBuilderCallback& callback, const T& data, double weight = 1.0)
     {
         addSimulationAndData(simulationBuilder(callback), *ArrayUtils::createData(data), nullptr,
                              weight);
+    }
+
+    //! Constructs simulation/data pair for later fit.
+    //! @param callback: simulation builder capable of producing simulations
+    //! @param data: experimental data array
+    //! @param uncertainties: data uncertainties array
+    //! @param weight: weight of dataset in metric calculations
+    template <class T>
+    void addSimulationAndData(PyBuilderCallback& callback, const T& data, const T& uncertainties,
+                              double weight = 1.0)
+    {
+        addSimulationAndData(simulationBuilder(callback), *ArrayUtils::createData(data),
+                             ArrayUtils::createData(uncertainties), weight);
     }
 
     virtual double evaluate(const Fit::Parameters& params);

--- a/Core/Fitting/FitObjective.h
+++ b/Core/Fitting/FitObjective.h
@@ -22,11 +22,11 @@
 #include "OutputData.h"
 #include "SimDataPair.h"
 
+class FitStatus;
 class IChiSquaredModule;
+class IMetricWrapper;
 class PyBuilderCallback;
 class PyObserverCallback;
-class FitStatus;
-class IMetricWrapper;
 
 //! Holds vector of `SimDataPair`s (experimental data and simulation results) for use in fitting.
 //! @ingroup fitting_internal
@@ -129,6 +129,11 @@ public:
     void run_simulations(const Fit::Parameters& params);
 
     void setChiSquaredModule(const IChiSquaredModule& module);
+
+    //! Sets objective metric to the FitObjective.
+    //! @param metric: metric name
+    //! @param norm: metric norm name (defaults to "l2")
+    void setObjectiveMetric(const std::string& metric, const std::string& norm = "l2");
 
 private:
     typedef std::vector<double> (SimDataPair::*DataPairAccessor)() const;

--- a/Core/Fitting/FitObjective.h
+++ b/Core/Fitting/FitObjective.h
@@ -16,10 +16,11 @@
 #define FITOBJECTIVE_H
 
 #include "FitTypes.h"
-#include "OutputData.h"
-#include "SimDataPair.h"
+#include "ArrayUtils.h"
 #include "IterationInfo.h"
 #include "MinimizerResult.h"
+#include "OutputData.h"
+#include "SimDataPair.h"
 
 class IChiSquaredModule;
 class PyBuilderCallback;
@@ -32,8 +33,9 @@ class IMetricWrapper;
 
 class BA_CORE_API_ FitObjective
 {
-public:
+    static simulation_builder_t simulationBuilder(PyBuilderCallback& callback);
 
+public:
     FitObjective();
     virtual ~FitObjective();
 
@@ -46,13 +48,12 @@ public:
                               std::unique_ptr<OutputData<double>> uncertainties,
                               double weight = 1.0);
 #endif
-    void addSimulationAndData(PyBuilderCallback& callback,
-                              const std::vector<double>& data,
-                              double weight = 1.0);
-
-    void addSimulationAndData(PyBuilderCallback& callback,
-                              const std::vector<std::vector<double>>& data,
-                              double weight = 1.0);
+    template <class T>
+    void addSimulationAndData(PyBuilderCallback& callback, const T& data, double weight = 1.0)
+    {
+        addSimulationAndData(simulationBuilder(callback), *ArrayUtils::createData(data), nullptr,
+                             weight);
+    }
 
     virtual double evaluate(const Fit::Parameters& params);
 

--- a/Core/Fitting/ObjectiveMetric.cpp
+++ b/Core/Fitting/ObjectiveMetric.cpp
@@ -23,6 +23,18 @@ const double double_max = std::numeric_limits<double>::max();
 const double double_min = std::numeric_limits<double>::min();
 const double ln10 = std::log(10.0);
 
+const std::map<std::string, std::function<std::unique_ptr<ObjectiveMetric>()>> metric_factory = {
+    {"Chi2", []() { return std::make_unique<Chi2Metric>(); }},
+    {"PoissonLike", []() { return std::make_unique<PoissonLikeMetric>(); }},
+    {"Log", []() { return std::make_unique<LogMetric>(); }},
+    {"RelativeDifference", []() { return std::make_unique<RelativeDifferenceMetric>(); }},
+    {"RQ4", []() { return std::make_unique<RQ4Metric>(); }}
+};
+
+const std::map<std::string, std::function<double(double)>> norm_factory = {
+    {"l1", ObjectiveMetric::l1_norm}, {"l2", ObjectiveMetric::l2_norm}
+};
+
 template<class T>
 T* copyMetric(const T& metric)
 {
@@ -64,6 +76,29 @@ const std::function<double(double)> ObjectiveMetric::l1_norm = [](double term) {
 const std::function<double(double)> ObjectiveMetric::l2_norm = [](double term) {
     return term * term;
 };
+
+std::unique_ptr<ObjectiveMetric> ObjectiveMetric::createMetric(const std::string& metric,
+                                                               const std::string& norm)
+{
+    const auto metric_iter = metric_factory.find(metric);
+    const auto norm_iter = norm_factory.find(norm);
+    if (metric_iter == metric_factory.end() || norm_iter == norm_factory.end()) {
+        std::stringstream ss;
+        ss << "Error in ObjectiveMetric::createMetric: either metric (" << metric << ") or norm ("
+           << norm << ") name is unknown.\n";
+        ss << "Available metrics:\n";
+        for (auto& item: metric_factory)
+            ss << "\t" << item.first << "\n";
+        ss << "Available norms:\n";
+        for (auto& item: norm_factory)
+            ss << "\t" << item.first << "\n";
+        throw std::runtime_error(ss.str());
+    }
+
+    auto result = metric_iter->second();
+    result->setNorm(norm_iter->second);
+    return result;
+}
 
 ObjectiveMetric::ObjectiveMetric(std::function<double(double)> norm)
     : m_norm(std::move(norm))

--- a/Core/Fitting/ObjectiveMetric.cpp
+++ b/Core/Fitting/ObjectiveMetric.cpp
@@ -128,6 +128,37 @@ double Chi2Metric::computeFromArrays(std::vector<double> sim_data, std::vector<d
     return std::isfinite(result) ? result : double_max;
 }
 
+// ----------------------- Poisson-like metric ---------------------------
+
+PoissonLikeMetric::PoissonLikeMetric()
+    : Chi2Metric()
+{}
+
+PoissonLikeMetric* PoissonLikeMetric::clone() const
+{
+    return copyMetric<PoissonLikeMetric>(*this);
+}
+
+double PoissonLikeMetric::computeFromArrays(std::vector<double> sim_data,
+                                            std::vector<double> exp_data,
+                                            std::vector<double> weight_factors) const
+{
+    checkIntegrity(sim_data, exp_data, weight_factors);
+
+    double result = 0.0;
+    auto norm_fun = norm();
+    for (size_t i = 0, sim_size = sim_data.size(); i < sim_size; ++i)
+    {
+        if (weight_factors[i] <= 0.0 || exp_data[i] < 0.0)
+            continue;
+        const double variance = std::max(1.0, sim_data[i]);
+        const double value = (sim_data[i] - exp_data[i]) / std::sqrt(variance);
+        result += norm_fun(value) * weight_factors[i];
+    }
+
+    return std::isfinite(result) ? result : double_max;
+}
+
 // ----------------------- Log metric ---------------------------
 
 LogMetric::LogMetric()

--- a/Core/Fitting/ObjectiveMetric.cpp
+++ b/Core/Fitting/ObjectiveMetric.cpp
@@ -236,7 +236,7 @@ double RelativeDifferenceMetric::computeFromArrays(std::vector<double> sim_data,
             continue;
         const double sim_val = std::max(double_min, sim_data[i]);
         const double exp_val = std::max(double_min, exp_data[i]);
-        result += norm_fun((exp_val / sim_val - 1.0)) * weight_factors[i];
+        result += norm_fun((exp_val - sim_val) / (exp_val + sim_val)) * weight_factors[i];
     }
 
     return std::isfinite(result) ? result : double_max;

--- a/Core/Fitting/ObjectiveMetric.cpp
+++ b/Core/Fitting/ObjectiveMetric.cpp
@@ -24,7 +24,7 @@ const double double_min = std::numeric_limits<double>::min();
 const double ln10 = std::log(10.0);
 
 template<class T>
-T* copyMetric(const ObjectiveMetric& metric)
+T* copyMetric(const T& metric)
 {
     std::unique_ptr<T> result(new T());
     result->setNorm(metric.norm());
@@ -96,7 +96,7 @@ Chi2Metric::Chi2Metric()
 
 Chi2Metric* Chi2Metric::clone() const
 {
-    return copyMetric<Chi2Metric>(*this);
+    return copyMetric(*this);
 }
 
 double Chi2Metric::computeFromArrays(std::vector<double> sim_data, std::vector<double> exp_data,
@@ -123,7 +123,7 @@ double Chi2Metric::computeFromArrays(std::vector<double> sim_data, std::vector<d
     double result = 0.0;
     for (size_t i = 0, sim_size = sim_data.size(); i < sim_size; ++i)
         if (exp_data[i] >= 0.0 && weight_factors[i] > 0.0)
-            result += norm_fun((exp_data[i] - sim_data[i])) * weight_factors[i];
+            result += norm_fun(exp_data[i] - sim_data[i]) * weight_factors[i];
 
     return std::isfinite(result) ? result : double_max;
 }
@@ -136,7 +136,7 @@ PoissonLikeMetric::PoissonLikeMetric()
 
 PoissonLikeMetric* PoissonLikeMetric::clone() const
 {
-    return copyMetric<PoissonLikeMetric>(*this);
+    return copyMetric(*this);
 }
 
 double PoissonLikeMetric::computeFromArrays(std::vector<double> sim_data,
@@ -167,7 +167,7 @@ LogMetric::LogMetric()
 
 LogMetric* LogMetric::clone() const
 {
-    return copyMetric<LogMetric>(*this);
+    return copyMetric(*this);
 }
 
 double LogMetric::computeFromArrays(std::vector<double> sim_data, std::vector<double> exp_data,
@@ -219,7 +219,7 @@ RelativeDifferenceMetric::RelativeDifferenceMetric()
 
 RelativeDifferenceMetric* RelativeDifferenceMetric::clone() const
 {
-    return copyMetric<RelativeDifferenceMetric>(*this);
+    return copyMetric(*this);
 }
 
 double RelativeDifferenceMetric::computeFromArrays(std::vector<double> sim_data,
@@ -250,7 +250,7 @@ RQ4Metric::RQ4Metric()
 
 RQ4Metric* RQ4Metric::clone() const
 {
-    return copyMetric<RQ4Metric>(*this);
+    return copyMetric(*this);
 }
 
 double RQ4Metric::compute(const SimDataPair& data_pair, bool use_weights) const

--- a/Core/Fitting/ObjectiveMetric.h
+++ b/Core/Fitting/ObjectiveMetric.h
@@ -17,6 +17,7 @@
 
 #include "ICloneable.h"
 #include <functional>
+#include <memory>
 #include <vector>
 
 class SimDataPair;
@@ -29,6 +30,9 @@ public:
     static const std::function<double(double)> l1_norm;
     //! L2 normalization function.
     static const std::function<double(double)> l2_norm;
+
+    static std::unique_ptr<ObjectiveMetric> createMetric(const std::string& metric,
+                                                         const std::string& norm);
 
     ObjectiveMetric(std::function<double(double)> norm);
 

--- a/Core/Fitting/ObjectiveMetric.h
+++ b/Core/Fitting/ObjectiveMetric.h
@@ -70,8 +70,9 @@ private:
     std::function<double(double)> m_norm; //! normalization function.
 };
 
-//! Implementation of the standard \f$ \chi^2 \f$ metric. With default L2 norm corresponds to the
-//! formula
+//! Implementation of the standard \f$ \chi^2 \f$ metric
+//! derived from maximum likelihood with Gaussian uncertainties.
+//! With default L2 norm corresponds to the formula
 //! \f[\chi^2 = \sum \frac{(I - D)^2}{\delta_D^2}\f]
 class BA_CORE_API_ Chi2Metric : public ObjectiveMetric
 {
@@ -90,6 +91,32 @@ public:
     double computeFromArrays(std::vector<double> sim_data, std::vector<double> exp_data,
                              std::vector<double> uncertainties,
                              std::vector<double> weight_factors) const override;
+
+    //! Computes metric value from data arrays. Negative values in exp_data
+    //! are ignored as well as non-positive weight_factors.
+    //! All arrays involved in the computation must be of the same size.
+    //! @param sim_data: array with simulated intensities.
+    //! @param exp_data: array with intensity values obtained from an experiment.
+    //! @param weight_factors: user-defined weighting factors. Used linearly, no matter which norm
+    //! is chosen.
+    double computeFromArrays(std::vector<double> sim_data, std::vector<double> exp_data,
+                             std::vector<double> weight_factors) const override;
+};
+
+//! Implementation of \f$ \chi^2 \f$ metric
+//! with standard deviation\f$\sigma = max(\sqrt{I}, 1)\f$,
+//! where \f$I\f$ is the simulated intensity.
+//! With default L2 norm corresponds to the formula
+//! \f[\chi^2 = \sum \frac{(I - D)^2}{max(I, 1)}\f]
+//! for unweighted experimental data. Falls to standard
+//! Chi2Metric when data uncertainties are taken into account.
+class BA_CORE_API_ PoissonLikeMetric : public Chi2Metric
+{
+public:
+    PoissonLikeMetric();
+    PoissonLikeMetric* clone() const override;
+
+    using Chi2Metric::computeFromArrays;
 
     //! Computes metric value from data arrays. Negative values in exp_data
     //! are ignored as well as non-positive weight_factors.

--- a/Core/Fitting/ObjectiveMetric.h
+++ b/Core/Fitting/ObjectiveMetric.h
@@ -165,9 +165,9 @@ public:
 
 //! Implementation of relative difference metric.
 //! With default L2 norm and weighting off corresponds to the formula
-//! \f[Result = \sum \frac{(I - D)^2}{I^2}\f]
-//! where \f$I\f$ is the simulated intensity. If weighting is on,
-//! coincides with the metric provided by Chi2Metric class.
+//! \f[Result = \sum \frac{(I - D)^2}{(I + D)^2}\f]
+//! where \f$I\f$ is the simulated intensity, \f$D\f$ - experimental data.
+//! If weighting is on, falls back to the standard \f$\chi^2\f$ metric.
 class BA_CORE_API_ RelativeDifferenceMetric : public Chi2Metric
 {
 public:

--- a/Core/InputOutput/OutputDataReadStrategy.cpp
+++ b/Core/InputOutput/OutputDataReadStrategy.cpp
@@ -163,7 +163,7 @@ OutputData<double>* OutputDataReadNumpyTXTStrategy::readOutputData(std::istream&
     }
 
     if(nrows < 2){
-        return ArrayUtils::createData1D(std::move(data[0])).release();
+        return ArrayUtils::createData(std::move(data[0])).release();
     }
     else if(ncols < 2){
         const size_t size = data.size();
@@ -171,10 +171,10 @@ OutputData<double>* OutputDataReadNumpyTXTStrategy::readOutputData(std::istream&
         for(size_t i = 0; i < size; ++i){
             vector1d[i] = data[i][0];
         }
-        return ArrayUtils::createData1D(std::move(vector1d)).release();
+        return ArrayUtils::createData(std::move(vector1d)).release();
     }
     else{
-        return ArrayUtils::createData2D(data).release();
+        return ArrayUtils::createData(data).release();
     }
 }
 

--- a/Core/Instrument/ArrayUtils.h
+++ b/Core/Instrument/ArrayUtils.h
@@ -25,34 +25,100 @@
 
 namespace ArrayUtils
 {
-
 //! Returns shape nrows, ncols of 2D array.
 template<class T> std::pair<size_t, size_t> getShape(const T& data);
+
+class CreateDataImpl {
+    //! Holds the dimensionality of template argument as the enum value.
+    //! Intended for vectors only.
+    template <typename T> struct nDim { enum { value = 0 }; };
+    template <typename T, typename A> struct nDim<std::vector<T, A>> {
+        enum { value = 1 + nDim<T>::value };
+    };
+
+    template <typename T> struct baseClass { using value = T; };
+    template <typename T, typename A> struct baseClass<std::vector<T, A>> {
+        using value = typename baseClass<T>::value;
+    };
+
+    template<class T>
+    using ReturnType = std::unique_ptr<OutputData<typename CreateDataImpl::baseClass<T>::value>>;
+
+    template <class T> friend ReturnType<T> createData(const T& vec);
+
+    template<class T>
+    static std::unique_ptr<OutputData<T>> createDataImpl(const std::vector<T>& vec);
+
+    template<class T>
+    static std::unique_ptr<OutputData<T>> createDataImpl(const std::vector<std::vector<T>>& vec);
+};
+
+//! Creates OutputData array from input vector.
+//! @param vec: input vector
+template<class T>
+CreateDataImpl::ReturnType<T> createData(const T& vec)
+{
+    constexpr const int size = CreateDataImpl::nDim<T>::value;
+    static_assert(size == 1 || size == 2,
+        "Error in ArrayUtils::createData: invalid dimensionality or type of the input argument");
+    static_assert(std::is_same<CreateDataImpl::ReturnType<T>,
+                               decltype(CreateDataImpl::createDataImpl(vec))>::value,
+                  "Error in ArrayUtils::createData: invalid return type.");
+    return CreateDataImpl::createDataImpl(vec);
+}
 
 #ifdef BORNAGAIN_PYTHON
 PyObject* createNumpyArray(const std::vector<double>& data);
 #endif // BORNAGAIN_PYTHON
-
-//! Creates OutputData from 1D vector.
-//! @param vec: std::vector<double>
-//! @return std::unique_ptr<OutputData<double>>
-template<class T> decltype(auto) createData1D(const T& vec);
 
 //! Creates 1D vector from OutputData.
 //! @param vec: OutputData<double>
 //! @return vector<double>
 template<class T> decltype(auto) createVector1D(const T& data);
 
-//! Creates OutputData from 2D vector.
-//! @param vec: std::vector<std::vector<double>>
-//! @return std::unique_ptr<OutputData<double>>
-template<class T> decltype(auto) createData2D(const T& vec);
-
 //! Creates 2D vector from OutputData.
 //! @param vec: OutputData<double>
 //! @return vector<vector<double>>
 template<class T> decltype(auto) createVector2D(const T& data);
 
+}
+
+template<class T>
+std::unique_ptr<OutputData<T>> ArrayUtils::CreateDataImpl::createDataImpl(const std::vector<T>& vec)
+{
+    auto result = std::make_unique<OutputData<T>>();
+    const size_t length = vec.size();
+    result->addAxis(FixedBinAxis("axis0", length, 0.0, static_cast<double>(length)));
+    result->setRawDataVector(vec);
+    return result;
+}
+
+template <class T>
+std::unique_ptr<OutputData<T>>
+ArrayUtils::CreateDataImpl::createDataImpl(const std::vector<std::vector<T>>& vec)
+{
+    auto result = std::make_unique<OutputData<T>>();
+
+    auto shape = ArrayUtils::getShape(vec);
+    const size_t nrows = shape.first;
+    const size_t ncols = shape.second;
+
+    if(nrows == 0 || ncols == 0)
+        throw std::runtime_error(
+            "Error in ArrayUtils::createDataImpl: input argument contains empty dimensions");
+
+    result->addAxis(FixedBinAxis("axis0", ncols, 0.0, static_cast<double>(ncols)));
+    result->addAxis(FixedBinAxis("axis1", nrows, 0.0, static_cast<double>(nrows)));
+
+    // filling the data
+    for(size_t row=0; row<nrows; ++row) {
+        for(size_t col=0; col<ncols; ++col) {
+            size_t globalbin = nrows - row - 1 + col*nrows;
+            (*result)[globalbin] = vec[row][col];
+        }
+    }
+
+    return result;
 }
 
 template<class T>  std::pair<size_t, size_t> ArrayUtils::getShape(const T& data){
@@ -66,17 +132,6 @@ template<class T>  std::pair<size_t, size_t> ArrayUtils::getShape(const T& data)
     return std::make_pair(nrows, ncols);
 }
 
-
-template<class T> decltype(auto) ArrayUtils::createData1D(const T& vec)
-{
-    using value_type = typename T::value_type;
-    std::unique_ptr<OutputData<value_type>> result(new OutputData<value_type>());
-    const size_t length = vec.size();
-    result->addAxis(FixedBinAxis("axis0", length, 0.0, static_cast<double>(length)));
-    result->setRawDataVector(vec);
-    return result;
-}
-
 template<class T> decltype(auto) ArrayUtils::createVector1D(const T& data)
 {
     if (data.getRank() != 1)
@@ -84,33 +139,6 @@ template<class T> decltype(auto) ArrayUtils::createVector1D(const T& data)
 
     using value_type = typename T::value_type;
     std::vector<value_type> result = data.getRawDataVector();
-    return result;
-}
-
-template<class T> decltype(auto) ArrayUtils::createData2D(const T& vec)
-{
-    using value_type = typename T::value_type::value_type;
-    std::unique_ptr<OutputData<value_type>> result(new OutputData<value_type>());
-
-    auto shape = ArrayUtils::getShape(vec);
-    const size_t nrows = shape.first;
-    const size_t ncols = shape.second;
-
-    if(nrows == 0 || ncols == 0)
-        throw Exceptions::LogicErrorException("ArrayUtils::createData2D() -> Error. "
-                                              "Not a two-dimensional array");
-
-    result->addAxis(FixedBinAxis("axis0", ncols, 0.0, static_cast<double>(ncols)));
-    result->addAxis(FixedBinAxis("axis1", nrows, 0.0, static_cast<double>(nrows)));
-
-    // filling the data
-    for(size_t row=0; row<nrows; ++row) {
-        for(size_t col=0; col<ncols; ++col) {
-            size_t globalbin = nrows - row - 1 + col*nrows;
-            (*result)[globalbin] = vec[row][col];
-        }
-    }
-
     return result;
 }
 

--- a/Core/Instrument/IntensityDataFunctions.cpp
+++ b/Core/Instrument/IntensityDataFunctions.cpp
@@ -321,6 +321,6 @@ SimulationResult IntensityDataFunctions::ConvertData(const Simulation& simulatio
                                                      const std::vector<std::vector<double>>& data,
                                                      bool put_masked_areas_to_zero)
 {
-    auto output_data = ArrayUtils::createData2D(data);
+    auto output_data = ArrayUtils::createData(data);
     return IntensityDataFunctions::ConvertData(simulation, *output_data, put_masked_areas_to_zero);
 }

--- a/Core/Instrument/PyArrayImportUtils.cpp
+++ b/Core/Instrument/PyArrayImportUtils.cpp
@@ -3,10 +3,11 @@
 
 OutputData<double>* PyArrayImport::importArrayToOutputData(const std::vector<double>& vec)
 {
-    return ArrayUtils::createData1D(vec).release();
+    return ArrayUtils::createData(vec).release();
 }
 
-OutputData<double>* PyArrayImport::importArrayToOutputData(const std::vector<std::vector<double>>& vec)
+OutputData<double>*
+PyArrayImport::importArrayToOutputData(const std::vector<std::vector<double>>& vec)
 {
-    return ArrayUtils::createData2D(vec).release();
+    return ArrayUtils::createData(vec).release();
 }

--- a/GUI/coregui/Views/FitWidgets/GUIFitObserver.cpp
+++ b/GUI/coregui/Views/FitWidgets/GUIFitObserver.cpp
@@ -51,7 +51,7 @@ void GUIFitObserver::update(const FitObjective* subject)
     if (subject->isCompleted())
         info.m_log_info = subject->minimizerResult().toString();
 
-    std::unique_ptr<OutputData<double>> data(subject->simulationResult().data());
+    std::unique_ptr<OutputData<double>> data(subject->dataPair().simulationResult().data());
     info.m_sim_values = data->getRawDataVector();
 
     m_iteration_info = info;

--- a/Tests/Functional/Fit/FitObjective/FitPlanCases.cpp
+++ b/Tests/Functional/Fit/FitObjective/FitPlanCases.cpp
@@ -95,7 +95,7 @@ std::unique_ptr<Simulation> RectDetPlan::createSimulation(const Parameters&) con
 // ----------------------------------------------------------------------------
 
 SpecularPlan::SpecularPlan()
-    : FitPlan("SpecularPlan", /*residual_based = */ true)
+    : FitPlan("SpecularPlan")
 {
     setSimulationName("BasicSpecular");
     setBuilderName("PlainMultiLayerBySLDBuilder");
@@ -108,7 +108,7 @@ SpecularPlan::~SpecularPlan() = default;
 // ----------------------------------------------------------------------------
 
 SpecularPlanQ::SpecularPlanQ()
-    : FitPlan("SpecularPlanQ", /*residual_based = */ true)
+    : FitPlan("SpecularPlanQ")
 {
     setSimulationName("BasicSpecularQ");
     setBuilderName("PlainMultiLayerBySLDBuilder");
@@ -121,7 +121,7 @@ SpecularPlanQ::~SpecularPlanQ() = default;
 // ----------------------------------------------------------------------------
 
 MultipleSpecPlan::MultipleSpecPlan()
-    : FitPlan("MultipleSpecPlan", /*residual_based = */ true)
+    : FitPlan("MultipleSpecPlan")
 {
     setSimulationName("BasicSpecular");
     setBuilderName("PlainMultiLayerBySLDBuilder");
@@ -149,7 +149,7 @@ std::unique_ptr<FitObjective> MultipleSpecPlan::createFitObjective() const
 // ----------------------------------------------------------------------------
 
 OffSpecFitPlan::OffSpecFitPlan()
-    : FitPlan("OffSpecFitPlan", /*residual_based*/true)
+    : FitPlan("OffSpecFitPlan")
 {
     setBuilderName("ResonatorBuilder");
     setSimulationName("OffSpecMini");

--- a/Tests/Functional/GUI/GUISpecial/CsvImportAssistantPerformanceTest.cpp
+++ b/Tests/Functional/GUI/GUISpecial/CsvImportAssistantPerformanceTest.cpp
@@ -28,7 +28,7 @@ void CsvImportAssistantPerformanceTest::writeTestFile()
 {
     remove(m_testFilename.c_str());
     OutputDataWriter* writer = OutputDataWriteFactory::getWriter(m_testFilename);
-    OutputData<double>* data = ArrayUtils::createData2D(m_testVector).release();
+    OutputData<double>* data = ArrayUtils::createData(m_testVector).release();
     writer->writeOutputData(*data);
 }
 

--- a/Tests/UnitTests/Core/DataStructure/ArrayUtilsTest.cpp
+++ b/Tests/UnitTests/Core/DataStructure/ArrayUtilsTest.cpp
@@ -17,7 +17,7 @@ TEST_F(ArrayUtilsTest, OutputDataFromVector1D)
 {
     // double
     const std::vector<double> vec_double = {10.0, 20.0, 30.0, 40.0};
-    auto data1 = ArrayUtils::createData1D(vec_double);
+    auto data1 = ArrayUtils::createData(vec_double);
 
     EXPECT_EQ(data1->getAllocatedSize(), vec_double.size());
     EXPECT_EQ(data1->getRawDataVector(), vec_double);
@@ -26,7 +26,7 @@ TEST_F(ArrayUtilsTest, OutputDataFromVector1D)
 
     // int
     const std::vector<int> vec_int = {10, 20, 30};
-    auto data2 = ArrayUtils::createData1D(vec_int);
+    auto data2 = ArrayUtils::createData(vec_int);
 
     EXPECT_EQ(data2->getAllocatedSize(), vec_int.size());
     EXPECT_EQ(data2->getRawDataVector(), vec_int);
@@ -54,7 +54,7 @@ TEST_F(ArrayUtilsTest, OutputDataFromVector2D)
         {4.0, 5.0, 6.0,  7.0},
         {8.0, 9.0, 10.0, 11.0}
     };
-    auto data = ArrayUtils::createData2D(vec_double);
+    auto data = ArrayUtils::createData(vec_double);
 
     EXPECT_EQ(data->getRank(), 2u);
     EXPECT_EQ(data->getAllocatedSize(), 12u);

--- a/Tests/UnitTests/Core/Fitting/ObjectiveMetricTest.cpp
+++ b/Tests/UnitTests/Core/Fitting/ObjectiveMetricTest.cpp
@@ -81,6 +81,58 @@ TEST_F(ObjectiveMetricTest, Chi2IllFormed)
                      std::numeric_limits<double>::max());
 }
 
+TEST_F(ObjectiveMetricTest, PoissionLikeWellFormed)
+{
+    std::vector<double> sim_data{1.0, 2.0, 4.0, 4.0};
+    std::vector<double> exp_data{2.0, 1.0, 5.0, 3.0};
+    std::vector<double> weight_factors{1.0, 1.0, 1.0, 2.0};
+
+    PoissonLikeMetric metric;
+
+    EXPECT_DOUBLE_EQ(metric.computeFromArrays(sim_data, sim_data, weight_factors), 0.0);
+    EXPECT_DOUBLE_EQ(metric.computeFromArrays(sim_data, exp_data, weight_factors), 2.25);
+
+    std::vector<double> exp_data_1 = exp_data;
+    exp_data_1[0] = -1.0;
+    EXPECT_DOUBLE_EQ(metric.computeFromArrays(sim_data, exp_data_1, weight_factors), 1.25);
+
+    std::vector<double> sim_data_1 = sim_data;
+    sim_data_1[0] = 0.0;
+    EXPECT_DOUBLE_EQ(metric.computeFromArrays(sim_data_1, exp_data, weight_factors), 5.25);
+
+    metric.setNorm(ObjectiveMetric::l1_norm);
+
+    std::vector<double> sim_data_2 = sim_data;
+    sim_data_2[1] = 1.0;
+    EXPECT_DOUBLE_EQ(metric.computeFromArrays(sim_data_2, exp_data, weight_factors), 2.5);
+
+    EXPECT_DOUBLE_EQ(metric.computeFromArrays({}, {}, {}, {}), 0.0);
+    EXPECT_DOUBLE_EQ(metric.computeFromArrays({}, {}, {}), 0.0);
+}
+
+TEST_F(ObjectiveMetricTest, PoissionLikeIllFormed)
+{
+    std::vector<double> sim_data {1.0, 2.0, 3.0, 4.0};
+    std::vector<double> exp_data {2.0, 1.0, 4.0, 3.0};
+    std::vector<double> weight_factors {1.0, 1.0, 1.0, 2.0};
+
+    PoissonLikeMetric metric;
+
+    EXPECT_THROW(metric.computeFromArrays({}, {}, {}, {1.0}), std::runtime_error);
+    EXPECT_THROW(metric.computeFromArrays({}, {}, {1.0}), std::runtime_error);
+    EXPECT_THROW(metric.computeFromArrays(sim_data, exp_data, {}, weight_factors),
+                 std::runtime_error);
+    EXPECT_THROW(metric.computeFromArrays({}, exp_data, weight_factors), std::runtime_error);
+
+    std::vector<double> sim_data_1 = sim_data;
+    sim_data_1[0] = -1.0;
+    EXPECT_THROW(metric.computeFromArrays(sim_data_1, exp_data, weight_factors),
+                 std::runtime_error);
+
+    std::vector<double> weight_factors_1(weight_factors.size(), 0.0);
+    EXPECT_DOUBLE_EQ(metric.computeFromArrays(sim_data, exp_data, weight_factors_1), 0.0);
+}
+
 TEST_F(ObjectiveMetricTest, LogWellFormed)
 {
     std::vector<double> sim_data {1.0, 10.0, 1.e+2, 1.e+4};

--- a/Tests/UnitTests/Core/Fitting/ObjectiveMetricTest.cpp
+++ b/Tests/UnitTests/Core/Fitting/ObjectiveMetricTest.cpp
@@ -212,19 +212,19 @@ TEST_F(ObjectiveMetricTest, RelativeDifferenceWellFormed)
     RelativeDifferenceMetric metric;
 
     EXPECT_DOUBLE_EQ(metric.computeFromArrays(sim_data, sim_data, weight_factors), 0.0);
-    EXPECT_DOUBLE_EQ(metric.computeFromArrays(sim_data, exp_data, weight_factors), 2.0);
+    EXPECT_DOUBLE_EQ(metric.computeFromArrays(sim_data, exp_data, weight_factors), 5.0 / 9.0);
 
     std::vector<double> exp_data_1 = exp_data;
     exp_data_1[0] = -1.0;
-    EXPECT_DOUBLE_EQ(metric.computeFromArrays(sim_data, exp_data_1, weight_factors), 1.0);
+    EXPECT_DOUBLE_EQ(metric.computeFromArrays(sim_data, exp_data_1, weight_factors), 4.0 / 9.0);
 
     std::vector<double> sim_data_1 = sim_data;
     sim_data_1[0] = 0.0;
     exp_data_1[0] = 0.0;
-    EXPECT_DOUBLE_EQ(metric.computeFromArrays(sim_data_1, exp_data_1, weight_factors), 1.0);
+    EXPECT_DOUBLE_EQ(metric.computeFromArrays(sim_data_1, exp_data_1, weight_factors), 4.0 / 9.0);
 
     metric.setNorm(ObjectiveMetric::l1_norm);
-    EXPECT_DOUBLE_EQ(metric.computeFromArrays(sim_data, exp_data, weight_factors), 3.0);
+    EXPECT_DOUBLE_EQ(metric.computeFromArrays(sim_data, exp_data, weight_factors), 5.0 / 3.0);
 
     EXPECT_DOUBLE_EQ(metric.computeFromArrays(sim_data, exp_data, uncertainties, weight_factors),
                      6.0);

--- a/Tests/UnitTests/GUI/TestCsvImportAssistant.cpp
+++ b/Tests/UnitTests/GUI/TestCsvImportAssistant.cpp
@@ -24,7 +24,7 @@ protected:
     {
         remove(m_testFilename.c_str());
         OutputDataWriter* writer = OutputDataWriteFactory::getWriter(m_testFilename);
-        OutputData<double>* data = ArrayUtils::createData2D(m_testVector).release();
+        OutputData<double>* data = ArrayUtils::createData(m_testVector).release();
         writer->writeOutputData(*data);
     }
 

--- a/Wrap/swig/extendCore.i
+++ b/Wrap/swig/extendCore.i
@@ -179,12 +179,29 @@ class ObserverCallbackWrapper(PyObserverCallback):
 
 %extend FitObjective {
 %pythoncode %{
-    def addSimulationAndData(self, callback, data, weight = 1.0):
+    def addSimulationAndData(self, callback, data, *args, **kwargs):
+        """
+        Sets simulation and experimental data to the fit objective.
+        Optionally accepts experimental data uncertainties and
+        user-defined dataset weight.
+
+        Arguments:
+
+        callback -- user-defined function returning fully-defined bornagain.Simulation object.
+        The function must use fit parameter dictionary as its input.
+
+        data -- numpy array with experimental data.
+
+        uncertainties -- numpy array with experimental data uncertainties.
+        Array shape must correspond to the shape of data. Optional argument.
+
+        weight -- user-defined weight of the dataset. If not specified, defaults to 1.0.
+        """
         if not hasattr(self, 'callback_container'):
             self.callback_container = []
         wrp = SimulationBuilderWrapper(callback)
         self.callback_container.append(wrp)
-        return self.addSimulationAndData_cpp(wrp, data, weight)
+        return self.addSimulationAndData_cpp(wrp, data, *args, **kwargs)
 
     def convert_params(self, params):
         """

--- a/Wrap/swig/extendCore.i
+++ b/Wrap/swig/extendCore.i
@@ -230,6 +230,35 @@ class ObserverCallbackWrapper(PyObserverCallback):
         self.wrp_plot_observer = ObserverCallbackWrapper(callback)
         return self.initPlot_cpp(every_nth, self.wrp_plot_observer)
 
+    def simulationResult(self, i=0):
+        """
+        Returns simulated values for i-th simulation-data pair
+        """
+        return self.dataPair(i).simulationResult();
+
+    def experimentalData(self, i=0):
+        """
+        Returns experimental values for i-th simulation-data pair
+        """
+        return self.dataPair(i).experimentalData();
+
+    def uncertaintyData(self, i=0):
+        """
+        Returns uncertainties for i-th simulation-data pair
+        """
+        return self.dataPair(i).uncertainties();
+
+    def relativeDifference(self, i=0):
+        """
+        Returns relative difference for i-th simulation-data pair
+        """
+        return self.dataPair(i).relativeDifference();
+
+    def absoluteDifference(self, i=0):
+        """
+        Returns absolute difference for i-th simulation-data pair
+        """
+        return self.dataPair(i).absoluteDifference();
 %}
 };
 

--- a/Wrap/swig/ignores.i
+++ b/Wrap/swig/ignores.i
@@ -41,6 +41,10 @@
 // ignored to avoid error (todo: check whether this is really necessary)
 %ignore Crystal::getTransformedLattice(const IRotation*) const;
 
+// ignored to prevent SimDataPair non-const methods being exposed to python API
+%ignore SimDataPair::SimDataPair;
+%ignore SimDataPair::runSimulation;
+
 // extra ignores for types and methods that shouldn't be visible in Python
 %ignore FormFactorDWBAPol;
 %ignore ISampleVisitor::visit(const FormFactorDWBAPol*);

--- a/Wrap/swig/libBornAgainCore.i
+++ b/Wrap/swig/libBornAgainCore.i
@@ -218,6 +218,7 @@
 #include "Rotations.h"
 #include "SampleBuilderFactory.h"
 #include "ScanResolution.h"
+#include "SimDataPair.h"
 #include "Simulation.h"
 #include "Simulation2D.h"
 #include "SimulationFactory.h"
@@ -469,6 +470,7 @@
 %include "Rotations.h"
 %include "ISelectionRule.h"
 %include "DepthProbeSimulation.h"
+%include "SimDataPair.h"
 %include "SpecularSimulation.h"
 %include "ThreadInfo.h"
 %template(SampleBuilderFactoryTemp) IFactory<std::string, IMultiLayerBuilder>;

--- a/Wrap/swig/libBornAgainCore.i
+++ b/Wrap/swig/libBornAgainCore.i
@@ -325,7 +325,11 @@
 %include "ChiSquaredModule.h"
 %include "FitOptions.h"
 %include "PyFittingCallbacks.h"
+
 %include "FitObjective.h"
+%template(addSimulationAndData) FitObjective::addSimulationAndData<std::vector<double>>;
+%template(addSimulationAndData) FitObjective::addSimulationAndData<std::vector<std::vector<double>>>;
+
 %include "MathFunctions.h"
 %include "IFactory.h"
 %include "IMultiLayerBuilder.h"

--- a/auto/Wrap/libBornAgainCore.py
+++ b/auto/Wrap/libBornAgainCore.py
@@ -6373,19 +6373,6 @@ class FitObjective(_object):
     __swig_destroy__ = _libBornAgainCore.delete_FitObjective
     __del__ = lambda self: None
 
-    def addSimulationAndData_cpp(self, *args):
-        """
-        addSimulationAndData_cpp(FitObjective self, PyBuilderCallback callback, vdouble1d_t data, double weight=1.0)
-        addSimulationAndData_cpp(FitObjective self, PyBuilderCallback callback, vdouble1d_t data)
-        addSimulationAndData_cpp(FitObjective self, PyBuilderCallback callback, vdouble2d_t data, double weight=1.0)
-        addSimulationAndData_cpp(FitObjective self, PyBuilderCallback callback, vdouble2d_t data)
-
-        void FitObjective::addSimulationAndData(PyBuilderCallback &callback, const std::vector< std::vector< double >> &data, double weight=1.0)
-
-        """
-        return _libBornAgainCore.FitObjective_addSimulationAndData_cpp(self, *args)
-
-
     def evaluate_cpp(self, params):
         """
         evaluate_cpp(FitObjective self, Parameters params) -> double
@@ -6457,88 +6444,12 @@ class FitObjective(_object):
         return _libBornAgainCore.FitObjective_weights_array(self)
 
 
-    def simulationResult(self, i_item=0):
+    def dataPair(self, i_item=0):
         """
-        simulationResult(FitObjective self, size_t i_item=0) -> SimulationResult
-        simulationResult(FitObjective self) -> SimulationResult
-
-        SimulationResult FitObjective::simulationResult(size_t i_item=0) const
-
-        Returns simulation result.
-
-        Parameters:
-        -----------
-
-        i_item: 
-        the index of fit pair 
-
+        dataPair(FitObjective self, size_t i_item=0) -> SimDataPair
+        dataPair(FitObjective self) -> SimDataPair
         """
-        return _libBornAgainCore.FitObjective_simulationResult(self, i_item)
-
-
-    def experimentalData(self, i_item=0):
-        """
-        experimentalData(FitObjective self, size_t i_item=0) -> SimulationResult
-        experimentalData(FitObjective self) -> SimulationResult
-
-        SimulationResult FitObjective::experimentalData(size_t i_item=0) const
-
-        Returns experimental data.
-
-        Parameters:
-        -----------
-
-        i_item: 
-        the index of fit pair 
-
-        """
-        return _libBornAgainCore.FitObjective_experimentalData(self, i_item)
-
-
-    def uncertaintyData(self, i_item=0):
-        """
-        uncertaintyData(FitObjective self, size_t i_item=0) -> SimulationResult
-        uncertaintyData(FitObjective self) -> SimulationResult
-        """
-        return _libBornAgainCore.FitObjective_uncertaintyData(self, i_item)
-
-
-    def relativeDifference(self, i_item=0):
-        """
-        relativeDifference(FitObjective self, size_t i_item=0) -> SimulationResult
-        relativeDifference(FitObjective self) -> SimulationResult
-
-        SimulationResult FitObjective::relativeDifference(size_t i_item=0) const
-
-        Returns relative difference between simulation and experimental data.
-
-        Parameters:
-        -----------
-
-        i_item: 
-        the index of fit pair 
-
-        """
-        return _libBornAgainCore.FitObjective_relativeDifference(self, i_item)
-
-
-    def absoluteDifference(self, i_item=0):
-        """
-        absoluteDifference(FitObjective self, size_t i_item=0) -> SimulationResult
-        absoluteDifference(FitObjective self) -> SimulationResult
-
-        SimulationResult FitObjective::absoluteDifference(size_t i_item=0) const
-
-        Returns absolute value of difference between simulation and experimental data.
-
-        Parameters:
-        -----------
-
-        i_item: 
-        the index of fit pair 
-
-        """
-        return _libBornAgainCore.FitObjective_absoluteDifference(self, i_item)
+        return _libBornAgainCore.FitObjective_dataPair(self, i_item)
 
 
     def initPrint(self, every_nth):
@@ -6671,12 +6582,54 @@ class FitObjective(_object):
         return _libBornAgainCore.FitObjective_setChiSquaredModule(self, module)
 
 
-    def addSimulationAndData(self, callback, data, weight = 1.0):
+    def setObjectiveMetric(self, *args):
+        """
+        setObjectiveMetric(FitObjective self, std::string const & metric, std::string const & norm)
+        setObjectiveMetric(FitObjective self, std::string const & metric)
+        """
+        return _libBornAgainCore.FitObjective_setObjectiveMetric(self, *args)
+
+
+    def addSimulationAndData_cpp(self, *args):
+        """
+        addSimulationAndData_cpp(FitObjective self, PyBuilderCallback callback, vdouble1d_t data, double weight=1.0)
+        addSimulationAndData_cpp(FitObjective self, PyBuilderCallback callback, vdouble1d_t data)
+        addSimulationAndData_cpp(FitObjective self, PyBuilderCallback callback, vdouble1d_t data, vdouble1d_t uncertainties, double weight=1.0)
+        addSimulationAndData_cpp(FitObjective self, PyBuilderCallback callback, vdouble1d_t data, vdouble1d_t uncertainties)
+        addSimulationAndData_cpp(FitObjective self, PyBuilderCallback callback, vdouble2d_t data, double weight=1.0)
+        addSimulationAndData_cpp(FitObjective self, PyBuilderCallback callback, vdouble2d_t data)
+        addSimulationAndData_cpp(FitObjective self, PyBuilderCallback callback, vdouble2d_t data, vdouble2d_t uncertainties, double weight=1.0)
+        addSimulationAndData_cpp(FitObjective self, PyBuilderCallback callback, vdouble2d_t data, vdouble2d_t uncertainties)
+
+        void FitObjective::addSimulationAndData(PyBuilderCallback &callback, const std::vector< std::vector< double >> &data, double weight=1.0)
+
+        """
+        return _libBornAgainCore.FitObjective_addSimulationAndData_cpp(self, *args)
+
+
+    def addSimulationAndData(self, callback, data, *args, **kwargs):
+        """
+        Sets simulation and experimental data to the fit objective.
+        Optionally accepts experimental data uncertainties and
+        user-defined dataset weight.
+
+        Arguments:
+
+        callback -- user-defined function returning fully-defined bornagain.Simulation object.
+        The function must use fit parameter dictionary as its input.
+
+        data -- numpy array with experimental data.
+
+        uncertainties -- numpy array with experimental data uncertainties.
+        Array shape must correspond to the shape of data. Optional argument.
+
+        weight -- user-defined weight of the dataset. If not specified, defaults to 1.0.
+        """
         if not hasattr(self, 'callback_container'):
             self.callback_container = []
         wrp = SimulationBuilderWrapper(callback)
         self.callback_container.append(wrp)
-        return self.addSimulationAndData_cpp(wrp, data, weight)
+        return self.addSimulationAndData_cpp(wrp, data, *args, **kwargs)
 
     def convert_params(self, params):
         """
@@ -6722,6 +6675,35 @@ class FitObjective(_object):
         self.wrp_plot_observer = ObserverCallbackWrapper(callback)
         return self.initPlot_cpp(every_nth, self.wrp_plot_observer)
 
+    def simulationResult(self, i=0):
+        """
+        Returns simulated values for i-th simulation-data pair
+        """
+        return self.dataPair(i).simulationResult();
+
+    def experimentalData(self, i=0):
+        """
+        Returns experimental values for i-th simulation-data pair
+        """
+        return self.dataPair(i).experimentalData();
+
+    def uncertaintyData(self, i=0):
+        """
+        Returns uncertainties for i-th simulation-data pair
+        """
+        return self.dataPair(i).uncertainties();
+
+    def relativeDifference(self, i=0):
+        """
+        Returns relative difference for i-th simulation-data pair
+        """
+        return self.dataPair(i).relativeDifference();
+
+    def absoluteDifference(self, i=0):
+        """
+        Returns absolute difference for i-th simulation-data pair
+        """
+        return self.dataPair(i).absoluteDifference();
 
     def __disown__(self):
         self.this.disown()
@@ -28835,6 +28817,136 @@ class DepthProbeSimulation(Simulation):
 
 DepthProbeSimulation_swigregister = _libBornAgainCore.DepthProbeSimulation_swigregister
 DepthProbeSimulation_swigregister(DepthProbeSimulation)
+
+class SimDataPair(_object):
+    """
+
+
+    Holds pair of simulation/experimental data to fit.
+
+    C++ includes: SimDataPair.h
+
+    """
+
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, SimDataPair, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, SimDataPair, name)
+
+    def __init__(self, *args, **kwargs):
+        raise AttributeError("No constructor defined")
+    __repr__ = _swig_repr
+    __swig_destroy__ = _libBornAgainCore.delete_SimDataPair
+    __del__ = lambda self: None
+
+    def containsUncertainties(self):
+        """containsUncertainties(SimDataPair self) -> bool"""
+        return _libBornAgainCore.SimDataPair_containsUncertainties(self)
+
+
+    def numberOfFitElements(self):
+        """
+        numberOfFitElements(SimDataPair self) -> size_t
+
+        size_t SimDataPair::numberOfFitElements() const
+
+        Returns the size of the data. It is equal to the number of non-masked detector channels which will participate in chi2 calculations. 
+
+        """
+        return _libBornAgainCore.SimDataPair_numberOfFitElements(self)
+
+
+    def simulationResult(self):
+        """
+        simulationResult(SimDataPair self) -> SimulationResult
+
+        SimulationResult SimDataPair::simulationResult() const
+
+        Returns simulation result. 
+
+        """
+        return _libBornAgainCore.SimDataPair_simulationResult(self)
+
+
+    def experimentalData(self):
+        """
+        experimentalData(SimDataPair self) -> SimulationResult
+
+        SimulationResult SimDataPair::experimentalData() const
+
+        Returns experimental data. 
+
+        """
+        return _libBornAgainCore.SimDataPair_experimentalData(self)
+
+
+    def uncertainties(self):
+        """uncertainties(SimDataPair self) -> SimulationResult"""
+        return _libBornAgainCore.SimDataPair_uncertainties(self)
+
+
+    def userWeights(self):
+        """userWeights(SimDataPair self) -> SimulationResult"""
+        return _libBornAgainCore.SimDataPair_userWeights(self)
+
+
+    def relativeDifference(self):
+        """
+        relativeDifference(SimDataPair self) -> SimulationResult
+
+        SimulationResult SimDataPair::relativeDifference() const
+
+        Returns relative difference between simulation and experimental data. 
+
+        """
+        return _libBornAgainCore.SimDataPair_relativeDifference(self)
+
+
+    def absoluteDifference(self):
+        """
+        absoluteDifference(SimDataPair self) -> SimulationResult
+
+        SimulationResult SimDataPair::absoluteDifference() const
+
+        """
+        return _libBornAgainCore.SimDataPair_absoluteDifference(self)
+
+
+    def simulation_array(self):
+        """
+        simulation_array(SimDataPair self) -> vdouble1d_t
+
+        std::vector< double > SimDataPair::simulation_array() const
+
+        Returns one dimensional array representing simulated intensities data. Masked areas and the area outside of region of interest are not included. 
+
+        """
+        return _libBornAgainCore.SimDataPair_simulation_array(self)
+
+
+    def experimental_array(self):
+        """
+        experimental_array(SimDataPair self) -> vdouble1d_t
+
+        std::vector< double > SimDataPair::experimental_array() const
+
+        Returns one dimensional array representing experimental data. Masked areas and the area outside of region of interest are not included. 
+
+        """
+        return _libBornAgainCore.SimDataPair_experimental_array(self)
+
+
+    def uncertainties_array(self):
+        """uncertainties_array(SimDataPair self) -> vdouble1d_t"""
+        return _libBornAgainCore.SimDataPair_uncertainties_array(self)
+
+
+    def user_weights_array(self):
+        """user_weights_array(SimDataPair self) -> vdouble1d_t"""
+        return _libBornAgainCore.SimDataPair_user_weights_array(self)
+
+SimDataPair_swigregister = _libBornAgainCore.SimDataPair_swigregister
+SimDataPair_swigregister(SimDataPair)
 
 class SpecularSimulation(Simulation):
     """

--- a/auto/Wrap/libBornAgainCore.py
+++ b/auto/Wrap/libBornAgainCore.py
@@ -6440,6 +6440,11 @@ class FitObjective(_object):
         return _libBornAgainCore.FitObjective_simulation_array(self)
 
 
+    def uncertainties(self):
+        """uncertainties(FitObjective self) -> vdouble1d_t"""
+        return _libBornAgainCore.FitObjective_uncertainties(self)
+
+
     def weights_array(self):
         """
         weights_array(FitObjective self) -> vdouble1d_t
@@ -6488,6 +6493,14 @@ class FitObjective(_object):
 
         """
         return _libBornAgainCore.FitObjective_experimentalData(self, i_item)
+
+
+    def uncertaintyData(self, i_item=0):
+        """
+        uncertaintyData(FitObjective self, size_t i_item=0) -> SimulationResult
+        uncertaintyData(FitObjective self) -> SimulationResult
+        """
+        return _libBornAgainCore.FitObjective_uncertaintyData(self, i_item)
 
 
     def relativeDifference(self, i_item=0):


### PR DESCRIPTION
Further steps to undertake:

1. Switch GUI to the new machinery
2. Extend default python plotter for reflectometry to show uncertainties
3. Write an example of usage