### PR TITLE
Futher optimization of computations on samples with large number of layers

### DIFF
--- a/Core/Multilayer/MultiLayer.cpp
+++ b/Core/Multilayer/MultiLayer.cpp
@@ -26,6 +26,20 @@
 #include "RealParameter.h"
 #include <iomanip>
 
+namespace {
+template<class T>
+void updateInstanceCounts(SafePointerVector<T>& container, INode* child)
+{
+    if (container.empty())
+        return;
+
+    size_t container_size = container.size();
+    if (container_size == 1)
+        container.back()->setCopyNumber(0);
+    child->setCopyNumber(static_cast<int>(container_size));
+}
+}
+
 MultiLayer::MultiLayer() : m_crossCorrLength(0)
 {
     setName(BornAgain::MultiLayerType);
@@ -128,6 +142,7 @@ void MultiLayer::init_parameters()
 
 void MultiLayer::addAndRegisterLayer(Layer* child)
 {
+    updateInstanceCounts(m_layers, child);
     m_layers.push_back(child);
     handleLayerThicknessRegistration();
     registerChild(child);
@@ -135,6 +150,7 @@ void MultiLayer::addAndRegisterLayer(Layer* child)
 
 void MultiLayer::addAndRegisterInterface(LayerInterface* child)
 {
+    updateInstanceCounts(m_interfaces, child);
     m_interfaces.push_back(child);
     registerChild(child);
 }

--- a/Core/Parametrization/INode.cpp
+++ b/Core/Parametrization/INode.cpp
@@ -56,10 +56,13 @@ INode* INode::parent()
     return const_cast<INode*>(m_parent);
 }
 
-int INode::copyNumber(const INode* node) const
+int INode::instanceNumber(const INode* node) const
 {
     if(node->parent() != this)
         return -1;
+
+    if (node->hasCopyNumber())
+        return node->copyNumber();
 
     int result(-1), count(0);
     for (auto child : getChildren()) {
@@ -73,7 +76,6 @@ int INode::copyNumber(const INode* node) const
         if (child->getName() == node->getName())
             ++count;
     }
-
     return count > 1 ? result : -1;
 }
 
@@ -81,7 +83,7 @@ std::string INode::displayName() const
 {
     std::string result = getName();
     if (m_parent) {
-        int index = m_parent->copyNumber(this);
+        int index = m_parent->instanceNumber(this);
         if (index >= 0)
             result = result + std::to_string(index);
     }

--- a/Core/Parametrization/INode.h
+++ b/Core/Parametrization/INode.h
@@ -44,17 +44,23 @@ public:
     const INode* parent() const;
     INode* parent();
 
-    //! Returns copyNumber of child, which takes into account existence of children with same name.
-    int copyNumber(const INode* node) const;
-
     //! Returns display name, composed from the name of node and it's copy number.
     std::string displayName() const;
 
     //! Creates new parameter pool, with all local parameters and those of its children.
     ParameterPool* createParameterTree() const;
 
+    void setCopyNumber(int copy_num) { m_copy_number = copy_num; }
+    int copyNumber() const { return m_copy_number; }
+    bool hasCopyNumber() const { return m_copy_number >= 0; }
+
 private:
+    //! Determines the number of INode instance in the parent,
+    //! with takes the existence of children with same name into account.
+    int instanceNumber(const INode* node) const;
+
     const INode* m_parent;
+    int m_copy_number = -1;
 };
 
 template <class T>

--- a/auto/Wrap/libBornAgainCore.py
+++ b/auto/Wrap/libBornAgainCore.py
@@ -2600,18 +2600,6 @@ class INode(IParameterized):
         return _libBornAgainCore.INode_parent(self, *args)
 
 
-    def copyNumber(self, node):
-        """
-        copyNumber(INode self, INode node) -> int
-
-        int INode::copyNumber(const INode *node) const
-
-        Returns copyNumber of child, which takes into account existence of children with same name. 
-
-        """
-        return _libBornAgainCore.INode_copyNumber(self, node)
-
-
     def displayName(self):
         """
         displayName(INode self) -> std::string
@@ -2634,6 +2622,28 @@ class INode(IParameterized):
 
         """
         return _libBornAgainCore.INode_createParameterTree(self)
+
+
+    def setCopyNumber(self, copy_num):
+        """setCopyNumber(INode self, int copy_num)"""
+        return _libBornAgainCore.INode_setCopyNumber(self, copy_num)
+
+
+    def copyNumber(self):
+        """
+        copyNumber(INode self) -> int
+
+        int INode::copyNumber(const INode *node) const
+
+        Returns copyNumber of child, which takes into account existence of children with same name. 
+
+        """
+        return _libBornAgainCore.INode_copyNumber(self)
+
+
+    def hasCopyNumber(self):
+        """hasCopyNumber(INode self) -> bool"""
+        return _libBornAgainCore.INode_hasCopyNumber(self)
 
     def __disown__(self):
         self.this.disown()


### PR DESCRIPTION
Before:

n_layers = 10,	 time = 4 ms
n_layers = 100,	 time = 25 ms
n_layers = 200,	 time = 58 ms
n_layers = 500,	 time = 214 ms
n_layers = 1000,	 time = 653 ms

After:

n_layers = 10,	 time = 4 ms
n_layers = 100,	 time = 21 ms
n_layers = 200,	 time = 46 ms
n_layers = 500,	 time = 160 ms
n_layers = 1000,	 time = 426 ms

It can be improved further by optimizing the string treatment in `INode` class (see screenshot from kcachegrind attached - mallocs and deletions are also supposedly related to string handling). But as we have discussed a better approach will be just to get rid of parameter pool and related machinery completely. Thus I will leave this optimization until we meet a final decision.

<img width="1920" alt="Screenshot_10000_layers" src="https://user-images.githubusercontent.com/22917299/65508468-9243ee00-ded0-11e9-9c66-a044dd0988dc.png">
