### PR TITLE
Fix off-spec simulations with rectangular detector

### DIFF
--- a/Core/Simulation/OffSpecSimulation.cpp
+++ b/Core/Simulation/OffSpecSimulation.cpp
@@ -72,7 +72,7 @@ void OffSpecSimulation::setBeamParameters(double wavelength, const IAxis& alpha_
         throw Exceptions::ClassInitializationException(
                 "OffSpecSimulation::prepareSimulation() "
                 "-> Error. Incoming alpha range size < 1.");
-    const double alpha_zero = 0.0;
+    const double alpha_zero = alpha_axis.getMin();
     m_instrument.setBeamParameters(wavelength, alpha_zero, phi_i);
     updateIntensityMap();
 }
@@ -114,12 +114,11 @@ void OffSpecSimulation::initSimulationElementVector()
     Beam beam = m_instrument.getBeam();
     const double wavelength = beam.getWavelength();
     const double phi_i = beam.getPhi();
-    const double alpha_shift = beam.getAlpha();
 
     for (size_t i = 0; i < mP_alpha_i_axis->size(); ++i) {
         // Incoming angle by convention defined as positive:
         double alpha_i = mP_alpha_i_axis->getBin(i).getMidPoint();
-        double total_alpha = alpha_i + alpha_shift;
+        double total_alpha = alpha_i;
         beam.setCentralK(wavelength, total_alpha, phi_i);
         auto sim_elements_i = generateSimulationElements(beam);
         m_sim_elements.insert(m_sim_elements.end(), std::make_move_iterator(sim_elements_i.begin()),

--- a/Core/Simulation/OffSpecSimulation.cpp
+++ b/Core/Simulation/OffSpecSimulation.cpp
@@ -192,14 +192,6 @@ void OffSpecSimulation::checkInitialization() const
     if (m_instrument.getDetectorDimension()!=2)
         throw Exceptions::RuntimeErrorException(
             "OffSpecSimulation::checkInitialization: detector is not two-dimensional");
-    const IAxis& phi_axis = m_instrument.getDetectorAxis(0);
-    if (phi_axis.getName()!=BornAgain::PHI_AXIS_NAME)
-        throw Exceptions::RuntimeErrorException(
-            "OffSpecSimulation::checkInitialization: phi-axis is not correct");
-    const IAxis& alpha_axis = m_instrument.getDetectorAxis(1);
-    if (alpha_axis.getName()!=BornAgain::ALPHA_AXIS_NAME)
-        throw Exceptions::RuntimeErrorException(
-            "OffSpecSimulation::checkInitialization: alpha-axis is not correct");
 }
 
 void OffSpecSimulation::initialize()

--- a/GUI/coregui/Models/InstrumentItems.cpp
+++ b/GUI/coregui/Models/InstrumentItems.cpp
@@ -259,6 +259,13 @@ OffSpecInstrumentItem::OffSpecInstrumentItem()
     : Instrument2DItem(Constants::OffSpecInstrumentType)
 {
     addAxisGroupProperty(this, P_ALPHA_AXIS);
+    auto inclination_item = getItem(P_ALPHA_AXIS)->getItem(BasicAxisItem::P_MIN);
+    auto beam_item = beamItem();
+    beam_item->setInclinationAngle(inclination_item->value().toDouble());
+    beam_item->getItem(BeamItem::P_INCLINATION_ANGLE)->setEnabled(false);
+    inclination_item->mapper()->setOnValueChange([beam_item, inclination_item]() {
+        beam_item->setInclinationAngle(inclination_item->value().toDouble());
+    });
 }
 
 std::vector<int> OffSpecInstrumentItem::shape() const


### PR DESCRIPTION
This PR resolves [issue](http://apps.jcns.fz-juelich.de/redmine/issues/2329) and enables off-spec simulations with non-zero starting inclinations.