### PR TITLE
Revert "UserManual/Scattering.tex: Correct eq. 1.22, add missing r'^2"

### DIFF
--- a/Doc/UserManual/Scattering.tex
+++ b/Doc/UserManual/Scattering.tex
@@ -453,7 +453,7 @@ To compute the far-field limit~\cref{EGinftydef},
 we expand for $\r'$ with $r'\ll r$:
 \begin{equation}
   \left|\r-\r'\right|
-  \doteq \sqrt{r^2+r'^2-2\r\,\r'}
+  \doteq \sqrt{r^2-2\r\,\r'}
   \doteq r - \frac{\r\,\r'}{r}
   \equiv r - \frac{\k_\sf \r'}{K},
 \end{equation}


### PR DESCRIPTION
Reverts scgmlz/BornAgain#890

Sorry for the confusion, but this is not an equation. The first two 'equation' signs denote approximate equality. In this case, the square of r' can be neglected, which is exactly what you want to achieve in the far field approximation.