### PR TITLE
Add missing python examples

### DIFF
--- a/Core/Basics/Exceptions.cpp
+++ b/Core/Basics/Exceptions.cpp
@@ -46,18 +46,6 @@ ClassInitializationException::ClassInitializationException(const std::string& me
      LogExceptionMessage(message);
 }
 
-SelfReferenceException::SelfReferenceException(const std::string& message)
-    : std::logic_error(message)
-{
-     LogExceptionMessage(message);
-}
-
-DeadReferenceException::DeadReferenceException(const std::string& message)
-    : std::runtime_error(message)
-{
-     LogExceptionMessage(message);
-}
-
 UnknownClassRegistrationException::UnknownClassRegistrationException(const std::string& message)
     : std::runtime_error(message)
 {

--- a/Core/Basics/Exceptions.h
+++ b/Core/Basics/Exceptions.h
@@ -54,18 +54,6 @@ public:
     ClassInitializationException(const std::string& message);
 };
 
-class BA_CORE_API_ SelfReferenceException : public std::logic_error
-{
-public:
-    SelfReferenceException(const std::string& message);
-};
-
-class BA_CORE_API_ DeadReferenceException : public std::runtime_error
-{
-public:
-    DeadReferenceException(const std::string& message);
-};
-
 class BA_CORE_API_ UnknownClassRegistrationException : public std::runtime_error
 {
 public:

--- a/Core/InputOutput/IntensityDataIOFactory.cpp
+++ b/Core/InputOutput/IntensityDataIOFactory.cpp
@@ -17,18 +17,13 @@
 #include "OutputDataReadFactory.h"
 #include "OutputDataWriteFactory.h"
 #include "SimulationResult.h"
-
+#include "FileSystemUtils.h"
 #include <fstream>
 #include <memory>
 
-namespace {
-bool FileExists(const std::string& filename);
-}
-
-
 OutputData<double>* IntensityDataIOFactory::readOutputData(const std::string& file_name)
 {
-    if (!FileExists(file_name))
+    if (!FileSystemUtils::IsFileExists(file_name))
         return nullptr;
     std::unique_ptr<OutputDataReader> P_reader(OutputDataReadFactory::getReader(file_name));
     if (P_reader)
@@ -38,7 +33,7 @@ OutputData<double>* IntensityDataIOFactory::readOutputData(const std::string& fi
 
 OutputData<double>* IntensityDataIOFactory::readReflectometryData(const std::string& file_name)
 {
-    if (!FileExists(file_name))
+    if (!FileSystemUtils::IsFileExists(file_name))
         return nullptr;
     std::unique_ptr<OutputDataReader> P_reader(OutputDataReadFactory::getReflectometryReader(file_name));
     if (P_reader)
@@ -72,11 +67,4 @@ void IntensityDataIOFactory::writeSimulationResult(const SimulationResult& resul
 {
     std::unique_ptr<OutputData<double>> P_data(result.data());
     writeOutputData(*P_data, file_name);
-}
-
-namespace {
-bool FileExists(const std::string& filename) {
-    std::ifstream fs(filename);
-    return fs.is_open();
-}
 }

--- a/Core/InputOutput/OutputDataReader.cpp
+++ b/Core/InputOutput/OutputDataReader.cpp
@@ -24,6 +24,7 @@
 #include "boost_streams.h"
 #endif
 #include <fstream>
+#include "FileSystemUtils.h"
 
 OutputDataReader::OutputDataReader(const std::string& file_name)
     : m_file_name(file_name)
@@ -41,7 +42,12 @@ OutputData<double>* OutputDataReader::getOutputData()
     if(isTiffFile(m_file_name) || isCompressed(m_file_name))
         openmode = std::ios::in | std::ios_base::binary;
 
-    fin.open(m_file_name.c_str(), openmode );
+#ifdef _WIN32
+    fin.open(FileSystemUtils::convert_utf8_to_utf16(m_file_name), openmode);
+#else
+    fin.open(m_file_name, openmode);
+#endif
+
     if(!fin.is_open())
         throw Exceptions::FileNotIsOpenException(
             "OutputDataReader::getOutputData() -> Error. Can't open file '"

--- a/Core/InputOutput/OutputDataWriter.cpp
+++ b/Core/InputOutput/OutputDataWriter.cpp
@@ -24,6 +24,7 @@
 #include "boost_streams.h"
 #endif
 #include <fstream>
+#include "FileSystemUtils.h"
 
 OutputDataWriter::OutputDataWriter(const std::string& file_name)
     : m_file_name(file_name)
@@ -36,13 +37,18 @@ void OutputDataWriter::writeOutputData(const OutputData<double>& data)
     if(!m_write_strategy)
         throw Exceptions::NullPointerException("OutputDataWriter::getOutputData() ->"
                                                " Error! No read strategy defined");
+
     std::ofstream fout;
     std::ios_base::openmode openmode = std::ios::out;
     if(isTiffFile(m_file_name) || isCompressed(m_file_name))
         openmode = std::ios::out | std::ios_base::binary;
 
+#ifdef _WIN32
+    fout.open(FileSystemUtils::convert_utf8_to_utf16(m_file_name), openmode);
+#else
+    fout.open(m_file_name, openmode);
+#endif
 
-    fout.open(m_file_name.c_str(), openmode );
     if(!fout.is_open())
         throw Exceptions::FileNotIsOpenException("OutputDataWriter::writeOutputData() -> Error. "
                                                  "Can't open file '"+m_file_name+"' for writing.");

--- a/Core/Tools/FileSystemUtils.cpp
+++ b/Core/Tools/FileSystemUtils.cpp
@@ -18,6 +18,8 @@
 #include <regex>
 #include <cassert>
 #include <stdexcept>
+#include <codecvt>
+#include <locale>
 
 std::string FileSystemUtils::extension(const std::string& path)
 {
@@ -33,12 +35,22 @@ std::string FileSystemUtils::extensions(const std::string& path)
 
 bool FileSystemUtils::createDirectory(const std::string& dir_name)
 {
+#ifdef _WIN32
+    boost::filesystem::path path(convert_utf8_to_utf16(dir_name));
+#else
+    boost::filesystem::path path(dir_name);
+#endif
     return boost::filesystem::create_directory(dir_name);
 }
 
 bool FileSystemUtils::createDirectories(const std::string& dir_name)
 {
-    return boost::filesystem::create_directories(dir_name);
+#ifdef _WIN32
+    boost::filesystem::path path(convert_utf8_to_utf16(dir_name));
+#else
+    boost::filesystem::path path(dir_name);
+#endif
+    return boost::filesystem::create_directories(path);
 }
 
 std::vector<std::string> FileSystemUtils::filesInDirectory(const std::string& dir_name)
@@ -94,3 +106,19 @@ std::string FileSystemUtils::stem_ext(const std::string& path)
     return npos != std::string::npos ? name.substr(0, npos) : std::string();
 }
 
+
+std::wstring FileSystemUtils::convert_utf8_to_utf16(const std::string& str)
+{
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+    return converter.from_bytes(str);
+}
+
+bool FileSystemUtils::IsFileExists(const std::string& str)
+{
+#ifdef _WIN32
+    boost::filesystem::path path(convert_utf8_to_utf16(str));
+#else
+    boost::filesystem::path path(str);
+#endif
+    return boost::filesystem::exists(path);
+}

--- a/Core/Tools/FileSystemUtils.h
+++ b/Core/Tools/FileSystemUtils.h
@@ -57,6 +57,12 @@ BA_CORE_API_ std::string stem_ext(const std::string& path);
 //! Returns file names that agree with a regex glob pattern.
 BA_CORE_API_ std::vector<std::string> glob(const std::string& dir, const std::string& pattern);
 
+//! Converts utf8 string represented by std::string to utf16 string represented by std::wstring.
+BA_CORE_API_ std::wstring convert_utf8_to_utf16(const std::string& str);
+
+//! Returns true if file with given name exists on disk.
+BA_CORE_API_ bool IsFileExists(const std::string& str);
+
 } // namespace FileSystemUtils
 
 #endif // FILESYSTEMUTILS_H

--- a/Examples/python/simulation/ex06_Reflectometry/FootprintCorrection.py
+++ b/Examples/python/simulation/ex06_Reflectometry/FootprintCorrection.py
@@ -1,0 +1,92 @@
+"""
+Specular simulation with a footprint correction
+for a square beam
+
+"""
+from matplotlib import pyplot as plt
+import bornagain as ba
+from bornagain import deg, angstrom
+
+
+def get_sample():
+    """
+    Defines sample and returns it
+    """
+
+    # creating materials
+    m_ambient = ba.MaterialBySLD("Ambient", 0.0, 0.0)
+    m_ti = ba.MaterialBySLD("Ti", -1.9493e-06, 0.0)
+    m_ni = ba.MaterialBySLD("Ni", 9.4245e-06, 0.0)
+    m_substrate = ba.MaterialBySLD("SiSubstrate", 2.0704e-06, 0.0)
+
+    # creating layers
+    ambient_layer = ba.Layer(m_ambient)
+    ti_layer = ba.Layer(m_ti, 30 * angstrom)
+    ni_layer = ba.Layer(m_ni, 70 * angstrom)
+    substrate_layer = ba.Layer(m_substrate)
+
+    # creating multilayer
+    multi_layer = ba.MultiLayer()
+    multi_layer.addLayer(ambient_layer)
+    for i in range(10):
+        multi_layer.addLayer(ti_layer)
+        multi_layer.addLayer(ni_layer)
+    multi_layer.addLayer(substrate_layer)
+
+    return multi_layer
+
+
+def get_simulation(footprint):
+    """
+    Defines and returns a specular simulation.
+    """
+    simulation = ba.SpecularSimulation()
+    scan = ba.AngularSpecScan(
+        1.54 * angstrom, 500 , 0.0 * deg, 0.6 * deg)
+    scan.setFootprintFactor(footprint)
+    simulation.setScan(scan)
+    return simulation
+
+
+def run_simulation(simulation):
+    """
+    Runs simulation and returns its result.
+    """
+    simulation.setSample(get_sample())
+    simulation.runSimulation()
+    return simulation.result()
+
+
+def get_plot_data(sim_result):
+    data = sim_result.data()
+    intensity = data.getArray()
+    x_axis = data.getAxis(0).getBinCenters()
+    return x_axis, intensity
+
+
+def plot(sim_result_1, sim_result_2):
+    """
+    Plots results from two different simulations
+    """
+
+    plt.semilogy(*get_plot_data(sim_result_1), *get_plot_data(sim_result_2))
+
+    plt.xlabel(r'$\alpha_i \; (deg)$', fontsize=16)
+    plt.ylabel(r'Intensity', fontsize=16)
+
+    plt.legend(['With footprint',
+                'Without footprint'],
+                loc='upper right')
+
+    plt.show()
+
+
+if __name__ == '__main__':
+    beam_sample_ratio = 0.01  # beam-to-sample size ratio
+    result_with_fp = run_simulation(
+        get_simulation(
+            footprint=ba.FootprintFactorSquare(beam_sample_ratio)
+        )
+    )
+    result_without_fp = run_simulation(get_simulation(footprint=None))
+    plot(result_with_fp, result_without_fp)

--- a/Examples/python/simulation/ex06_Reflectometry/SpecularSimulationWithRoughness.py
+++ b/Examples/python/simulation/ex06_Reflectometry/SpecularSimulationWithRoughness.py
@@ -1,0 +1,66 @@
+"""
+Example of simulating a reflectometry experiment
+with a rough sample using BornAgain.
+
+"""
+import bornagain as ba
+from bornagain import deg, angstrom, nm
+
+
+def get_sample():
+    """
+    Defines sample and returns it
+    """
+
+    # creating materials
+    m_ambient = ba.MaterialBySLD("Ambient", 0.0, 0.0)
+    m_ti = ba.MaterialBySLD("Ti", -1.9493e-06, 0.0)
+    m_ni = ba.MaterialBySLD("Ni", 9.4245e-06, 0.0)
+    m_substrate = ba.MaterialBySLD("SiSubstrate", 2.0704e-06, 0.0)
+
+    # creating layers
+    ambient_layer = ba.Layer(m_ambient)
+    ti_layer = ba.Layer(m_ti, 30 * angstrom)
+    ni_layer = ba.Layer(m_ni, 70 * angstrom)
+    substrate_layer = ba.Layer(m_substrate)
+
+    # defining roughness
+    roughness = ba.LayerRoughness()
+    roughness.setSigma(1.0 * nm)
+
+    # creating multilayer
+    multi_layer = ba.MultiLayer()
+    multi_layer.addLayer(ambient_layer)
+    for i in range(10):
+        multi_layer.addLayerWithTopRoughness(ti_layer, roughness)
+        multi_layer.addLayerWithTopRoughness(ni_layer, roughness)
+    multi_layer.addLayerWithTopRoughness(substrate_layer, roughness)
+
+    return multi_layer
+
+
+def get_simulation(scan_size=500):
+    """
+    Defines and returns a specular simulation.
+    """
+    simulation = ba.SpecularSimulation()
+    scan = ba.AngularSpecScan(1.54 * angstrom, scan_size,
+                              0.0 * deg, 2.0 * deg)
+    simulation.setScan(scan)
+    return simulation
+
+
+def run_simulation():
+    """
+    Runs simulation and returns its result.
+    """
+    sample = get_sample()
+    simulation = get_simulation()
+    simulation.setSample(sample)
+    simulation.runSimulation()
+    return simulation.result()
+
+
+if __name__ == '__main__':
+    results = run_simulation()
+    ba.plot_simulation_result(results)

--- a/Examples/python/simulation/ex07_Miscellaneous/PolarizedSANS.py
+++ b/Examples/python/simulation/ex07_Miscellaneous/PolarizedSANS.py
@@ -1,0 +1,80 @@
+"""
+Simple example demonstrating how polarized SANS experiments can be
+simulated with BornAgain.
+"""
+
+import bornagain as ba
+from bornagain import deg, nm, kvector_t
+
+# Magnetization of the particle's core material (A/m)
+magnetization_core = kvector_t(0.0, 0.0, 1e7)
+
+
+def get_sample():
+    """
+    Returns a sample with a magnetic core-shell particle in a solvent.
+    """
+    # Defining Materials
+    mat_solvent = ba.HomogeneousMaterial("Solvent", 5e-6, 0.0)
+    mat_core = ba.HomogeneousMaterial("Core", 6e-6, 2e-8,
+                                      magnetization_core)
+    mat_shell = ba.HomogeneousMaterial("Shell", 1e-7, 2e-8)
+
+    # Defining Layer
+    solvent_layer = ba.Layer(mat_solvent)
+
+    # Defining particle layout with a core-shell particle
+    layout = ba.ParticleLayout()
+    core_sphere_ff = ba.FormFactorFullSphere(10*nm)
+    shell_sphere_ff = ba.FormFactorFullSphere(12*nm)
+    core = ba.Particle(mat_core, core_sphere_ff)
+    shell = ba.Particle(mat_shell, shell_sphere_ff)
+    position = kvector_t(0.0, 0.0, 2.0)
+    particleCoreShell = ba.ParticleCoreShell(shell, core, position)
+    layout.addParticle(particleCoreShell)
+
+    # Adding layout to layer
+    solvent_layer.addLayout(layout)
+
+    # Defining Multilayer with single layer
+    multiLayer = ba.MultiLayer()
+    multiLayer.addLayer(solvent_layer)
+    return multiLayer
+
+
+def get_simulation():
+    """
+    Returns a polarized SANS simulation
+    """
+    simulation = ba.GISASSimulation()
+
+    # Defining detector
+    simulation.setDetectorParameters(200, -3.0*deg, 3.0*deg, 200, -3.0*deg, 3.0*deg)
+
+    # Defining beam parameters
+    simulation.setBeamParameters(0.5*nm, 0.0*deg, 0.0*deg)
+    simulation.setBeamIntensity(1e12)
+
+    # Defining beam polarization and polarization analysis for spin-flip channel
+    analyzer_dir = kvector_t(0.0, 0.0, -1.0)
+    beampol = kvector_t(0.0, 0.0, 1.0)
+    simulation.setBeamPolarization(beampol)
+    simulation.setAnalyzerProperties(analyzer_dir, 1.0, 0.5)
+
+    return simulation
+
+
+def run_simulation():
+    """
+    Runs simulation and returns intensity map.
+    """
+    simulation = get_simulation()
+    simulation.setSample(get_sample())
+    simulation.runSimulation()
+    return simulation.result()
+
+
+if __name__ == '__main__': 
+    result = run_simulation()
+    ba.plot_simulation_result(result, cmap='jet', units=ba.AxesUnits.QSPACE,
+                              aspect='auto')

--- a/Fit/RootAdapter/MinimizerResultUtils.cpp
+++ b/Fit/RootAdapter/MinimizerResultUtils.cpp
@@ -58,11 +58,11 @@ std::string MinimizerResultUtils::reportParameters(const Fit::Parameters& parame
 
     result << MinimizerUtils::sectionString("FitParameters");
 
-    result << "Name       StartValue  Limits                        FitValue     Error"
-           << std::endl;
+    result << "Name                       StartValue  Limits                        FitValue"
+           << "     Error" << std::endl;
 
     for (const auto& par : parameters) {
-        result << boost::format("# %-8s %-8.3e   %-28s  %-8.3e    %8.3e \n") % par.name()
+        result << boost::format("%-26.26s %-8.3e   %-28s  %-8.3e    %8.3e \n") % par.name()
                       % par.startValue() % par.limits().toString() % par.value() % par.error();
     }
 

--- a/Tests/Functional/Core/CoreSpecial/CMakeLists.txt
+++ b/Tests/Functional/Core/CoreSpecial/CMakeLists.txt
@@ -4,7 +4,7 @@ set(test_cases
     BatchSimulation
     PolDWBAMagCylinders
     FourierTransformation
-#    CoreIO
+#    CoreIOPerformance
 #    DetectorTest
 #    MesoPerformance
 )

--- a/Tests/Functional/Core/CoreSpecial/CMakeLists.txt
+++ b/Tests/Functional/Core/CoreSpecial/CMakeLists.txt
@@ -7,6 +7,7 @@ set(test_cases
 #    CoreIOPerformance
 #    DetectorTest
 #    MesoPerformance
+#    CoreIOPath
 )
 
 # build executables for each test case

--- a/Tests/Functional/Core/CoreSpecial/CoreIOPathTest.cpp
+++ b/Tests/Functional/Core/CoreSpecial/CoreIOPathTest.cpp
@@ -1,0 +1,27 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Tests/Functional/Core/CoreIO/CoreIOTest.h
+//! @brief     Defines CoreIOTest class
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#include "CoreIOPathTest.h"
+#include <iostream>
+
+CoreIOPathTest::CoreIOPathTest()
+{
+
+}
+
+bool CoreIOPathTest::runTest()
+{
+    std::cout << "Hello world" << std::endl;
+    return true;
+}

--- a/Tests/Functional/Core/CoreSpecial/CoreIOPathTest.cpp
+++ b/Tests/Functional/Core/CoreSpecial/CoreIOPathTest.cpp
@@ -13,15 +13,64 @@
 // ************************************************************************** //
 
 #include "CoreIOPathTest.h"
+#include "BATesting.h"
+#include "FileSystemUtils.h"
+#include "IntensityDataIOFactory.h"
+#include "OutputData.h"
+#include "TestUtils.h"
+#include <boost/filesystem.hpp>
 #include <iostream>
+#include <memory>
 
-CoreIOPathTest::CoreIOPathTest()
+namespace
 {
+std::unique_ptr<OutputData<double>> createTestData();
+bool test_io(const OutputData<double>* data, const std::string& file_name);
+} // namespace
 
-}
+CoreIOPathTest::CoreIOPathTest() = default;
 
 bool CoreIOPathTest::runTest()
 {
-    std::cout << "Hello world" << std::endl;
-    return true;
+    const auto data = createTestData();
+    const char filename_rus[] = "\xd0\xb4\xd0\xb0\xd0\xbd\xd0\xbd\xd1\x8b\xd0\xb5\x2e\x69\x6e\x74";
+    const char dirname_rus[] =
+        "\xd0\xb4\xd0\xb8\xd1\x80\xd0\xb5\xd0\xba\xd1\x82\xd0\xbe\xd1\x80\xd0\xb8\xd1\x8f";
+
+    const boost::filesystem::path test_dir(BATesting::CoreOutputDir());
+    const boost::filesystem::path test_subdir("test_CoreIOPathTest");
+
+    FileSystemUtils::createDirectories((test_dir / test_subdir).string());
+
+    // tests file writing when file name contains cyrillic characters
+    bool success(true);
+    boost::filesystem::path test_file(filename_rus);
+    success &= test_io(data.get(), (test_dir / test_subdir / test_file).string());
+
+    // tests file writing and directory creation when dirname contains cyrillic characters
+    boost::filesystem::path test_subdir_rus(dirname_rus);
+    FileSystemUtils::createDirectories((test_dir / test_subdir / test_subdir_rus).string());
+    success &= test_io(data.get(), (test_dir / test_subdir / test_subdir_rus / test_file).string());
+
+    return success;
 }
+
+namespace
+{
+std::unique_ptr<OutputData<double>> createTestData()
+{
+    std::unique_ptr<OutputData<double>> result(new OutputData<double>);
+    result->addAxis("x", 10, 0.0, 10.0);
+    for (size_t i = 0; i < result->getAllocatedSize(); ++i)
+        (*result)[i] = static_cast<double>(i);
+    return result;
+}
+
+bool test_io(const OutputData<double>* data, const std::string& file_name)
+{
+    IntensityDataIOFactory::writeOutputData(*data, file_name);
+    std::unique_ptr<OutputData<double>> loaded(IntensityDataIOFactory::readOutputData(file_name));
+    return TestUtils::isTheSame(*data, *loaded, 1e-06);
+}
+
+} // namespace

--- a/Tests/Functional/Core/CoreSpecial/CoreIOPathTest.h
+++ b/Tests/Functional/Core/CoreSpecial/CoreIOPathTest.h
@@ -1,0 +1,31 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Tests/Functional/Core/CoreIO/CoreIOTest.h
+//! @brief     Defines CoreIOTest class
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#ifndef COREIOPATHTEST_H
+#define COREIOPATHTEST_H
+
+#include "IFunctionalTest.h"
+
+//! Functional test to validate read/write to files containing non-ascii characters in a path.
+
+class CoreIOPathTest : public IFunctionalTest
+{
+public:
+    CoreIOPathTest();
+
+    bool runTest();
+
+};
+
+#endif // COREIOPATHTEST_H

--- a/Tests/Functional/Core/CoreSpecial/CoreIOPathTest.h
+++ b/Tests/Functional/Core/CoreSpecial/CoreIOPathTest.h
@@ -25,7 +25,6 @@ public:
     CoreIOPathTest();
 
     bool runTest();
-
 };
 
 #endif // COREIOPATHTEST_H

--- a/Tests/Functional/Core/CoreSpecial/CoreIOPerformanceTest.cpp
+++ b/Tests/Functional/Core/CoreSpecial/CoreIOPerformanceTest.cpp
@@ -12,7 +12,7 @@
 //
 // ************************************************************************** //
 
-#include "CoreIOTest.h"
+#include "CoreIOPerformanceTest.h"
 #include "IntensityDataIOFactory.h"
 #include "Benchmark.h"
 #include "Numeric.h"
@@ -22,7 +22,7 @@
 #include <iomanip>
 #include <boost/format.hpp>
 
-bool CoreIOTest::runTest()
+bool CoreIOPerformanceTest::runTest()
 {
     std::cout << "CoreIOTest::runTest()" << std::endl;
 
@@ -48,7 +48,7 @@ bool CoreIOTest::runTest()
     return success;
 }
 
-bool CoreIOTest::test_io(int nx, int ny, bool random_data, const std::string& ext)
+bool CoreIOPerformanceTest::test_io(int nx, int ny, bool random_data, const std::string& ext)
 {
     std::cout << "Test " << nx << "x" << ny << ", "
               << (random_data ? "random data" : "zeros")
@@ -97,7 +97,7 @@ bool CoreIOTest::test_io(int nx, int ny, bool random_data, const std::string& ex
     return success;
 }
 
-std::unique_ptr<OutputData<double>> CoreIOTest::createData(int nx, int ny, bool fill)
+std::unique_ptr<OutputData<double>> CoreIOPerformanceTest::createData(int nx, int ny, bool fill)
 {
     std::unique_ptr<OutputData<double>> result(new OutputData<double>);
     result->addAxis("x", nx, 0.0, static_cast<double>(nx));
@@ -118,7 +118,7 @@ std::unique_ptr<OutputData<double>> CoreIOTest::createData(int nx, int ny, bool 
 
 //! Returns biggest element difference found.
 
-double CoreIOTest::biggest_difference(const OutputData<double>& data, const OutputData<double>& ref)
+double CoreIOPerformanceTest::biggest_difference(const OutputData<double>& data, const OutputData<double>& ref)
 {
     if (data.getAllocatedSize() != ref.getAllocatedSize())
         throw std::runtime_error("CoreIOTest::biggest_difference() -> Error. Size is different.");
@@ -132,7 +132,7 @@ double CoreIOTest::biggest_difference(const OutputData<double>& data, const Outp
     return max_diff;
 }
 
-std::string CoreIOTest::report() const
+std::string CoreIOPerformanceTest::report() const
 {
     std::ostringstream result;
 

--- a/Tests/Functional/Core/CoreSpecial/CoreIOPerformanceTest.h
+++ b/Tests/Functional/Core/CoreSpecial/CoreIOPerformanceTest.h
@@ -12,8 +12,8 @@
 //
 // ************************************************************************** //
 
-#ifndef COREIOTEST_H
-#define COREIOTEST_H
+#ifndef COREIOPERFORMANCETEST_H
+#define COREIOPERFORMANCETEST_H
 
 #include "IFunctionalTest.h"
 #include "OutputData.h"
@@ -22,11 +22,11 @@
 
 //! Functional test to validate read/write of large data files.
 
-class CoreIOTest : public IFunctionalTest
+class CoreIOPerformanceTest : public IFunctionalTest
 {
 public:
-    CoreIOTest() {}
-    ~CoreIOTest() {}
+    CoreIOPerformanceTest() {}
+    ~CoreIOPerformanceTest() {}
 
     bool runTest();
 
@@ -52,4 +52,4 @@ private:
     std::vector<TestResults> m_test_results;
 };
 
-#endif // COREIOTEST_H
+#endif // COREIOPERFORMANCETEST_H

--- a/Tests/Functional/Core/CoreSpecial/CoreSpecialTestFactory.cpp
+++ b/Tests/Functional/Core/CoreSpecial/CoreSpecialTestFactory.cpp
@@ -16,7 +16,7 @@
 #include "BatchSimulation.h"
 #include "DetectorTest.h"
 #include "PolDWBAMagCylinders.h"
-#include "CoreIOTest.h"
+#include "CoreIOPerformanceTest.h"
 #include "FourierTransformationTest.h"
 #include "MesoCrystalPerformanceTest.h"
 
@@ -30,8 +30,8 @@ CoreSpecialTestFactory::CoreSpecialTestFactory()
                  create_new<PolDWBAMagCylinders>,
                  "Special test for polarized materials");
 
-    registerItem("CoreIO",
-                 create_new<CoreIOTest>,
+    registerItem("CoreIOPerformance",
+                 create_new<CoreIOPerformanceTest>,
                  "Input/output of heavy files");
 
     registerItem("DetectorTest",

--- a/Tests/Functional/Core/CoreSpecial/CoreSpecialTestFactory.cpp
+++ b/Tests/Functional/Core/CoreSpecial/CoreSpecialTestFactory.cpp
@@ -17,6 +17,7 @@
 #include "DetectorTest.h"
 #include "PolDWBAMagCylinders.h"
 #include "CoreIOPerformanceTest.h"
+#include "CoreIOPathTest.h"
 #include "FourierTransformationTest.h"
 #include "MesoCrystalPerformanceTest.h"
 
@@ -33,6 +34,10 @@ CoreSpecialTestFactory::CoreSpecialTestFactory()
     registerItem("CoreIOPerformance",
                  create_new<CoreIOPerformanceTest>,
                  "Input/output of heavy files");
+
+    registerItem("CoreIOPath",
+                 create_new<CoreIOPathTest>,
+                 "Input/output to files containing non-ascii characters in a path");
 
     registerItem("DetectorTest",
                  create_new<DetectorTest>,

--- a/Wrap/python/plot_utils.py
+++ b/Wrap/python/plot_utils.py
@@ -47,22 +47,22 @@ def translate_axis_label(label):
     :return: LaTeX representation
     """
     label_dict = {
-                 'X [nbins]'     : r'$X \; (bins)$',
-                 'phi_f [rad]'   : r'$\varphi_f \; (rad)$',
-                 'phi_f [deg]'   : r'$\varphi_f \; (deg)$',
-                 'alpha_i [rad]' : r'$\alpha_i \; (rad)$',
-                 'alpha_i [deg]' : r'$\alpha_i \; (deg)$',
-                 'X [mm]'        : r'$X \; (mm)$',
-                 'Qx [1/nm]'     : r'$Q_x \; (nm^{-1})$',
-                 'Qy [1/nm]'     : r'$Q_y \; (nm^{-1})$',
-                 'Q [1/nm]'      : r'$Q \; (nm^{-1})$',
+                 'X [nbins]'     : r'$X \; $(bins)',
+                 'phi_f [rad]'   : r'$\varphi_f \; $(rad)',
+                 'phi_f [deg]'   : r'$\varphi_f \; $(deg)',
+                 'alpha_i [rad]' : r'$\alpha_i \; $(rad)',
+                 'alpha_i [deg]' : r'$\alpha_i \; $(deg)',
+                 'X [mm]'        : r'$X \; $(mm)',
+                 'Qx [1/nm]'     : r'$Q_x \; $(nm$^{-1}$)',
+                 'Qy [1/nm]'     : r'$Q_y \; $(nm$^{-1}$)',
+                 'Q [1/nm]'      : r'$Q \; $(nm$^{-1}$)',
 
-                 'Y [nbins]'     : r'$Y \; (bins)$',
-                 'alpha_f [rad]' : r'$\alpha_f \; (rad)$',
-                 'alpha_f [deg]' : r'$\alpha_f \; (deg)$',
-                 'Y [mm]'        : r'$Y \; (mm)$',
-                 'Qz [1/nm]'     : r'$Q_z \; (nm^{-1})$',
-                 'Position [nm]' : r'$Position \; (nm)$'
+                 'Y [nbins]'     : r'$Y \; $(bins)',
+                 'alpha_f [rad]' : r'$\alpha_f \; $(rad)',
+                 'alpha_f [deg]' : r'$\alpha_f \; $(deg)',
+                 'Y [mm]'        : r'$Y \; $(mm)',
+                 'Qz [1/nm]'     : r'$Q_z \; $(nm$^{-1}$)',
+                 'Position [nm]' : r'$Position \; $(nm)'
                  }
     if label in label_dict.keys():
         return label_dict[label]

--- a/cmake/generic/modules/FindFFTW.cmake
+++ b/cmake/generic/modules/FindFFTW.cmake
@@ -1,73 +1,46 @@
 # Find the FFTW includes and library.
-# 
+#
 # This module defines
 # FFTW_INCLUDE_DIR, where to locate fftw3.h file
 # FFTW_LIBRARIES, the libraries to link against to use fftw3
-# FFTW_FOUND.  If false, you cannot build anything that requires fftw3.
 # FFTW_LIBRARY, where to find the libfftw3 library.
 
-set(FFTW_FOUND 0)
-if(FFTW_LIBRARY AND FFTW_INCLUDE_DIR)
-  set(FFTW_FIND_QUIETLY TRUE)
+# --- Looking for headers -----
+
+find_path(FFTW_INCLUDE_DIR fftw3.h)
+if(NOT FFTW_INCLUDE_DIR)
+    message(ERROR " Missed dependency. Can't find FFTW headers, please make sure that you've installed FFTW development version.")
 endif()
 
-if(NOT WIN32)
-    find_path(FFTW_INCLUDE_DIR fftw3.h
-        $ENV{FFTW_DIR}/include
-        $ENV{FFTW3} $ENV{FFTW3}/include $ENV{FFTW3}/api
-        /usr/local/include
-        /usr/include
-        /opt/fftw3/include
-        /opt/local/include
-        DOC "Specify the directory containing fftw3.h"
-    )
+# --- Looking for library -----
 
-    find_library(FFTW_LIBRARY NAMES fftw3 fftw3-3 PATHS
-        $ENV{FFTW_DIR}/lib
-        $ENV{FFTW3} $ENV{FFTW3}/lib $ENV{FFTW3}/.libs
-        /usr/local/lib
-        /usr/lib 
-        /opt/fftw3/lib
-        HINTS /opt/local/lib
-        DOC "Specify the fttw3 library here."
-    )
-else()
-    find_path(FFTW_INCLUDE_DIR fftw3.h
-        HINTS ENV PATH
-        PATHS "C:/opt/local_x64/include"  # if fftw cannot be found in env path
-        PATH_SUFFIXES ../include
-        NO_DEFAULT_PATH
-    )
-#    message("XXX ${FFTW_INCLUDE_DIR}")
+set(FFTW_NAMES ${FFTW_NAMES} fftw3 fftw3-3 libfftw3-3)
 
-    find_library(FFTW_LIBRARY libfftw3-3
-        HINTS ENV PATH
-        PATHS "C:/opt/local_x64/lib"  # if fftw cannot be found in env path
-        NO_DEFAULT_PATH
-    )
+find_library(FFTW_LIBRARY NAMES ${FFTW_NAMES} QUIET)
 
+if (WIN31)
     string( REPLACE ".lib" ".dll" FFTW_LIBRARY_DLL "${FFTW_LIBRARY}" )
     if (NOT EXISTS ${FFTW_LIBRARY_DLL})
         message(FATAL_ERROR "File ${FFTW_LIBRARY_DLL} does not exist")
-    endif (NOT EXISTS ${FFTW_LIBRARY_DLL})
+    endif(NOT EXISTS ${FFTW_LIBRARY_DLL})
 endif()
 
-if(FFTW_INCLUDE_DIR AND FFTW_LIBRARY)
-  set(FFTW_FOUND 1 )
-  if(NOT FFTW_FIND_QUIETLY)
-     message(STATUS "Found fftw3 includes at ${FFTW_INCLUDE_DIR}")
-     message(STATUS "Found fftw3 library at ${FFTW_LIBRARY}")
-  endif()
+# --- Processing variables -----
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(FFTW REQUIRED_VARS FFTW_LIBRARY FFTW_INCLUDE_DIR)
+
+if(FFTW_FOUND)
+    set( FFTW_LIBRARIES ${FFTW_LIBRARY} )
 endif()
 
-
-if( NOT FFTW_FOUND )
-    if( FFTW_FIND_REQUIRED )
-        message( FATAL_ERROR "FindFFTW: can't find fftw3 header or library" )
+if(FFTW_FOUND)
+    message(STATUS "Found FFTW: includes at ${FFTW_INCLUDE_DIR}, libraries at ${FFTW_LIBRARIES}")
+else()
+    message(STATUS "Cant'f find fftw3 library: ${FFTW_INCLUDE_DIR}, ${FFTW_LIBRARIES}.")
+    if (NOT WIN32 AND NOT APPLE)
+        message(STATUS "Please note, that shared version of FFTW library is required (use enable-shared during configuration phase).")
     endif()
 endif()
 
-
-set(FFTW_LIBRARIES ${FFTW_LIBRARY})
-
-mark_as_advanced(FFTW_FOUND FFTW_LIBRARY FFTW_INCLUDE_DIR FFTW_LIBRARY_DLL)
+mark_as_advanced(FFTW_INCLUDE_DIR FFTW_LIBRARY FFTW_LIBRARY_DLL)

--- a/cmake/generic/modules/FindFFTW.cmake
+++ b/cmake/generic/modules/FindFFTW.cmake
@@ -15,8 +15,14 @@ endif()
 # --- Looking for library -----
 
 set(FFTW_NAMES ${FFTW_NAMES} fftw3 fftw3-3 libfftw3-3)
+set( ba_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+
+if (NOT APPLE AND NOT WIN32)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .so) # require shared version of library
+endif()
 
 find_library(FFTW_LIBRARY NAMES ${FFTW_NAMES} QUIET)
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${ba_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
 
 if (WIN31)
     string( REPLACE ".lib" ".dll" FFTW_LIBRARY_DLL "${FFTW_LIBRARY}" )


### PR DESCRIPTION
This PR addresses issue 2381 (http://apps.jcns.fz-juelich.de/redmine/issues/2381):

> There is an example tutorial on FootprintCorrection in the BornAgan website (https://www.bornagainproject.org/documentation/tutorial-examples/reflectometry/footprint-correction/) with a snippet included.
> The same example is missing on the BornAgain repository. [...]
> 
> The same holds true for the tutorial "Specular Simulation With a Rough Sample" https://www.bornagainproject.org/documentation/tutorial-examples/reflectometry/specular-simulation-with-roughness/

The two missing examples were added together with the relevant tests.