### PR TITLE
Fix O(n_layer^2) bug

### DIFF
--- a/Core/Multilayer/MultiLayer.cpp
+++ b/Core/Multilayer/MultiLayer.cpp
@@ -105,11 +105,13 @@ void MultiLayer::setExternalField(kvector_t ext_field)
 std::vector<const INode*> MultiLayer::getChildren() const
 {
     std::vector<const INode*> result;
-    for (auto p_layer : m_layers) {
-        result.push_back(p_layer);
-        auto i_layer = MultiLayerUtils::IndexOfLayer(*this, p_layer);
-        if (const LayerInterface* p_interface =
-                MultiLayerUtils::LayerBottomInterface(*this, i_layer))
+    const size_t layer_size = m_layers.size();
+    result.reserve(layer_size + m_interfaces.size());
+
+    for (size_t i = 0; i < layer_size; ++i) {
+        result.push_back(m_layers[i]);
+        const LayerInterface* p_interface = MultiLayerUtils::LayerBottomInterface(*this, i);
+        if (p_interface)
             result.push_back(p_interface);
     }
     return result;

--- a/Core/StandardSamples/PlainMultiLayerBySLDBuilder.cpp
+++ b/Core/StandardSamples/PlainMultiLayerBySLDBuilder.cpp
@@ -18,8 +18,8 @@
 #include "MultiLayer.h"
 #include "Units.h"
 
-PlainMultiLayerBySLDBuilder::PlainMultiLayerBySLDBuilder()
-    : m_number_of_layers(10)
+PlainMultiLayerBySLDBuilder::PlainMultiLayerBySLDBuilder(int n_layers)
+    : m_number_of_layers(n_layers)
     , m_si { 2.0704e-06, 2.3726e-11}
     , m_ti {-1.9493e-06, 9.6013e-10}
     , m_ni { 9.4245e-06, 1.1423e-09}
@@ -44,7 +44,7 @@ MultiLayer* PlainMultiLayerBySLDBuilder::buildSample() const
     Layer substrate_layer(substrate_material);
 
     multi_layer->addLayer(vacuum_layer);
-    for (size_t i = 0; i < m_number_of_layers; ++i) {
+    for (int i = 0; i < m_number_of_layers; ++i) {
         multi_layer->addLayer(ti_layer);
         multi_layer->addLayer(ni_layer);
     }

--- a/Core/StandardSamples/PlainMultiLayerBySLDBuilder.h
+++ b/Core/StandardSamples/PlainMultiLayerBySLDBuilder.h
@@ -24,15 +24,15 @@
 class BA_CORE_API_ PlainMultiLayerBySLDBuilder : public IMultiLayerBuilder
 {
 public:
-    PlainMultiLayerBySLDBuilder();
-    MultiLayer* buildSample() const override;
+    PlainMultiLayerBySLDBuilder(int n_layers = 10);
+    MultiLayer* buildSample() const override; // passes ownership
 
 protected:
     struct MaterialData {
         double sld_real; //!< real part of sld in AA^{-2}
         double sld_imag; //!< imaginary part of sld in AA^{-2}
     };
-    size_t m_number_of_layers;
+    int m_number_of_layers;
     MaterialData m_si;
     MaterialData m_ti;
     MaterialData m_ni;

--- a/Tests/Functional/Core/CoreSpecial/CMakeLists.txt
+++ b/Tests/Functional/Core/CoreSpecial/CMakeLists.txt
@@ -4,6 +4,7 @@ set(test_cases
     BatchSimulation
     PolDWBAMagCylinders
     FourierTransformation
+    MultilayerPerformance
 #    CoreIOPerformance
 #    DetectorTest
 #    MesoPerformance

--- a/Tests/Functional/Core/CoreSpecial/CoreSpecialTestFactory.cpp
+++ b/Tests/Functional/Core/CoreSpecial/CoreSpecialTestFactory.cpp
@@ -14,12 +14,13 @@
 
 #include "CoreSpecialTestFactory.h"
 #include "BatchSimulation.h"
-#include "DetectorTest.h"
-#include "PolDWBAMagCylinders.h"
-#include "CoreIOPerformanceTest.h"
 #include "CoreIOPathTest.h"
+#include "CoreIOPerformanceTest.h"
+#include "DetectorTest.h"
 #include "FourierTransformationTest.h"
 #include "MesoCrystalPerformanceTest.h"
+#include "MultilayerPerformanceTest.h"
+#include "PolDWBAMagCylinders.h"
 
 CoreSpecialTestFactory::CoreSpecialTestFactory()
 {
@@ -50,4 +51,8 @@ CoreSpecialTestFactory::CoreSpecialTestFactory()
     registerItem("MesoPerformance",
                  create_new<MesoCrystalPerformanceTest>,
                  "Heavy mesocrystal simulation");
+
+    registerItem("MultilayerPerformance",
+                 create_new<MultilayerPerformanceTest>,
+                 "Reflectometry performance on samples with a large number of layers");
 }

--- a/Tests/Functional/Core/CoreSpecial/MultilayerPerformanceTest.cpp
+++ b/Tests/Functional/Core/CoreSpecial/MultilayerPerformanceTest.cpp
@@ -1,0 +1,60 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Tests/Functional/Core/CoreSpecial/MultilayerPerformanceTest.cpp
+//! @brief     Implements class MultilayerPerformanceTest
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#include "MultilayerPerformanceTest.h"
+#include "MultiLayer.h"
+#include "PlainMultiLayerBySLDBuilder.h"
+#include "SpecularSimulation.h"
+#include "StandardSimulations.h"
+#include <chrono>
+
+using Results = std::vector<std::pair<int, long>>;
+
+namespace
+{
+const std::vector<int> n_layers = {10, 100, 200, 500, 1000};
+
+const auto now = std::chrono::high_resolution_clock::now;
+const auto duration = [](auto time_interval) {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(time_interval).count();
+};
+
+void report(const Results& results)
+{
+    for (auto& pair : results)
+        std::cout << "n_layers = " << pair.first << ",\t time = " << pair.second << " ms\n";
+}
+} // namespace
+
+MultilayerPerformanceTest::~MultilayerPerformanceTest() = default;
+
+bool MultilayerPerformanceTest::runTest()
+{
+    Results results;
+    results.reserve(n_layers.size());
+
+    for (int layer_mult: n_layers) {
+        const auto start_time = now();
+        std::unique_ptr<MultiLayer> sample(PlainMultiLayerBySLDBuilder(layer_mult).buildSample());
+        std::unique_ptr<SpecularSimulation> simulation(StandardSimulations::BasicSpecular());
+        simulation->setSample(*sample);
+
+        simulation->runSimulation();
+
+        results.push_back({layer_mult, duration(now() - start_time)});
+    }
+
+    report(results);
+    return true;
+}

--- a/Tests/Functional/Core/CoreSpecial/MultilayerPerformanceTest.h
+++ b/Tests/Functional/Core/CoreSpecial/MultilayerPerformanceTest.h
@@ -1,0 +1,31 @@
+// ************************************************************************** //
+//
+//  BornAgain: simulate and fit scattering at grazing incidence
+//
+//! @file      Tests/Functional/Core/CoreSpecial/MultilayerPerformanceTest.h
+//! @brief     Defines class MultilayerPerformanceTest
+//!
+//! @homepage  http://www.bornagainproject.org
+//! @license   GNU General Public License v3 or higher (see COPYING)
+//! @copyright Forschungszentrum Jülich GmbH 2018
+//! @authors   Scientific Computing Group at MLZ (see CITATION, AUTHORS)
+//
+// ************************************************************************** //
+
+#ifndef MULTILAYERPERFORMANCETEST_H
+#define MULTILAYERPERFORMANCETEST_H
+
+#include "IFunctionalTest.h"
+
+//! Functional test for measuring simulation performance on samples with different number of layers.
+
+class MultilayerPerformanceTest : public IFunctionalTest
+{
+public:
+    ~MultilayerPerformanceTest() override;
+
+private:
+    bool runTest() override;
+};
+
+#endif // MULTILAYERPERFORMANCETEST_H


### PR DESCRIPTION
Before:

n_layers = 10,	 time = 4 ms
n_layers = 100,	 time = 64 ms
n_layers = 200,	 time = 349 ms
n_layers = 500,	 time = 4547 ms
n_layers = 1000,	 time = 34026 ms

After:

n_layers = 10,	 time = 4 ms
n_layers = 100,	 time = 28 ms
n_layers = 200,	 time = 52 ms
n_layers = 500,	 time = 210 ms
n_layers = 1000,	 time = 646 ms