### PR TITLE
Fix memory leakage both in GUI and PythonAPI

### DIFF
--- a/Core/Fitting/ObjectiveMetric.cpp
+++ b/Core/Fitting/ObjectiveMetric.cpp
@@ -252,8 +252,8 @@ double RQ4Metric::compute(const SimDataPair& data_pair, bool use_weights) const
         return Chi2Metric::compute(data_pair, use_weights);
 
     // fetching data in RQ4 form
-    std::unique_ptr<OutputData<double>> sim_data(data_pair.simulationResult().data(AxesUnits::RQ4));
-    std::unique_ptr<OutputData<double>> exp_data(data_pair.experimentalData().data(AxesUnits::RQ4));
+    auto sim_data = data_pair.simulationResult().data(AxesUnits::RQ4);
+    auto exp_data = data_pair.experimentalData().data(AxesUnits::RQ4);
 
     return computeFromArrays(sim_data->getRawDataVector(), exp_data->getRawDataVector(),
                              data_pair.user_weights_array());

--- a/Core/InputOutput/IntensityDataIOFactory.cpp
+++ b/Core/InputOutput/IntensityDataIOFactory.cpp
@@ -65,6 +65,6 @@ void IntensityDataIOFactory::writeIntensityData(const IHistogram& histogram,
 void IntensityDataIOFactory::writeSimulationResult(const SimulationResult& result,
                                                    const std::string& file_name)
 {
-    std::unique_ptr<OutputData<double>> P_data(result.data());
-    writeOutputData(*P_data, file_name);
+    auto data = result.data();
+    writeOutputData(*data, file_name);
 }

--- a/Core/Instrument/SimulationResult.cpp
+++ b/Core/Instrument/SimulationResult.cpp
@@ -58,12 +58,12 @@ SimulationResult& SimulationResult::operator=(SimulationResult&& other)
     return *this;
 }
 
-OutputData<double>* SimulationResult::data(AxesUnits units) const
+std::unique_ptr<OutputData<double> > SimulationResult::data(AxesUnits units) const
 {
     if (!mP_data)
         throw std::runtime_error(
             "Error in SimulationResult::data:Attempt to access non-initialized data");
-    return mP_unit_converter->createConvertedData(*mP_data, units).release();
+    return mP_unit_converter->createConvertedData(*mP_data, units);
 }
 
 Histogram2D* SimulationResult::histogram2d(AxesUnits units) const
@@ -72,7 +72,7 @@ Histogram2D* SimulationResult::histogram2d(AxesUnits units) const
         throw std::runtime_error("Error in SimulationResult::histogram2d: "
                                  "dimension of data is not 2. Please use axis(), array() and "
                                  "data() functions for 1D data.");
-    std::unique_ptr<OutputData<double>> P_data(data(units));
+    auto P_data = data(units);
     return new Histogram2D(*P_data);
 }
 

--- a/Core/Instrument/SimulationResult.h
+++ b/Core/Instrument/SimulationResult.h
@@ -51,7 +51,7 @@ public:
     SimulationResult& operator=(SimulationResult&& other);
 
 #ifndef SWIG
-    OutputData<double>* data(AxesUnits units = AxesUnits::DEFAULT) const;
+    std::unique_ptr<OutputData<double>> data(AxesUnits units = AxesUnits::DEFAULT) const;
 #endif
 
     Histogram2D* histogram2d(AxesUnits units = AxesUnits::DEFAULT) const;

--- a/Core/Instrument/SimulationResult.h
+++ b/Core/Instrument/SimulationResult.h
@@ -50,7 +50,10 @@ public:
     SimulationResult& operator=(const SimulationResult& other);
     SimulationResult& operator=(SimulationResult&& other);
 
+#ifndef SWIG
     OutputData<double>* data(AxesUnits units = AxesUnits::DEFAULT) const;
+#endif
+
     Histogram2D* histogram2d(AxesUnits units = AxesUnits::DEFAULT) const;
 
     //! Provide AxisInfo for each axis and the given units

--- a/GUI/coregui/Models/JobItemUtils.cpp
+++ b/GUI/coregui/Models/JobItemUtils.cpp
@@ -125,7 +125,7 @@ void JobItemUtils::setResults(DataItem* intensityItem, const Simulation* simulat
         updateAxesTitle(intensityItem, converter, converter.defaultUnits());
     }
     auto selected_units = JobItemUtils::axesUnitsFromName(intensityItem->selectedAxesUnits());
-    std::unique_ptr<OutputData<double>> data(sim_result.data(selected_units));
+    auto data = sim_result.data(selected_units);
     intensityItem->setOutputData(data.release());
 }
 

--- a/GUI/coregui/Views/FitWidgets/GUIFitObserver.cpp
+++ b/GUI/coregui/Views/FitWidgets/GUIFitObserver.cpp
@@ -51,7 +51,7 @@ void GUIFitObserver::update(const FitObjective* subject)
     if (subject->isCompleted())
         info.m_log_info = subject->minimizerResult().toString();
 
-    std::unique_ptr<OutputData<double>> data(subject->dataPair().simulationResult().data());
+    auto data = subject->dataPair().simulationResult().data();
     info.m_sim_values = data->getRawDataVector();
 
     m_iteration_info = info;

--- a/Tests/Functional/Core/CoreSpecial/BatchSimulation.cpp
+++ b/Tests/Functional/Core/CoreSpecial/BatchSimulation.cpp
@@ -32,8 +32,8 @@ bool BatchSimulation::runTest()
     simulation->setSampleBuilder(builder);
     simulation->runSimulation();
     auto sim_result = simulation->result();
-    const std::unique_ptr<OutputData<double>> reference(sim_result.data());
-    const std::unique_ptr<OutputData<double>> result(reference->clone());
+    const auto reference = sim_result.data();
+    const auto result = reference->clone();
     result->setAllTo(0.0);
 
     const unsigned n_batches = 9;

--- a/Tests/Functional/Core/CoreSpecial/PolDWBAMagCylinders.cpp
+++ b/Tests/Functional/Core/CoreSpecial/PolDWBAMagCylinders.cpp
@@ -44,19 +44,19 @@ bool PolDWBAMagCylinders::runTest()
     simulation->setAnalyzerProperties(zplus, 1.0, 0.5);
     simulation->runSimulation();
     auto sim_result = simulation->result();
-    const std::unique_ptr<OutputData<double> > P_data00(sim_result.data());
+    const auto P_data00 = sim_result.data();
 
     simulation->setBeamPolarization(zplus);
     simulation->setAnalyzerProperties(zplus, -1.0, 0.5);
     simulation->runSimulation();
     sim_result = simulation->result();
-    const std::unique_ptr<OutputData<double> > P_data01(sim_result.data());
+    const auto P_data01 = sim_result.data();
 
     simulation->setBeamPolarization(zmin);
     simulation->setAnalyzerProperties(zplus, 1.0, 0.5);
     simulation->runSimulation();
     sim_result = simulation->result();
-    const std::unique_ptr<OutputData<double> > P_data10(sim_result.data());
+    const auto P_data10 = sim_result.data();
 
     simulation->setBeamPolarization(zmin);
     simulation->setAnalyzerProperties(zplus, -1.0, 0.5);

--- a/Tests/Functional/Core/CoreStandardTest/CoreStandardTest.cpp
+++ b/Tests/Functional/Core/CoreStandardTest/CoreStandardTest.cpp
@@ -36,7 +36,7 @@ bool CoreStandardTest::runTest()
     assert(m_reference_simulation);
     m_reference_simulation->runSimulation();
     auto sim_result = m_reference_simulation->result();
-    const std::unique_ptr<OutputData<double>> result_data(sim_result.data());
+    const auto result_data = sim_result.data();
 
     // Compare with reference if available.
     bool success = false;

--- a/Tests/Functional/Core/SelfConsistenceTest/SelfConsistenceTest.cpp
+++ b/Tests/Functional/Core/SelfConsistenceTest/SelfConsistenceTest.cpp
@@ -45,7 +45,7 @@ bool SelfConsistenceTest::runTest()
     {
         simulation->runSimulation();
         auto sim_result = simulation->result();
-        results.push_back(std::unique_ptr<OutputData<double>>(sim_result.data()));
+        results.push_back(sim_result.data());
     }
 
     // Compare with reference if available.

--- a/Tests/Functional/Fit/FitObjective/FitPlan.cpp
+++ b/Tests/Functional/Fit/FitObjective/FitPlan.cpp
@@ -126,5 +126,5 @@ std::unique_ptr<OutputData<double> > FitPlan::createOutputData() const
     params.setValues(expectedValues());
     auto simulation = buildSimulation(params);
     simulation->runSimulation();
-    return std::unique_ptr<OutputData<double>>(simulation->result().data());
+    return simulation->result().data();
 }

--- a/Tests/Functional/GUI/GUIStandardTest/GUIStandardTest.cpp
+++ b/Tests/Functional/GUI/GUIStandardTest/GUIStandardTest.cpp
@@ -54,8 +54,8 @@ bool GUIStandardTest::runTest()
     domain_simulation->runSimulation();
     auto domain_result = domain_simulation->result();
 
-    const std::unique_ptr<OutputData<double> > domain_data(domain_result.data());
-    const std::unique_ptr<OutputData<double> > reference_data(ref_result.data());
+    const auto domain_data = domain_result.data();
+    const auto reference_data = ref_result.data();
 
     return TestUtils::isTheSame(*domain_data, *reference_data, m_threshold);
 }

--- a/Tests/Functional/Python/PyPersistence/example_template.py
+++ b/Tests/Functional/Python/PyPersistence/example_template.py
@@ -150,7 +150,7 @@ def check_result(result, example_name):
     print("Loading reference file '{}'".format(reffile))
     reference = ba.IntensityDataIOFactory.readOutputData(reffile)
 
-    diff = ba.getRelativeDifference(result.data(), reference)
+    diff = ba.getRelativeDifference(ba.importArrayToOutputData(result.array()), reference)
 
     if diff > TOLERANCE:
         print("Failure - Difference {0} is above tolerance level {1}".format(diff, TOLERANCE))

--- a/Tests/Functional/Python/PyStandard/PyStandardTest.cpp
+++ b/Tests/Functional/Python/PyStandard/PyStandardTest.cpp
@@ -48,7 +48,7 @@ bool PyStandardTest::runTest()
     m_reference_simulation->runSimulation();
     auto ref_result = m_reference_simulation->result();
 
-    const std::unique_ptr<OutputData<double>> reference_data(ref_result.data());
+    const auto reference_data = ref_result.data();
 
     // Compare results
     const std::unique_ptr<OutputData<double>> domain_data(

--- a/Tests/UnitTests/Core/Fresnel/DepthProbeSimulationTest.cpp
+++ b/Tests/UnitTests/Core/Fresnel/DepthProbeSimulationTest.cpp
@@ -166,7 +166,7 @@ TEST_F(DepthProbeSimulationTest, ResultAquisition)
 
     EXPECT_THROW(sim_result.data(AxesUnits::MM), std::runtime_error);
 
-    const std::unique_ptr<OutputData<double>> output(sim_result.data());
+    const auto output = sim_result.data();
     EXPECT_EQ(depth_map->getTotalNumberOfBins(), output->getAllocatedSize());
     EXPECT_EQ(depth_map->getRank(), output->getRank());
     EXPECT_EQ(depth_map->getXaxis().getMin(), output->getAxis(0).getMin());
@@ -186,8 +186,8 @@ TEST_F(DepthProbeSimulationTest, SimulationClone)
 
     SimulationResult clone_result = clone->result();
 
-    std::unique_ptr<OutputData<double>> sim_output(sim_result.data());
-    std::unique_ptr<OutputData<double>> clone_output(clone_result.data());
+    auto sim_output = sim_result.data();
+    auto clone_output = clone_result.data();
 
     EXPECT_EQ(sim_output->getAllocatedSize(), clone_output->getAllocatedSize());
     for (size_t i = 0; i < sim_output->getAllocatedSize(); ++i) {

--- a/Tests/UnitTests/Core/Fresnel/SpecularSimulationTest.cpp
+++ b/Tests/UnitTests/Core/Fresnel/SpecularSimulationTest.cpp
@@ -174,7 +174,7 @@ TEST_F(SpecularSimulationTest, ConstructSimulation)
     EXPECT_EQ(3u, sim->sample()->numberOfLayers());
 
     SimulationResult sim_result = sim->result();
-    std::unique_ptr<OutputData<double>> data(sim_result.data());
+    auto data = sim_result.data();
     EXPECT_EQ(data->getAllocatedSize(), 10u);
     EXPECT_EQ(data->totalSum(), 0.0);
     EXPECT_EQ(data->getRank(), 1u);
@@ -182,7 +182,7 @@ TEST_F(SpecularSimulationTest, ConstructSimulation)
     sim->runSimulation();
     sim_result = sim->result();
 
-    data.reset(sim_result.data());
+    data = sim_result.data();
     EXPECT_EQ(data->getAllocatedSize(), 10u);
     EXPECT_EQ(data->getRank(), 1u);
 
@@ -203,7 +203,7 @@ TEST_F(SpecularSimulationTest, SimulationClone)
     EXPECT_EQ(3u, clone->sample()->numberOfLayers());
 
     SimulationResult clone_result = clone->result();
-    std::unique_ptr<OutputData<double>> data(clone_result.data());
+    auto data = clone_result.data();
     EXPECT_EQ(data->getAllocatedSize(), 10u);
     EXPECT_EQ(data->totalSum(), 0.0);
 
@@ -214,7 +214,7 @@ TEST_F(SpecularSimulationTest, SimulationClone)
     std::unique_ptr<SpecularSimulation> clone2(sim->clone());
     clone_result = clone2->result();
 
-    const std::unique_ptr<OutputData<double>> output_data(clone_result.data());
+    const auto output_data = clone_result.data();
     EXPECT_EQ(10u, output_data->getAllocatedSize());
 
     checkBeamState(*clone2);

--- a/Tests/UnitTests/Core/Other/SimulationResultTest.cpp
+++ b/Tests/UnitTests/Core/Other/SimulationResultTest.cpp
@@ -35,7 +35,7 @@ TEST_F(SimulationResultTest, accessToEmptySimulation)
     EXPECT_EQ(result.size(), size_t(nx*ny));
 
     // OutputData has correct size and amplitudes
-    std::unique_ptr<OutputData<double>> data(result.data());
+    auto data = result.data();
     EXPECT_EQ(data->getAllocatedSize(), size_t(nx*ny));
     EXPECT_EQ(data->totalSum(), 0.0);
 }
@@ -53,7 +53,7 @@ TEST_F(SimulationResultTest, accessToEmptyRoiSimulation)
     EXPECT_EQ(result.size(), 9u);
 
     // OutputData has correct size and amplitudes
-    std::unique_ptr<OutputData<double>> data(result.data());
+    auto data = result.data();
     EXPECT_EQ(data->getAllocatedSize(), 9u);
     EXPECT_EQ(data->totalSum(), 0.0);
 }

--- a/Wrap/swig/libBornAgainCore.i
+++ b/Wrap/swig/libBornAgainCore.i
@@ -245,7 +245,6 @@
 %newobject ScanResolution::scanRelativeResolution;
 %newobject ScanResolution::scanAbsoluteResolution;
 
-%newobject SimulationResult::data(AxesUnits units_type = AxesUnits::DEFAULT) const;
 %newobject SimulationResult::histogram2d(AxesUnits units_type = AxesUnits::DEFAULT) const;
 
 %newobject IntensityDataIOFactory::readOutputData(const std::string& file_name);

--- a/auto/Wrap/libBornAgainCore.py
+++ b/auto/Wrap/libBornAgainCore.py
@@ -18297,17 +18297,6 @@ class SimulationResult(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def data(self, *args):
-        """
-        data(SimulationResult self, AxesUnits units) -> IntensityData
-        data(SimulationResult self) -> IntensityData
-
-        OutputData< double > * SimulationResult::data(AxesUnits units=AxesUnits::DEFAULT) const
-
-        """
-        return _libBornAgainCore.SimulationResult_data(self, *args)
-
-
     def histogram2d(self, *args):
         """
         histogram2d(SimulationResult self, AxesUnits units) -> Histogram2D


### PR DESCRIPTION
Leak summary
`
==79988==    definitely lost: 38,162 bytes in 988 blocks
==79988==    indirectly lost: 42,095,920 bytes in 3,206 blocks
`
After
`
==14538==    definitely lost: 20,978 bytes in 454 blocks
==14538==    indirectly lost: 2,184 bytes in 15 blocks
`