### PR TITLE
UserManual/Scattering.tex: Correct eq. 1.22, add missing r'^2

### DIFF
--- a/Doc/UserManual/Scattering.tex
+++ b/Doc/UserManual/Scattering.tex
@@ -453,7 +453,7 @@ To compute the far-field limit~\cref{EGinftydef},
 we expand for $\r'$ with $r'\ll r$:
 \begin{equation}
   \left|\r-\r'\right|
-  \doteq \sqrt{r^2-2\r\,\r'}
+  \doteq \sqrt{r^2+r'^2-2\r\,\r'}
   \doteq r - \frac{\r\,\r'}{r}
   \equiv r - \frac{\k_\sf \r'}{K},
 \end{equation}


### PR DESCRIPTION
Hi,

I think there is a small mistake in equation 1.22 of the UserManual (section 1.2.2, page 14 of Version 1.7.2).
It states:
|\vec r - \vec r'| = sqrt(r^2 - 2 \vec r \vec r')
but I think correct is:
|\vec r - \vec r'| = sqrt(r^2 + r'^2 - 2 \vec r \vec r')

In this pull request, this is corrected.

Cheers + thanks for the helpful Manual,

Mika
