### PR TITLE
remove redundant call to prepareSimulation()

### DIFF
--- a/Core/Simulation/Simulation.cpp
+++ b/Core/Simulation/Simulation.cpp
@@ -216,7 +216,6 @@ void Simulation::updateSample()
 //! If desired, the simulation is run in several threads.
 void Simulation::runSingleSimulation(size_t batch_start, size_t batch_size, double weight)
 {
-    prepareSimulation();
     initSimulationElementVector();
 
     const size_t n_threads = m_options.getNumberOfThreads();


### PR DESCRIPTION
Simulation::prepareSimulation() was called twice pretty much after each other in Simulation::runSimulation() and Simulation::runSingleSimulation( … ).