### PR TITLE
Qt warnings

### DIFF
--- a/Core/Vector/Transform3D.cpp
+++ b/Core/Vector/Transform3D.cpp
@@ -22,12 +22,6 @@ Transform3D::Transform3D()
     m_inverse_matrix.setIdentity();
 }
 
-Transform3D::Transform3D(const Transform3D& other)
-: m_matrix(other.m_matrix)
-, m_inverse_matrix(other.m_inverse_matrix)
-{
-}
-
 Transform3D::Transform3D(const Eigen::Matrix3d& matrix)
     : m_matrix(matrix)
 {

--- a/Core/Vector/Transform3D.h
+++ b/Core/Vector/Transform3D.h
@@ -31,9 +31,6 @@ public:
     //! Constructs unit transformation
     Transform3D();
 
-    //! Copy constructor
-    Transform3D(const Transform3D& other);
-
 #ifndef SWIG
     //! Constructor from matrix (no checks if this is an element of SO(3)!)
     Transform3D(const Eigen::Matrix3d& matrix);

--- a/GUI/coregui/Models/Data1DViewItem.cpp
+++ b/GUI/coregui/Models/Data1DViewItem.cpp
@@ -155,8 +155,18 @@ QPair<QVector<double>, QVector<double>> Data1DViewItem::graphData(Data1DProperti
     const auto data = DataViewUtils::getTranslatedData(this, property_item->dataItem());
     if (!data)
         return {};
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    auto centers = data->getAxis(0).getBinCenters();
+    auto values = data->getRawDataVector();
+    return {QVector<double>(centers.begin(), centers.end()),
+                   QVector<double>(values.begin(), values.end())};
+#else
     return {QVector<double>::fromStdVector(data->getAxis(0).getBinCenters()),
                 QVector<double>::fromStdVector(data->getRawDataVector())};
+#endif
+
+
 }
 
 JobItem* Data1DViewItem::jobItem()

--- a/GUI/coregui/Models/FTDecayFunctionItems.cpp
+++ b/GUI/coregui/Models/FTDecayFunctionItems.cpp
@@ -140,11 +140,9 @@ FTDecayFunction2DCauchyItem::FTDecayFunction2DCauchyItem()
 
 std::unique_ptr<IFTDecayFunction2D> FTDecayFunction2DCauchyItem::createFTDecayFunction() const
 {
-    auto result = std::make_unique<FTDecayFunction2DCauchy>(
+    return std::make_unique<FTDecayFunction2DCauchy>(
         getItemValue(P_DECAY_LENGTH_X).toDouble(), getItemValue(P_DECAY_LENGTH_Y).toDouble(),
         Units::deg2rad(getItemValue(P_GAMMA).toDouble()));
-
-    return std::move(result);
 }
 
 // --------------------------------------------------------------------------------------------- //
@@ -159,11 +157,9 @@ FTDecayFunction2DGaussItem::FTDecayFunction2DGaussItem()
 
 std::unique_ptr<IFTDecayFunction2D> FTDecayFunction2DGaussItem::createFTDecayFunction() const
 {
-    auto result = std::make_unique<FTDecayFunction2DGauss>(
+    return std::make_unique<FTDecayFunction2DGauss>(
         getItemValue(P_DECAY_LENGTH_X).toDouble(), getItemValue(P_DECAY_LENGTH_Y).toDouble(),
         Units::deg2rad(getItemValue(P_GAMMA).toDouble()));
-
-    return std::move(result);
 }
 
 // --------------------------------------------------------------------------------------------- //
@@ -182,10 +178,8 @@ FTDecayFunction2DVoigtItem::FTDecayFunction2DVoigtItem()
 
 std::unique_ptr<IFTDecayFunction2D> FTDecayFunction2DVoigtItem::createFTDecayFunction() const
 {
-    auto result = std::make_unique<FTDecayFunction2DVoigt>(
+    return std::make_unique<FTDecayFunction2DVoigt>(
         getItemValue(P_DECAY_LENGTH_X).toDouble(), getItemValue(P_DECAY_LENGTH_Y).toDouble(),
         getItemValue(P_ETA).toDouble(),
         Units::deg2rad(getItemValue(P_GAMMA).toDouble()));
-
-    return std::move(result);
 }

--- a/GUI/coregui/Models/FTDistributionItems.cpp
+++ b/GUI/coregui/Models/FTDistributionItems.cpp
@@ -163,11 +163,10 @@ FTDistribution2DCauchyItem::FTDistribution2DCauchyItem()
 
 std::unique_ptr<IFTDistribution2D> FTDistribution2DCauchyItem::createFTDistribution() const
 {
-    auto result = std::make_unique<FTDistribution2DCauchy>(
+    return std::make_unique<FTDistribution2DCauchy>(
                 getItemValue(P_OMEGA_X).toDouble(),
                 getItemValue(P_OMEGA_Y).toDouble(),
                 Units::deg2rad(getItemValue(P_GAMMA).toDouble()));
-    return std::move(result);
 }
 
 // --------------------------------------------------------------------------------------------- //
@@ -181,11 +180,9 @@ FTDistribution2DGaussItem::FTDistribution2DGaussItem()
 
 std::unique_ptr<IFTDistribution2D> FTDistribution2DGaussItem::createFTDistribution() const
 {
-    auto result = std::make_unique<FTDistribution2DGauss>(
+    return std::make_unique<FTDistribution2DGauss>(
         getItemValue(P_OMEGA_X).toDouble(), getItemValue(P_OMEGA_Y).toDouble(),
         Units::deg2rad(getItemValue(P_GAMMA).toDouble()));
-
-    return std::move(result);
 }
 
 // --------------------------------------------------------------------------------------------- //
@@ -199,10 +196,9 @@ FTDistribution2DGateItem::FTDistribution2DGateItem()
 
 std::unique_ptr<IFTDistribution2D> FTDistribution2DGateItem::createFTDistribution() const
 {
-    auto result = std::make_unique<FTDistribution2DGate>(
+    return std::make_unique<FTDistribution2DGate>(
         getItemValue(P_OMEGA_X).toDouble(), getItemValue(P_OMEGA_Y).toDouble(),
         Units::deg2rad(getItemValue(P_GAMMA).toDouble()));
-    return std::move(result);
 }
 
 // --------------------------------------------------------------------------------------------- //
@@ -216,10 +212,9 @@ FTDistribution2DConeItem::FTDistribution2DConeItem()
 
 std::unique_ptr<IFTDistribution2D> FTDistribution2DConeItem::createFTDistribution() const
 {
-    auto result = std::make_unique<FTDistribution2DCone>(
+    return std::make_unique<FTDistribution2DCone>(
         getItemValue(P_OMEGA_X).toDouble(), getItemValue(P_OMEGA_Y).toDouble(),
         Units::deg2rad(getItemValue(P_GAMMA).toDouble()));
-    return std::move(result);
 }
 
 // --------------------------------------------------------------------------------------------- //
@@ -239,9 +234,8 @@ FTDistribution2DVoigtItem::FTDistribution2DVoigtItem()
 
 std::unique_ptr<IFTDistribution2D> FTDistribution2DVoigtItem::createFTDistribution() const
 {
-    auto result = std::make_unique<FTDistribution2DVoigt>(
+    return std::make_unique<FTDistribution2DVoigt>(
         getItemValue(P_OMEGA_X).toDouble(), getItemValue(P_OMEGA_Y).toDouble(),
         getItemValue(P_ETA).toDouble(),
         Units::deg2rad(getItemValue(P_GAMMA).toDouble()));
-    return std::move(result);
 }

--- a/GUI/coregui/Models/InterferenceFunctionItems.cpp
+++ b/GUI/coregui/Models/InterferenceFunctionItems.cpp
@@ -80,7 +80,7 @@ InterferenceFunction1DLatticeItem::createInterferenceFunction() const
         getGroupItem(InterferenceFunction1DLatticeItem::P_DECAY_FUNCTION));
     result->setDecayFunction(*pdfItem->createFTDecayFunction());
     setPositionVariance(result.get());
-    return std::move(result);
+    return std::unique_ptr<IInterferenceFunction>(result.release());
 }
 
 // --------------------------------------------------------------------------------------------- //
@@ -124,7 +124,7 @@ InterferenceFunction2DLatticeItem::createInterferenceFunction() const
     result->setIntegrationOverXi(getItemValue(P_XI_INTEGRATION).toBool());
     setPositionVariance(result.get());
 
-    return std::move(result);
+    return std::unique_ptr<IInterferenceFunction>(result.release());
 }
 
 void InterferenceFunction2DLatticeItem::update_rotation_availability()
@@ -210,7 +210,7 @@ InterferenceFunction2DParaCrystalItem::createInterferenceFunction() const
                                         *pdf2Item.createFTDistribution());
 
     setPositionVariance(result.get());
-    return std::move(result);
+    return std::unique_ptr<IInterferenceFunction>(result.release());
 }
 
 //! Sets rotation property of the lattice enabled/disabled depending on integration flag.
@@ -292,7 +292,7 @@ InterferenceFunctionFinite2DLatticeItem::createInterferenceFunction() const
     result->setIntegrationOverXi(getItemValue(P_XI_INTEGRATION).toBool());
     setPositionVariance(result.get());
 
-    return std::move(result);
+    return std::unique_ptr<IInterferenceFunction>(result.release());
 }
 
 void InterferenceFunctionFinite2DLatticeItem::update_rotation_availability()
@@ -326,7 +326,7 @@ std::unique_ptr<IInterferenceFunction> InterferenceFunctionHardDiskItem::createI
     auto result = std::make_unique<InterferenceFunctionHardDisk>(
         getItemValue(P_RADIUS).toDouble(), getItemValue(P_DENSITY).toDouble());
     setPositionVariance(result.get());
-    return std::move(result);
+    return std::unique_ptr<IInterferenceFunction>(result.release());
 }
 
 // --------------------------------------------------------------------------------------------- //
@@ -371,5 +371,5 @@ InterferenceFunctionRadialParaCrystalItem::createInterferenceFunction() const
     auto& pdfItem = groupItem<FTDistribution1DItem>(P_PDF);
     result->setProbabilityDistribution(*pdfItem.createFTDistribution());
     setPositionVariance(result.get());
-    return std::move(result);
+    return std::unique_ptr<IInterferenceFunction>(result.release());
 }

--- a/GUI/coregui/Models/JobItem.cpp
+++ b/GUI/coregui/Models/JobItem.cpp
@@ -183,7 +183,7 @@ void JobItem::setDuration(int duration)
 {
     QString str;
     if (duration != 0)
-        str.sprintf("%7.3f", duration / 1000.);
+        str = QString("%7.3f").arg(duration / 1000.);
     setItemValue(P_DURATION, str.simplified());
 }
 

--- a/GUI/coregui/Models/RectangularDetectorItem.cpp
+++ b/GUI/coregui/Models/RectangularDetectorItem.cpp
@@ -188,7 +188,7 @@ std::unique_ptr<IDetector2D> RectangularDetectorItem::createDomainDetector() con
         result->setPerpendicularToReflectedBeam(distance);
         result->setDirectBeamPosition(dbeam_u0, dbeam_v0);
     }
-    return std::move(result);
+    return std::unique_ptr<IDetector2D>(result.release());
 }
 
 //! updates property tooltips and visibility flags, depending from type of alignment selected

--- a/GUI/coregui/Models/SphericalDetectorItem.cpp
+++ b/GUI/coregui/Models/SphericalDetectorItem.cpp
@@ -62,7 +62,7 @@ std::unique_ptr<IDetector2D> SphericalDetectorItem::createDomainDetector() const
 
     result->setDetectorParameters(n_x, x_min, x_max, n_y, y_min, y_max);
 
-    return std::move(result);
+    return std::unique_ptr<IDetector2D>(result.release());
 }
 
 int SphericalDetectorItem::xSize() const

--- a/GUI/coregui/Views/InfoWidgets/DistributionWidget.cpp
+++ b/GUI/coregui/Views/InfoWidgets/DistributionWidget.cpp
@@ -223,7 +223,12 @@ void DistributionWidget::plot_multiple_values()
     double sumOfWeights = std::accumulate(yp.begin(), yp.end(), 0.0);
     Q_ASSERT(sumOfWeights != 0.0);
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    QVector<double> xBar(xp.begin(), xp.end());
+#else
     QVector<double> xBar = QVector<double>::fromStdVector(xp);
+#endif
+
     QVector<double> yBar(xBar.size());
     std::transform(yp.begin(), yp.end(), yBar.begin(),
                    [&](double value) { return value / sumOfWeights; });
@@ -239,7 +244,11 @@ void DistributionWidget::plot_multiple_values()
     std::transform(xf.begin(), xf.end(), yf.begin(),
                    [&](double value) { return dist->probabilityDensity(value); });
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    QVector<double> xFunc(xf.begin(), xf.end());
+#else
     QVector<double> xFunc = QVector<double>::fromStdVector(xf);
+#endif
     QVector<double> yFunc(xFunc.size());
     std::transform(yf.begin(), yf.end(), yFunc.begin(),
                    [&](double value) { return value / sumOfWeights; });

--- a/GUI/coregui/Views/IntensityDataWidgets/ProjectionsPlot.cpp
+++ b/GUI/coregui/Views/IntensityDataWidgets/ProjectionsPlot.cpp
@@ -283,8 +283,16 @@ void ProjectionsPlot::setGraphFromItem(QCPGraph* graph, SessionItem* item)
         hist.reset(m_hist2d->projectionY(value));
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    auto centers = hist->getBinCenters();
+    auto values = hist->getBinValues();
+    graph->setData(QVector<double>(centers.begin(), centers.end()),
+                   QVector<double>(values.begin(), values.end()));
+#else
     graph->setData(QVector<double>::fromStdVector(hist->getBinCenters()),
                    QVector<double>::fromStdVector(hist->getBinValues()));
+#endif
+
 }
 
 void ProjectionsPlot::setInterpolate(bool isInterpolated)

--- a/GUI/coregui/Views/IntensityDataWidgets/SaveProjectionsAssistant.cpp
+++ b/GUI/coregui/Views/IntensityDataWidgets/SaveProjectionsAssistant.cpp
@@ -126,9 +126,20 @@ SaveProjectionsAssistant::projectionsData(const QString& projectionsType,
             data.axis_value = item->getItemValue(VerticalLineItem::P_POSX).toDouble();
             hist.reset(m_hist2d->projectionY(data.axis_value));
         }
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        auto values = hist->getBinValues();
+        auto centers = hist->getBinCenters();
+        data.bin_values = QVector<double>(values.begin(), values.end());
+        if (result.bin_centers.isEmpty())
+            result.bin_centers = QVector<double>(centers.begin(), centers.end());
+#else
         data.bin_values = QVector<double>::fromStdVector(hist->getBinValues());
         if (result.bin_centers.isEmpty())
             result.bin_centers = QVector<double>::fromStdVector(hist->getBinCenters());
+#endif
+
+
 
         result.projections.push_back(data);
     }

--- a/GUI/coregui/mainwindow/ProjectUtils.cpp
+++ b/GUI/coregui/mainwindow/ProjectUtils.cpp
@@ -120,8 +120,15 @@ bool ProjectUtils::removeFiles(const QString &dirname, const QStringList &filena
 
 QStringList ProjectUtils::substract(const QStringList &lhs, const QStringList &rhs)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    auto lhs_set = QSet<QString>{lhs.begin(), lhs.end()};
+    auto rhs_set = QSet<QString>{rhs.begin(), rhs.end()};
+    QSet<QString> diff = lhs_set.subtract(rhs_set);
+    return diff.values();
+#else
     QSet<QString> diff = lhs.toSet().subtract(rhs.toSet());
     return diff.toList();
+#endif
 }
 
 QString ProjectUtils::readTextFile(const QString& fileName)

--- a/GUI/coregui/mainwindow/SplashScreen.cpp
+++ b/GUI/coregui/mainwindow/SplashScreen.cpp
@@ -17,6 +17,7 @@
 #include <QStyle>
 #include <QCoreApplication>
 #include <QTime>
+#include <QElapsedTimer>
 
 namespace {
 const int panel_height = 380;
@@ -38,7 +39,7 @@ void SplashScreen::start(int show_during)
 {
     show();
     QTime dieTime = QTime::currentTime().addMSecs(show_during);
-    QTime timer;
+    QElapsedTimer timer;
     timer.start();
     while (QTime::currentTime() < dieTime) {
         setProgress(timer.elapsed() / (show_during / 100));

--- a/GUI/coregui/mainwindow/actionmanager.cpp
+++ b/GUI/coregui/mainwindow/actionmanager.cpp
@@ -158,7 +158,7 @@ void ActionManager::aboutToShowFileMenu()
         hasRecentProjects = true;
         QAction* action = m_recentProjectsMenu->addAction(
             QDir::toNativeSeparators(GUI_StringUtils::withTildeHomePath(file)));
-        action->setData(qVariantFromValue(file));
+        action->setData(QVariant::fromValue(file));
         connect(action, &QAction::triggered, m_mainWindow, &MainWindow::openRecentProject);
     }
     m_recentProjectsMenu->setEnabled(hasRecentProjects);

--- a/GUI/coregui/utils/MessageService.cpp
+++ b/GUI/coregui/utils/MessageService.cpp
@@ -59,7 +59,12 @@ QStringList MessageService::senderList() const
     for (auto message : messages())
         set.insert(message->senderName());
 
-    return set.toList();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        return set.values();
+#else
+        return set.toList();
+#endif
+
 }
 
 //! Reports number of messages of given type reported by the sender.

--- a/Tests/UnitTests/Core/Detector/RectangularDetectorTest.cpp
+++ b/Tests/UnitTests/Core/Detector/RectangularDetectorTest.cpp
@@ -68,8 +68,8 @@ TEST_F(RectangularDetectorTest, PerpToSample)
     size_t nbinsx(5u), nbinsy(4u);
     double width(50.0), height(40.0);
     double distance(100.0), u0(20.0), v0(10.0);
-    double dx = width / nbinsx;
-    double dy = height / nbinsy;
+//    double dx = width / nbinsx;
+//    double dy = height / nbinsy;
 
     RectangularDetector det(nbinsx, width, nbinsy, height);
 
@@ -121,8 +121,8 @@ TEST_F(RectangularDetectorTest, PerpToDirectBeam)
     size_t nbinsx(5u), nbinsy(4u);
     double width(50.0), height(40.0);
     double distance(100.0), u0(20.0), v0(10.0);
-    double dx = width / nbinsx;
-    double dy = height / nbinsy;
+//    double dx = width / nbinsx;
+//    double dy = height / nbinsy;
     double alpha_i(10.0 * Units::degree);
 
     RectangularDetector det(nbinsx, width, nbinsy, height);
@@ -164,8 +164,8 @@ TEST_F(RectangularDetectorTest, PerpToReflectedBeam)
     size_t nbinsx(5u), nbinsy(4u);
     double width(50.0), height(40.0);
     double distance(100.0), u0(20.0), v0(10.0);
-    double dx = width / nbinsx;
-    double dy = height / nbinsy;
+//    double dx = width / nbinsx;
+//    double dy = height / nbinsy;
     double alpha_i(10.0 * Units::degree);
 
     RectangularDetector det(nbinsx, width, nbinsy, height);
@@ -209,8 +209,8 @@ TEST_F(RectangularDetectorTest, PerpToReflectedBeamDpos)
     size_t nbinsx(5u), nbinsy(4u);
     double width(50.0), height(40.0);
     double distance(100.0), u0(20.0), v0(10.0);
-    double dx = width / nbinsx;
-    double dy = height / nbinsy;
+//    double dx = width / nbinsx;
+//    double dy = height / nbinsy;
     double alpha_i(10.0 * Units::degree);
 
     RectangularDetector det(nbinsx, width, nbinsy, height);

--- a/ThirdParty/GUI/qcustomplot/qcustomplot.cpp
+++ b/ThirdParty/GUI/qcustomplot/qcustomplot.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
 **                                                                        **
 **  QCustomPlot, an easy to use, modern plotting widget for Qt            **
-**  Copyright (C) 2011-2017 Emanuel Eichhammer                            **
+**  Copyright (C) 2011-2018 Emanuel Eichhammer                            **
 **                                                                        **
 **  This program is free software: you can redistribute it and/or modify  **
 **  it under the terms of the GNU General Public License as published by  **
@@ -19,15 +19,15 @@
 ****************************************************************************
 **           Author: Emanuel Eichhammer                                   **
 **  Website/Contact: http://www.qcustomplot.com/                          **
-**             Date: 04.09.17                                             **
-**          Version: 2.0.0                                                **
+**             Date: 25.06.18                                             **
+**          Version: 2.0.1                                                **
 ****************************************************************************/
 
 #include "qcustomplot.h"
 
 
 /* including file 'src/vector2d.cpp', size 7340                              */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPVector2D
@@ -260,7 +260,7 @@ QCPVector2D &QCPVector2D::operator-=(const QCPVector2D &vector)
 
 
 /* including file 'src/painter.cpp', size 8670                               */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPPainter
@@ -478,7 +478,7 @@ void QCPPainter::makeNonCosmetic()
 
 
 /* including file 'src/paintbuffer.cpp', size 18502                          */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPAbstractPaintBuffer
@@ -950,8 +950,8 @@ void QCPPaintBufferGlFbo::reallocateBuffer()
 /* end of 'src/paintbuffer.cpp' */
 
 
-/* including file 'src/layer.cpp', size 37064                                */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/layer.cpp', size 37304                                */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPLayer
@@ -1464,9 +1464,13 @@ bool QCPLayerable::realVisibility() const
   placed in \a details. So in the subsequent \ref selectEvent, the decision which part was
   selected doesn't have to be done a second time for a single selection operation.
   
+  In the case of 1D Plottables (\ref QCPAbstractPlottable1D, like \ref QCPGraph or \ref QCPBars) \a
+  details will be set to a \ref QCPDataSelection, describing the closest data point to \a pos.
+  
   You may pass 0 as \a details to indicate that you are not interested in those selection details.
   
-  \see selectEvent, deselectEvent, mousePressEvent, wheelEvent, QCustomPlot::setInteractions
+  \see selectEvent, deselectEvent, mousePressEvent, wheelEvent, QCustomPlot::setInteractions,
+  QCPAbstractPlottable1D::selectTestRect
 */
 double QCPLayerable::selectTest(const QPointF &pos, bool onlySelectable, QVariant *details) const
 {
@@ -1804,7 +1808,7 @@ void QCPLayerable::wheelEvent(QWheelEvent *event)
 
 
 /* including file 'src/axis/range.cpp', size 12221                           */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPRange
@@ -2125,8 +2129,8 @@ bool QCPRange::validRange(const QCPRange &range)
 /* end of 'src/axis/range.cpp' */
 
 
-/* including file 'src/selection.cpp', size 21906                            */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/selection.cpp', size 21941                            */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPDataRange
@@ -2136,8 +2140,9 @@ bool QCPRange::validRange(const QCPRange &range)
   \brief Describes a data range given by begin and end index
   
   QCPDataRange holds two integers describing the begin (\ref setBegin) and end (\ref setEnd) index
-  of a contiguous set of data points. The end index points to the data point above the last data point that's part of
-  the data range, similarly to the nomenclature used in standard iterators.
+  of a contiguous set of data points. The end index points to the data point just after the last
+  data point that's part of the data range, similarly to the nomenclature used in standard
+  iterators.
   
   Data Ranges are not bound to a certain plottable, thus they can be freely exchanged, created and
   modified. If a non-contiguous data set shall be described, the class \ref QCPDataSelection is
@@ -2184,7 +2189,7 @@ bool QCPRange::validRange(const QCPRange &range)
 
 /*! \fn void QCPDataRange::setEnd(int end)
   
-  Sets the end of this data range. The \a end index points to the data point just above the last
+  Sets the end of this data range. The \a end index points to the data point just after the last
   data point that is part of the data range.
   
   No checks or corrections are made to ensure the resulting range is valid (\ref isValid).
@@ -2300,7 +2305,7 @@ bool QCPDataRange::intersects(const QCPDataRange &other) const
 }
 
 /*!
-  Returns whether all data points described by this data range are also in \a other.
+  Returns whether all data points of \a other are also contained inside this data range.
   
   \see intersects
 */
@@ -2631,7 +2636,8 @@ void QCPDataSelection::enforceType(QCP::SelectionType type)
     }
     case QCP::stDataRange:
     {
-      mDataRanges = QList<QCPDataRange>() << span();
+      if (!isEmpty())
+        mDataRanges = QList<QCPDataRange>() << span();
       break;
     }
     case QCP::stMultipleDataRanges:
@@ -2726,7 +2732,7 @@ QCPDataSelection QCPDataSelection::inverse(const QCPDataRange &outerRange) const
 
 
 /* including file 'src/selectionrect.cpp', size 9224                         */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPSelectionRect
@@ -2954,8 +2960,8 @@ void QCPSelectionRect::draw(QCPPainter *painter)
 /* end of 'src/selectionrect.cpp' */
 
 
-/* including file 'src/layout.cpp', size 79064                               */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/layout.cpp', size 79139                               */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPMarginGroup
@@ -4074,7 +4080,7 @@ QCPLayoutGrid::QCPLayoutGrid() :
   mColumnSpacing(5),
   mRowSpacing(5),
   mWrap(0),
-  mFillOrder(foRowsFirst)
+  mFillOrder(foColumnsFirst)
 {
 }
 
@@ -4350,7 +4356,8 @@ void QCPLayoutGrid::setWrap(int count)
   The specified \a order defines whether rows or columns are filled first. Using \ref setWrap, you
   can control at which row/column count wrapping into the next column/row will occur. If you set it
   to zero, no wrapping will ever occur. Changing the fill order also changes the meaning of the
-  linear index used e.g. in \ref elementAt and \ref takeAt.
+  linear index used e.g. in \ref elementAt and \ref takeAt. The default fill order for \ref
+  QCPLayoutGrid is \ref foColumnsFirst.
 
   If you want to have all current elements arranged in the new order, set \a rearrange to true. The
   elements will be rearranged in a way that tries to preserve their linear index. However, empty
@@ -5125,7 +5132,7 @@ void QCPLayoutInset::addElement(QCPLayoutElement *element, const QRectF &rect)
 
 
 /* including file 'src/lineending.cpp', size 11536                           */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPLineEnding
@@ -5424,7 +5431,7 @@ void QCPLineEnding::draw(QCPPainter *painter, const QCPVector2D &pos, double ang
 
 
 /* including file 'src/axis/axisticker.cpp', size 18664                      */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPAxisTicker
@@ -5844,7 +5851,7 @@ double QCPAxisTicker::cleanMantissa(double input) const
 
 
 /* including file 'src/axis/axistickerdatetime.cpp', size 14443              */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPAxisTickerDateTime
@@ -6141,7 +6148,7 @@ double QCPAxisTickerDateTime::dateTimeToKey(const QDate date)
 
 
 /* including file 'src/axis/axistickertime.cpp', size 11747                  */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPAxisTickerTime
@@ -6390,7 +6397,7 @@ void QCPAxisTickerTime::replaceUnit(QString &text, QCPAxisTickerTime::TimeUnit u
 
 
 /* including file 'src/axis/axistickerfixed.cpp', size 5583                  */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPAxisTickerFixed
@@ -6491,8 +6498,8 @@ double QCPAxisTickerFixed::getTickStep(const QCPRange &range)
 /* end of 'src/axis/axistickerfixed.cpp' */
 
 
-/* including file 'src/axis/axistickertext.cpp', size 8653                   */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/axis/axistickertext.cpp', size 8661                   */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPAxisTickerText
@@ -6562,7 +6569,7 @@ void QCPAxisTickerText::setTicks(const QMap<double, QString> &ticks)
   
   \see addTicks, addTick, clear
 */
-void QCPAxisTickerText::setTicks(const QVector<double> &positions, const QVector<QString> labels)
+void QCPAxisTickerText::setTicks(const QVector<double> &positions, const QVector<QString> &labels)
 {
   clear();
   addTicks(positions, labels);
@@ -6600,7 +6607,7 @@ void QCPAxisTickerText::clear()
   
   \see addTicks, setTicks, clear
 */
-void QCPAxisTickerText::addTick(double position, QString label)
+void QCPAxisTickerText::addTick(double position, const QString &label)
 {
   mTicks.insert(position, label);
 }
@@ -6705,7 +6712,7 @@ QVector<double> QCPAxisTickerText::createTickVector(double tickStep, const QCPRa
 
 
 /* including file 'src/axis/axistickerpi.cpp', size 11170                    */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPAxisTickerPi
@@ -6992,7 +6999,7 @@ QString QCPAxisTickerPi::unicodeSubscript(int number) const
 
 
 /* including file 'src/axis/axistickerlog.cpp', size 7106                    */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPAxisTickerLog
@@ -7132,8 +7139,8 @@ QVector<double> QCPAxisTickerLog::createTickVector(double tickStep, const QCPRan
 /* end of 'src/axis/axistickerlog.cpp' */
 
 
-/* including file 'src/axis/axis.cpp', size 99397                            */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/axis/axis.cpp', size 99515                            */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -7653,10 +7660,14 @@ QCPLineEnding QCPAxis::upperEnding() const
 /*!
   Sets whether the axis uses a linear scale or a logarithmic scale.
   
-  Note that this method controls the coordinate transformation. You will likely also want to use a
-  logarithmic tick spacing and labeling, which can be achieved by setting an instance of \ref
-  QCPAxisTickerLog via \ref setTicker. See the documentation of \ref QCPAxisTickerLog about the
-  details of logarithmic axis tick creation.
+  Note that this method controls the coordinate transformation. For logarithmic scales, you will
+  likely also want to use a logarithmic tick spacing and labeling, which can be achieved by setting
+  the axis ticker to an instance of \ref QCPAxisTickerLog :
+  
+  \snippet documentation/doc-code-snippets/mainwindow.cpp qcpaxisticker-log-creation
+  
+  See the documentation of \ref QCPAxisTickerLog about the details of logarithmic axis tick
+  creation.
   
   \ref setNumberPrecision
 */
@@ -9819,7 +9830,7 @@ void QCPAxisPainterPrivate::getMaxTickLabelSize(const QFont &font, const QString
 
 
 /* including file 'src/scatterstyle.cpp', size 17450                         */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPScatterStyle
@@ -10293,7 +10304,7 @@ void QCPScatterStyle::drawShape(QCPPainter *painter, double x, double y) const
 //amalgamation: add datacontainer.cpp
 
 /* including file 'src/plottable.cpp', size 38845                            */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPSelectionDecorator
@@ -11265,8 +11276,8 @@ void QCPAbstractPlottable::deselectEvent(bool *selectionStateChanged)
 /* end of 'src/plottable.cpp' */
 
 
-/* including file 'src/item.cpp', size 49269                                 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/item.cpp', size 49271                                 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPItemAnchor
@@ -12411,7 +12422,7 @@ double QCPAbstractItem::rectDistance(const QRectF &rect, const QPointF &pos, boo
   QList<QLineF> lines;
   lines << QLineF(rect.topLeft(), rect.topRight()) << QLineF(rect.bottomLeft(), rect.bottomRight())
         << QLineF(rect.topLeft(), rect.bottomLeft()) << QLineF(rect.topRight(), rect.bottomRight());
-  double minDistSqr = std::numeric_limits<double>::max();
+  double minDistSqr = (std::numeric_limits<double>::max)();
   for (int i=0; i<lines.size(); ++i)
   {
     double distSqr = QCPVector2D(pos).distanceSquaredToLine(lines.at(i).p1(), lines.at(i).p2());
@@ -12536,8 +12547,8 @@ QCP::Interaction QCPAbstractItem::selectionCategory() const
 /* end of 'src/item.cpp' */
 
 
-/* including file 'src/core.cpp', size 125037                                */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/core.cpp', size 126207                                */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCustomPlot
@@ -14189,7 +14200,17 @@ int QCustomPlot::axisRectCount() const
   added, all of them may be accessed with this function in a linear fashion (even when they are
   nested in a layout hierarchy or inside other axis rects via QCPAxisRect::insetLayout).
   
-  \see axisRectCount, axisRects
+  The order of the axis rects is given by the fill order of the \ref QCPLayout that is holding
+  them. For example, if the axis rects are in the top level grid layout (accessible via \ref
+  QCustomPlot::plotLayout), they are ordered from left to right, top to bottom, if the layout's
+  default \ref QCPLayoutGrid::setFillOrder "setFillOrder" of \ref QCPLayoutGrid::foColumnsFirst
+  "foColumnsFirst" wasn't changed.
+  
+  If you want to access axis rects by their row and column index, use the layout interface. For
+  example, use \ref QCPLayoutGrid::element of the top level grid layout, and \c qobject_cast the
+  returned layout element to \ref QCPAxisRect. (See also \ref thelayoutsystem.)
+  
+  \see axisRectCount, axisRects, QCPLayoutGrid::setFillOrder
 */
 QCPAxisRect *QCustomPlot::axisRect(int index) const
 {
@@ -14207,7 +14228,13 @@ QCPAxisRect *QCustomPlot::axisRect(int index) const
 /*!
   Returns all axis rects in the plot.
   
-  \see axisRectCount, axisRect
+  The order of the axis rects is given by the fill order of the \ref QCPLayout that is holding
+  them. For example, if the axis rects are in the top level grid layout (accessible via \ref
+  QCustomPlot::plotLayout), they are ordered from left to right, top to bottom, if the layout's
+  default \ref QCPLayoutGrid::setFillOrder "setFillOrder" of \ref QCPLayoutGrid::foColumnsFirst
+  "foColumnsFirst" wasn't changed.
+  
+  \see axisRectCount, axisRect, QCPLayoutGrid::setFillOrder
 */
 QList<QCPAxisRect*> QCustomPlot::axisRects() const
 {
@@ -15718,8 +15745,8 @@ void QCustomPlot::toPainter(QCPPainter *painter, int width, int height)
 
 //amalgamation: add plottable1d.cpp
 
-/* including file 'src/colorgradient.cpp', size 24646                        */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/colorgradient.cpp', size 25342                        */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -16282,10 +16309,22 @@ void QCPColorGradient::updateColorBuffer()
       QMap<double, QColor>::const_iterator it = mColorStops.lowerBound(position);
       if (it == mColorStops.constEnd()) // position is on or after last stop, use color of last stop
       {
-        mColorBuffer[i] = (it-1).value().rgba();
+        if (useAlpha)
+        {
+          const QColor col = (it-1).value();
+          const float alphaPremultiplier = col.alpha()/255.0f; // since we use QImage::Format_ARGB32_Premultiplied
+          mColorBuffer[i] = qRgba(col.red()*alphaPremultiplier, col.green()*alphaPremultiplier, col.blue()*alphaPremultiplier, col.alpha());
+        } else
+          mColorBuffer[i] = (it-1).value().rgba();
       } else if (it == mColorStops.constBegin()) // position is on or before first stop, use color of first stop
       {
-        mColorBuffer[i] = it.value().rgba();
+        if (useAlpha)
+        {
+          const QColor col = it.value();
+          const float alphaPremultiplier = col.alpha()/255.0f; // since we use QImage::Format_ARGB32_Premultiplied
+          mColorBuffer[i] = qRgba(col.red()*alphaPremultiplier, col.green()*alphaPremultiplier, col.blue()*alphaPremultiplier, col.alpha());
+        } else
+          mColorBuffer[i] = it.value().rgba();
       } else // position is in between stops (or on an intermediate stop), interpolate color
       {
         QMap<double, QColor>::const_iterator high = it;
@@ -16359,7 +16398,7 @@ void QCPColorGradient::updateColorBuffer()
 
 
 /* including file 'src/selectiondecorator-bracket.cpp', size 12313           */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPSelectionDecoratorBracket
@@ -16645,7 +16684,7 @@ QPointF QCPSelectionDecoratorBracket::getPixelCoordinates(const QCPPlottableInte
 
 
 /* including file 'src/layoutelements/layoutelement-axisrect.cpp', size 47584 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200  */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200  */
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -17919,8 +17958,8 @@ void QCPAxisRect::wheelEvent(QWheelEvent *event)
 /* end of 'src/layoutelements/layoutelement-axisrect.cpp' */
 
 
-/* including file 'src/layoutelements/layoutelement-legend.cpp', size 31097  */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/layoutelements/layoutelement-legend.cpp', size 31153  */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPAbstractLegendItem
@@ -18259,7 +18298,7 @@ QSize QCPPlottableLegendItem::minimumOuterSizeHint() const
 
   Use the methods \ref setFillOrder and \ref setWrap inherited from \ref QCPLayoutGrid to control
   in which order (column first or row first) the legend is filled up when calling \ref addItem, and
-  at which column or row wrapping occurs.
+  at which column or row wrapping occurs. The default fill order for legends is \ref foRowsFirst.
 
   By default, every QCustomPlot has one legend (\ref QCustomPlot::legend) which is placed in the
   inset layout of the main axis rect (\ref QCPAxisRect::insetLayout). To move the legend to another
@@ -18836,7 +18875,7 @@ void QCPLegend::parentPlotInitialized(QCustomPlot *parentPlot)
 
 
 /* including file 'src/layoutelements/layoutelement-textelement.cpp', size 12761 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200     */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200     */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPTextElement
@@ -19239,8 +19278,8 @@ QColor QCPTextElement::mainTextColor() const
 /* end of 'src/layoutelements/layoutelement-textelement.cpp' */
 
 
-/* including file 'src/layoutelements/layoutelement-colorscale.cpp', size 25770 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200    */
+/* including file 'src/layoutelements/layoutelement-colorscale.cpp', size 26246 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200    */
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -19459,12 +19498,21 @@ void QCPColorScale::setDataRange(const QCPRange &dataRange)
 }
 
 /*!
-  Sets the scale type of the color scale, i.e. whether values are linearly associated with colors
+  Sets the scale type of the color scale, i.e. whether values are associated with colors linearly
   or logarithmically.
   
   It is equivalent to calling QCPColorMap::setDataScaleType on any of the connected color maps. It is
   also equivalent to directly accessing the \ref axis and setting its scale type with \ref
   QCPAxis::setScaleType.
+  
+  Note that this method controls the coordinate transformation. For logarithmic scales, you will
+  likely also want to use a logarithmic tick spacing and labeling, which can be achieved by setting
+  the color scale's \ref axis ticker to an instance of \ref QCPAxisTickerLog :
+  
+  \snippet documentation/doc-code-snippets/mainwindow.cpp qcpaxisticker-log-colorscale
+  
+  See the documentation of \ref QCPAxisTickerLog about the details of logarithmic axis tick
+  creation.
   
   \see setDataRange, setGradient
 */
@@ -19899,8 +19947,8 @@ void QCPColorScaleAxisRectPrivate::axisSelectableChanged(QCPAxis::SelectablePart
 /* end of 'src/layoutelements/layoutelement-colorscale.cpp' */
 
 
-/* including file 'src/plottables/plottable-graph.cpp', size 73960           */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/plottables/plottable-graph.cpp', size 74194           */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPGraphData
@@ -20259,7 +20307,14 @@ void QCPGraph::addData(double key, double value)
   mDataContainer->add(QCPGraphData(key, value));
 }
 
-/* inherits documentation from base class */
+/*!
+  Implements a selectTest specific to this plottable's point geometry.
+
+  If \a details is not 0, it will be set to a \ref QCPDataSelection, describing the closest data
+  point to \a pos.
+  
+  \seebaseclassmethod \ref QCPAbstractPlottable::selectTest
+*/
 double QCPGraph::selectTest(const QPointF &pos, bool onlySelectable, QVariant *details) const
 {
   if ((onlySelectable && mSelectable == QCP::stNone) || mDataContainer->isEmpty())
@@ -20857,11 +20912,11 @@ void QCPGraph::getOptimizedLineData(QVector<QCPGraphData> *lineData, const QCPGr
   if (begin == end) return;
   
   int dataCount = end-begin;
-  int maxCount = std::numeric_limits<int>::max();
+  int maxCount = (std::numeric_limits<int>::max)();
   if (mAdaptiveSampling)
   {
     double keyPixelSpan = qAbs(keyAxis->coordToPixel(begin->key)-keyAxis->coordToPixel((end-1)->key));
-    if (2*keyPixelSpan+2 < (double)std::numeric_limits<int>::max())
+    if (2*keyPixelSpan+2 < static_cast<double>((std::numeric_limits<int>::max)()))
       maxCount = 2*keyPixelSpan+2;
   }
   
@@ -20958,7 +21013,7 @@ void QCPGraph::getOptimizedScatterData(QVector<QCPGraphData> *scatterData, QCPGr
   }
   if (begin == end) return;
   int dataCount = end-begin;
-  int maxCount = std::numeric_limits<int>::max();
+  int maxCount = (std::numeric_limits<int>::max)();
   if (mAdaptiveSampling)
   {
     int keyPixelSpan = qAbs(keyAxis->coordToPixel(begin->key)-keyAxis->coordToPixel((end-1)->key));
@@ -21583,7 +21638,7 @@ double QCPGraph::pointDistance(const QPointF &pixelPoint, QCPGraphDataContainer:
     return -1.0;
   
   // calculate minimum distances to graph data points and find closestData iterator:
-  double minDistSqr = std::numeric_limits<double>::max();
+  double minDistSqr = (std::numeric_limits<double>::max)();
   // determine which key range comes into question, taking selection tolerance around pos into account:
   double posKeyMin, posKeyMax, dummy;
   pixelsToCoords(pixelPoint-QPointF(mParentPlot->selectionTolerance(), mParentPlot->selectionTolerance()), posKeyMin, dummy);
@@ -21647,8 +21702,8 @@ int QCPGraph::findIndexBelowY(const QVector<QPointF> *data, double y) const
 /* end of 'src/plottables/plottable-graph.cpp' */
 
 
-/* including file 'src/plottables/plottable-curve.cpp', size 63527           */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/plottables/plottable-curve.cpp', size 63742           */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPCurveData
@@ -22014,7 +22069,14 @@ void QCPCurve::addData(double key, double value)
     mDataContainer->add(QCPCurveData(0.0, key, value));
 }
 
-/* inherits documentation from base class */
+/*!
+  Implements a selectTest specific to this plottable's point geometry.
+
+  If \a details is not 0, it will be set to a \ref QCPDataSelection, describing the closest data
+  point to \a pos.
+  
+  \seebaseclassmethod \ref QCPAbstractPlottable::selectTest
+*/
 double QCPCurve::selectTest(const QPointF &pos, bool onlySelectable, QVariant *details) const
 {
   if ((onlySelectable && mSelectable == QCP::stNone) || mDataContainer->isEmpty())
@@ -23064,7 +23126,7 @@ double QCPCurve::pointDistance(const QPointF &pixelPoint, QCPCurveDataContainer:
   }
   
   // calculate minimum distances to curve data points and find closestData iterator:
-  double minDistSqr = std::numeric_limits<double>::max();
+  double minDistSqr = (std::numeric_limits<double>::max)();
   // iterate over found data points and then choose the one with the shortest distance to pos:
   QCPCurveDataContainer::const_iterator begin = mDataContainer->constBegin();
   QCPCurveDataContainer::const_iterator end = mDataContainer->constEnd();
@@ -23096,8 +23158,8 @@ double QCPCurve::pointDistance(const QPointF &pixelPoint, QCPCurveDataContainer:
 /* end of 'src/plottables/plottable-curve.cpp' */
 
 
-/* including file 'src/plottables/plottable-bars.cpp', size 43512            */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/plottables/plottable-bars.cpp', size 43725            */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -23844,7 +23906,14 @@ QCPDataSelection QCPBars::selectTestRect(const QRectF &rect, bool onlySelectable
   return result;
 }
 
-/* inherits documentation from base class */
+/*!
+  Implements a selectTest specific to this plottable's point geometry.
+
+  If \a details is not 0, it will be set to a \ref QCPDataSelection, describing the closest data
+  point to \a pos.
+  
+  \seebaseclassmethod \ref QCPAbstractPlottable::selectTest
+*/
 double QCPBars::selectTest(const QPointF &pos, bool onlySelectable, QVariant *details) const
 {
   Q_UNUSED(details)
@@ -24264,8 +24333,8 @@ void QCPBars::connectBars(QCPBars *lower, QCPBars *upper)
 /* end of 'src/plottables/plottable-bars.cpp' */
 
 
-/* including file 'src/plottables/plottable-statisticalbox.cpp', size 28622  */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/plottables/plottable-statisticalbox.cpp', size 28837  */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPStatisticalBoxData
@@ -24669,7 +24738,14 @@ QCPDataSelection QCPStatisticalBox::selectTestRect(const QRectF &rect, bool only
   return result;
 }
 
-/* inherits documentation from base class */
+/*!
+  Implements a selectTest specific to this plottable's point geometry.
+
+  If \a details is not 0, it will be set to a \ref QCPDataSelection, describing the closest data
+  point to \a pos.
+  
+  \seebaseclassmethod \ref QCPAbstractPlottable::selectTest
+*/
 double QCPStatisticalBox::selectTest(const QPointF &pos, bool onlySelectable, QVariant *details) const
 {
   Q_UNUSED(details)
@@ -24684,7 +24760,7 @@ double QCPStatisticalBox::selectTest(const QPointF &pos, bool onlySelectable, QV
     QCPStatisticalBoxDataContainer::const_iterator visibleBegin, visibleEnd;
     QCPStatisticalBoxDataContainer::const_iterator closestDataPoint = mDataContainer->constEnd();
     getVisibleDataBounds(visibleBegin, visibleEnd);
-    double minDistSqr = std::numeric_limits<double>::max();
+    double minDistSqr = (std::numeric_limits<double>::max)();
     for (QCPStatisticalBoxDataContainer::const_iterator it=visibleBegin; it!=visibleEnd; ++it)
     {
       if (getQuartileBox(it).contains(pos)) // quartile box
@@ -24919,7 +24995,7 @@ QVector<QLineF> QCPStatisticalBox::getWhiskerBarLines(QCPStatisticalBoxDataConta
 
 
 /* including file 'src/plottables/plottable-colormap.cpp', size 47881        */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPColorMapData
@@ -26053,8 +26129,8 @@ void QCPColorMap::drawLegendIcon(QCPPainter *painter, const QRectF &rect) const
 /* end of 'src/plottables/plottable-colormap.cpp' */
 
 
-/* including file 'src/plottables/plottable-financial.cpp', size 42610       */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/plottables/plottable-financial.cpp', size 42827       */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPFinancialData
@@ -26459,7 +26535,14 @@ QCPDataSelection QCPFinancial::selectTestRect(const QRectF &rect, bool onlySelec
   return result;
 }
 
-/* inherits documentation from base class */
+/*!
+  Implements a selectTest specific to this plottable's point geometry.
+
+  If \a details is not 0, it will be set to a \ref QCPDataSelection, describing the closest data
+  point to \a pos.
+  
+  \seebaseclassmethod \ref QCPAbstractPlottable::selectTest
+*/
 double QCPFinancial::selectTest(const QPointF &pos, bool onlySelectable, QVariant *details) const
 {
   Q_UNUSED(details)
@@ -26852,7 +26935,7 @@ double QCPFinancial::ohlcSelectTest(const QPointF &pos, const QCPFinancialDataCo
   QCPAxis *valueAxis = mValueAxis.data();
   if (!keyAxis || !valueAxis) { qDebug() << Q_FUNC_INFO << "invalid key or value axis"; return -1; }
 
-  double minDistSqr = std::numeric_limits<double>::max();
+  double minDistSqr = (std::numeric_limits<double>::max)();
   if (keyAxis->orientation() == Qt::Horizontal)
   {
     for (QCPFinancialDataContainer::const_iterator it=begin; it!=end; ++it)
@@ -26899,7 +26982,7 @@ double QCPFinancial::candlestickSelectTest(const QPointF &pos, const QCPFinancia
   QCPAxis *valueAxis = mValueAxis.data();
   if (!keyAxis || !valueAxis) { qDebug() << Q_FUNC_INFO << "invalid key or value axis"; return -1; }
 
-  double minDistSqr = std::numeric_limits<double>::max();
+  double minDistSqr = (std::numeric_limits<double>::max)();
   if (keyAxis->orientation() == Qt::Horizontal)
   {
     for (QCPFinancialDataContainer::const_iterator it=begin; it!=end; ++it)
@@ -27008,8 +27091,8 @@ QRectF QCPFinancial::selectionHitBox(QCPFinancialDataContainer::const_iterator i
 /* end of 'src/plottables/plottable-financial.cpp' */
 
 
-/* including file 'src/plottables/plottable-errorbar.cpp', size 37355        */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/plottables/plottable-errorbar.cpp', size 37570        */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPErrorBarsData
@@ -27451,7 +27534,14 @@ int QCPErrorBars::findEnd(double sortKey, bool expandedRange) const
   return 0;
 }
 
-/* inherits documentation from base class */
+/*!
+  Implements a selectTest specific to this plottable's point geometry.
+
+  If \a details is not 0, it will be set to a \ref QCPDataSelection, describing the closest data
+  point to \a pos.
+  
+  \seebaseclassmethod \ref QCPAbstractPlottable::selectTest
+*/
 double QCPErrorBars::selectTest(const QPointF &pos, bool onlySelectable, QVariant *details) const
 {
   if (!mDataPlottable) return -1;
@@ -27870,7 +27960,7 @@ double QCPErrorBars::pointDistance(const QPointF &pixelPoint, QCPErrorBarsDataCo
   getVisibleDataBounds(begin, end, QCPDataRange(0, dataCount()));
   
   // calculate minimum distances to error backbones (whiskers are ignored for speed) and find closestData iterator:
-  double minDistSqr = std::numeric_limits<double>::max();
+  double minDistSqr = (std::numeric_limits<double>::max)();
   QVector<QLineF> backbones, whiskers;
   for (QCPErrorBarsDataContainer::const_iterator it=begin; it!=end; ++it)
   {
@@ -27970,7 +28060,7 @@ bool QCPErrorBars::rectIntersectsLine(const QRectF &pixelRect, const QLineF &lin
 
 
 /* including file 'src/items/item-straightline.cpp', size 7592               */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPItemStraightLine
@@ -28151,7 +28241,7 @@ QPen QCPItemStraightLine::mainPen() const
 
 
 /* including file 'src/items/item-line.cpp', size 8498                       */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPItemLine
@@ -28381,8 +28471,8 @@ QPen QCPItemLine::mainPen() const
 /* end of 'src/items/item-line.cpp' */
 
 
-/* including file 'src/items/item-curve.cpp', size 7159                      */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/items/item-curve.cpp', size 7248                      */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPItemCurve
@@ -28492,9 +28582,12 @@ double QCPItemCurve::selectTest(const QPointF &pos, bool onlySelectable, QVarian
   QPainterPath cubicPath(startVec);
   cubicPath.cubicTo(startDirVec, endDirVec, endVec);
   
-  QPolygonF polygon = cubicPath.toSubpathPolygons().first();
+  QList<QPolygonF> polygons = cubicPath.toSubpathPolygons();
+  if (polygons.isEmpty())
+    return -1;
+  const QPolygonF polygon = polygons.first();
   QCPVector2D p(pos);
-  double minDistSqr = std::numeric_limits<double>::max();
+  double minDistSqr = (std::numeric_limits<double>::max)();
   for (int i=1; i<polygon.size(); ++i)
   {
     double distSqr = p.distanceSquaredToLine(polygon.at(i-1), polygon.at(i));
@@ -28547,7 +28640,7 @@ QPen QCPItemCurve::mainPen() const
 
 
 /* including file 'src/items/item-rect.cpp', size 6479                       */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPItemRect
@@ -28704,7 +28797,7 @@ QBrush QCPItemRect::mainBrush() const
 
 
 /* including file 'src/items/item-text.cpp', size 13338                      */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPItemText
@@ -29052,7 +29145,7 @@ QBrush QCPItemText::mainBrush() const
 
 
 /* including file 'src/items/item-ellipse.cpp', size 7863                    */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPItemEllipse
@@ -29240,7 +29333,7 @@ QBrush QCPItemEllipse::mainBrush() const
 
 
 /* including file 'src/items/item-pixmap.cpp', size 10615                    */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPItemPixmap
@@ -29510,7 +29603,7 @@ QPen QCPItemPixmap::mainPen() const
 
 
 /* including file 'src/items/item-tracer.cpp', size 14624                    */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPItemTracer
@@ -29880,7 +29973,7 @@ QBrush QCPItemTracer::mainBrush() const
 
 
 /* including file 'src/items/item-bracket.cpp', size 10687                   */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPItemBracket

--- a/ThirdParty/GUI/qcustomplot/qcustomplot.h
+++ b/ThirdParty/GUI/qcustomplot/qcustomplot.h
@@ -1,7 +1,7 @@
 /***************************************************************************
 **                                                                        **
 **  QCustomPlot, an easy to use, modern plotting widget for Qt            **
-**  Copyright (C) 2011-2017 Emanuel Eichhammer                            **
+**  Copyright (C) 2011-2018 Emanuel Eichhammer                            **
 **                                                                        **
 **  This program is free software: you can redistribute it and/or modify  **
 **  it under the terms of the GNU General Public License as published by  **
@@ -19,8 +19,8 @@
 ****************************************************************************
 **           Author: Emanuel Eichhammer                                   **
 **  Website/Contact: http://www.qcustomplot.com/                          **
-**             Date: 04.09.17                                             **
-**          Version: 2.0.0                                                **
+**             Date: 25.06.18                                             **
+**          Version: 2.0.1                                                **
 ****************************************************************************/
 
 #ifndef QCUSTOMPLOT_H
@@ -112,11 +112,16 @@ class QCPColorMap;
 class QCPColorScale;
 class QCPBars;
 
-/* including file 'src/global.h', size 16225                                 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/global.h', size 16357                                 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
+
+#define QCUSTOMPLOT_VERSION_STR "2.0.1"
+#define QCUSTOMPLOT_VERSION 0x020001
 
 // decl definitions for shared library compilation/usage:
-#if defined(QCUSTOMPLOT_COMPILE_LIBRARY)
+#if defined(QT_STATIC_BUILD)
+#  define QCP_LIB_DECL
+#elif defined(QCUSTOMPLOT_COMPILE_LIBRARY)
 #  define QCP_LIB_DECL Q_DECL_EXPORT
 #elif defined(QCUSTOMPLOT_USE_LIBRARY)
 #  define QCP_LIB_DECL Q_DECL_IMPORT
@@ -132,7 +137,7 @@ class QCPBars;
 /*!
   The QCP Namespace contains general enums, QFlags and functions used throughout the QCustomPlot
   library.
-
+  
   It provides QMetaObject-based reflection of its enums and flags via \a QCP::staticMetaObject.
 */
 #ifndef Q_MOC_RUN
@@ -179,7 +184,7 @@ enum ExportPen { epNoCosmetic     ///< Cosmetic pens are converted to pens with 
 /*!
   Represents negative and positive sign domain, e.g. for passing to \ref
   QCPAbstractPlottable::getKeyRange and \ref QCPAbstractPlottable::getValueRange.
-
+  
   This is primarily needed when working with logarithmic axis scales, since only one of the sign
   domains can be visible at a time.
 */
@@ -190,7 +195,7 @@ enum SignDomain { sdNegative  ///< The negative sign domain, i.e. numbers smalle
 
 /*!
   Defines the sides of a rectangular entity to which margins can be applied.
-
+  
   \see QCPLayoutElement::setAutoMargins, QCPAxisRect::setAutoMargins
 */
 enum MarginSide { msLeft     = 0x01 ///< <tt>0x01</tt> left margin
@@ -206,9 +211,9 @@ Q_DECLARE_FLAGS(MarginSides, MarginSide)
   Defines what objects of a plot can be forcibly drawn antialiased/not antialiased. If an object is
   neither forcibly drawn antialiased nor forcibly drawn not antialiased, it is up to the respective
   element how it is drawn. Typically it provides a \a setAntialiased function for this.
-
+  
   \c AntialiasedElements is a flag of or-combined elements of this enum type.
-
+  
   \see QCustomPlot::setAntialiasedElements, QCustomPlot::setNotAntialiasedElements
 */
 enum AntialiasedElement { aeAxes           = 0x0001 ///< <tt>0x0001</tt> Axis base line and tick marks
@@ -229,7 +234,7 @@ Q_DECLARE_FLAGS(AntialiasedElements, AntialiasedElement)
 
 /*!
   Defines plotting hints that control various aspects of the quality and speed of plotting.
-
+  
   \see QCustomPlot::setPlottingHints
 */
 enum PlottingHint { phNone              = 0x000 ///< <tt>0x000</tt> No hints are set
@@ -243,9 +248,9 @@ Q_DECLARE_FLAGS(PlottingHints, PlottingHint)
 
 /*!
   Defines the mouse interactions possible with QCustomPlot.
-
+  
   \c Interactions is a flag of or-combined elements of this enum type.
-
+  
   \see QCustomPlot::setInteractions
 */
 enum Interaction { iRangeDrag         = 0x001 ///< <tt>0x001</tt> Axis ranges are draggable (see \ref QCPAxisRect::setRangeDrag, \ref QCPAxisRect::setRangeDragAxes)
@@ -261,7 +266,7 @@ Q_DECLARE_FLAGS(Interactions, Interaction)
 
 /*!
   Defines the behaviour of the selection rect.
-
+  
   \see QCustomPlot::setSelectionRectMode, QCustomPlot::selectionRect, QCPSelectionRect
 */
 enum SelectionRectMode { srmNone    ///< The selection rect is disabled, and all mouse events are forwarded to the underlying objects, e.g. for axis range dragging
@@ -273,7 +278,7 @@ enum SelectionRectMode { srmNone    ///< The selection rect is disabled, and all
 /*!
   Defines the different ways a plottable can be selected. These images show the effect of the
   different selection types, when the indicated selection rect was dragged:
-
+  
   <center>
   <table>
   <tr>
@@ -285,7 +290,7 @@ enum SelectionRectMode { srmNone    ///< The selection rect is disabled, and all
   </tr>
   </table>
   </center>
-
+  
   \see QCPAbstractPlottable::setSelectable, QCPDataSelection::enforceType
 */
 enum SelectionType { stNone                ///< The plottable is not selectable
@@ -296,7 +301,7 @@ enum SelectionType { stNone                ///< The plottable is not selectable
                     };
 
 /*! \internal
-
+  
   Returns whether the specified \a value is considered an invalid data value for plottables (i.e.
   is \e nan or \e +/-inf). This function is used to check data validity upon replots, when the
   compiler flag \c QCUSTOMPLOT_CHECK_DATA is set.
@@ -308,7 +313,7 @@ inline bool isInvalidData(double value)
 
 /*! \internal
   \overload
-
+  
   Checks two arguments instead of one.
 */
 inline bool isInvalidData(double value1, double value2)
@@ -317,9 +322,9 @@ inline bool isInvalidData(double value1, double value2)
 }
 
 /*! \internal
-
+  
   Sets the specified \a side of \a margins to \a value
-
+  
   \see getMarginValue
 */
 inline void setMarginValue(QMargins &margins, QCP::MarginSide side, int value)
@@ -336,10 +341,10 @@ inline void setMarginValue(QMargins &margins, QCP::MarginSide side, int value)
 }
 
 /*! \internal
-
+  
   Returns the value of the specified \a side of \a margins. If \a side is \ref QCP::msNone or
   \ref QCP::msAll, returns 0.
-
+  
   \see setMarginValue
 */
 inline int getMarginValue(const QMargins &margins, QCP::MarginSide side)
@@ -377,7 +382,7 @@ Q_DECLARE_METATYPE(QCP::SelectionType)
 
 
 /* including file 'src/vector2d.h', size 4928                                */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPVector2D
 {
@@ -386,23 +391,23 @@ public:
   QCPVector2D(double x, double y);
   QCPVector2D(const QPoint &point);
   QCPVector2D(const QPointF &point);
-
+  
   // getters:
   double x() const { return mX; }
   double y() const { return mY; }
   double &rx() { return mX; }
   double &ry() { return mY; }
-
+  
   // setters:
   void setX(double x) { mX = x; }
   void setY(double y) { mY = y; }
-
+  
   // non-virtual methods:
   double length() const { return qSqrt(mX*mX+mY*mY); }
   double lengthSquared() const { return mX*mX+mY*mY; }
   QPoint toPoint() const { return QPoint(mX, mY); }
   QPointF toPointF() const { return QPointF(mX, mY); }
-
+  
   bool isNull() const { return qIsNull(mX) && qIsNull(mY); }
   void normalize();
   QCPVector2D normalized() const;
@@ -411,16 +416,16 @@ public:
   double distanceSquaredToLine(const QCPVector2D &start, const QCPVector2D &end) const;
   double distanceSquaredToLine(const QLineF &line) const;
   double distanceToStraightLine(const QCPVector2D &base, const QCPVector2D &direction) const;
-
+  
   QCPVector2D &operator*=(double factor);
   QCPVector2D &operator/=(double divisor);
   QCPVector2D &operator+=(const QCPVector2D &vector);
   QCPVector2D &operator-=(const QCPVector2D &vector);
-
+  
 private:
   // property members:
   double mX, mY;
-
+  
   friend inline const QCPVector2D operator*(double factor, const QCPVector2D &vec);
   friend inline const QCPVector2D operator*(const QCPVector2D &vec, double factor);
   friend inline const QCPVector2D operator/(const QCPVector2D &vec, double divisor);
@@ -451,7 +456,7 @@ inline QDebug operator<< (QDebug d, const QCPVector2D &vec)
 
 
 /* including file 'src/painter.h', size 4035                                 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPPainter : public QPainter
 {
@@ -469,10 +474,10 @@ public:
   Q_ENUMS(PainterMode)
   Q_FLAGS(PainterModes)
   Q_DECLARE_FLAGS(PainterModes, PainterMode)
-
+  
   QCPPainter();
   explicit QCPPainter(QPaintDevice *device);
-
+  
   // getters:
   bool antialiasing() const { return testRenderHint(QPainter::Antialiasing); }
   PainterModes modes() const { return mModes; }
@@ -491,15 +496,15 @@ public:
   void drawLine(const QPointF &p1, const QPointF &p2) {drawLine(QLineF(p1, p2));}
   void save();
   void restore();
-
+  
   // non-virtual methods:
   void makeNonCosmetic();
-
+  
 protected:
   // property members:
   PainterModes mModes;
   bool mIsAntialiasing;
-
+  
   // non-property members:
   QStack<bool> mAntialiasingStack;
 };
@@ -510,38 +515,38 @@ Q_DECLARE_METATYPE(QCPPainter::PainterMode)
 
 
 /* including file 'src/paintbuffer.h', size 4958                             */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPAbstractPaintBuffer
 {
 public:
   explicit QCPAbstractPaintBuffer(const QSize &size, double devicePixelRatio);
   virtual ~QCPAbstractPaintBuffer();
-
+  
   // getters:
   QSize size() const { return mSize; }
   bool invalidated() const { return mInvalidated; }
   double devicePixelRatio() const { return mDevicePixelRatio; }
-
+  
   // setters:
   void setSize(const QSize &size);
   void setInvalidated(bool invalidated=true);
   void setDevicePixelRatio(double ratio);
-
+  
   // introduced virtual methods:
   virtual QCPPainter *startPainting() = 0;
   virtual void donePainting() {}
   virtual void draw(QCPPainter *painter) const = 0;
   virtual void clear(const QColor &color) = 0;
-
+  
 protected:
   // property members:
   QSize mSize;
   double mDevicePixelRatio;
-
+  
   // non-property members:
   bool mInvalidated;
-
+  
   // introduced virtual methods:
   virtual void reallocateBuffer() = 0;
 };
@@ -552,16 +557,16 @@ class QCP_LIB_DECL QCPPaintBufferPixmap : public QCPAbstractPaintBuffer
 public:
   explicit QCPPaintBufferPixmap(const QSize &size, double devicePixelRatio);
   virtual ~QCPPaintBufferPixmap();
-
+  
   // reimplemented virtual methods:
   virtual QCPPainter *startPainting() Q_DECL_OVERRIDE;
   virtual void draw(QCPPainter *painter) const Q_DECL_OVERRIDE;
   void clear(const QColor &color) Q_DECL_OVERRIDE;
-
+  
 protected:
   // non-property members:
   QPixmap mBuffer;
-
+  
   // reimplemented virtual methods:
   virtual void reallocateBuffer() Q_DECL_OVERRIDE;
 };
@@ -573,17 +578,17 @@ class QCP_LIB_DECL QCPPaintBufferGlPbuffer : public QCPAbstractPaintBuffer
 public:
   explicit QCPPaintBufferGlPbuffer(const QSize &size, double devicePixelRatio, int multisamples);
   virtual ~QCPPaintBufferGlPbuffer();
-
+  
   // reimplemented virtual methods:
   virtual QCPPainter *startPainting() Q_DECL_OVERRIDE;
   virtual void draw(QCPPainter *painter) const Q_DECL_OVERRIDE;
   void clear(const QColor &color) Q_DECL_OVERRIDE;
-
+  
 protected:
   // non-property members:
   QGLPixelBuffer *mGlPBuffer;
   int mMultisamples;
-
+  
   // reimplemented virtual methods:
   virtual void reallocateBuffer() Q_DECL_OVERRIDE;
 };
@@ -596,19 +601,19 @@ class QCP_LIB_DECL QCPPaintBufferGlFbo : public QCPAbstractPaintBuffer
 public:
   explicit QCPPaintBufferGlFbo(const QSize &size, double devicePixelRatio, QWeakPointer<QOpenGLContext> glContext, QWeakPointer<QOpenGLPaintDevice> glPaintDevice);
   virtual ~QCPPaintBufferGlFbo();
-
+  
   // reimplemented virtual methods:
   virtual QCPPainter *startPainting() Q_DECL_OVERRIDE;
   virtual void donePainting() Q_DECL_OVERRIDE;
   virtual void draw(QCPPainter *painter) const Q_DECL_OVERRIDE;
   void clear(const QColor &color) Q_DECL_OVERRIDE;
-
+  
 protected:
   // non-property members:
   QWeakPointer<QOpenGLContext> mGlContext;
   QWeakPointer<QOpenGLPaintDevice> mGlPaintDevice;
   QOpenGLFramebufferObject *mGlFrameBuffer;
-
+  
   // reimplemented virtual methods:
   virtual void reallocateBuffer() Q_DECL_OVERRIDE;
 };
@@ -618,7 +623,7 @@ protected:
 
 
 /* including file 'src/layer.h', size 6885                                   */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPLayer : public QObject
 {
@@ -632,7 +637,7 @@ class QCP_LIB_DECL QCPLayer : public QObject
   Q_PROPERTY(LayerMode mode READ mode WRITE setMode)
   /// \endcond
 public:
-
+  
   /*!
     Defines the different rendering modes of a layer. Depending on the mode, certain layers can be
     replotted individually, without the need to replot (possibly complex) layerables on other
@@ -644,10 +649,10 @@ public:
                    ,lmBuffered ///< Layer has its own paint buffer and may be replotted individually (see \ref replot).
                  };
   Q_ENUMS(LayerMode)
-
+  
   QCPLayer(QCustomPlot* parentPlot, const QString &layerName);
   virtual ~QCPLayer();
-
+  
   // getters:
   QCustomPlot *parentPlot() const { return mParentPlot; }
   QString name() const { return mName; }
@@ -655,14 +660,14 @@ public:
   QList<QCPLayerable*> children() const { return mChildren; }
   bool visible() const { return mVisible; }
   LayerMode mode() const { return mMode; }
-
+  
   // setters:
   void setVisible(bool visible);
   void setMode(LayerMode mode);
-
+  
   // non-virtual methods:
   void replot();
-
+  
 protected:
   // property members:
   QCustomPlot *mParentPlot;
@@ -671,19 +676,19 @@ protected:
   QList<QCPLayerable*> mChildren;
   bool mVisible;
   LayerMode mMode;
-
+  
   // non-property members:
   QWeakPointer<QCPAbstractPaintBuffer> mPaintBuffer;
-
+  
   // non-virtual methods:
   void draw(QCPPainter *painter);
   void drawToPaintBuffer();
   void addChild(QCPLayerable *layerable, bool prepend);
   void removeChild(QCPLayerable *layerable);
-
+  
 private:
   Q_DISABLE_COPY(QCPLayer)
-
+  
   friend class QCustomPlot;
   friend class QCPLayerable;
 };
@@ -702,29 +707,29 @@ class QCP_LIB_DECL QCPLayerable : public QObject
 public:
   QCPLayerable(QCustomPlot *plot, QString targetLayer=QString(), QCPLayerable *parentLayerable=0);
   virtual ~QCPLayerable();
-
+  
   // getters:
   bool visible() const { return mVisible; }
   QCustomPlot *parentPlot() const { return mParentPlot; }
   QCPLayerable *parentLayerable() const { return mParentLayerable.data(); }
   QCPLayer *layer() const { return mLayer; }
   bool antialiased() const { return mAntialiased; }
-
+  
   // setters:
   void setVisible(bool on);
   Q_SLOT bool setLayer(QCPLayer *layer);
   bool setLayer(const QString &layerName);
   void setAntialiased(bool enabled);
-
+  
   // introduced virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const;
 
   // non-property methods:
   bool realVisibility() const;
-
+  
 signals:
   void layerChanged(QCPLayer *newLayer);
-
+  
 protected:
   // property members:
   bool mVisible;
@@ -732,7 +737,7 @@ protected:
   QPointer<QCPLayerable> mParentLayerable;
   QCPLayer *mLayer;
   bool mAntialiased;
-
+  
   // introduced virtual methods:
   virtual void parentPlotInitialized(QCustomPlot *parentPlot);
   virtual QCP::Interaction selectionCategory() const;
@@ -748,16 +753,16 @@ protected:
   virtual void mouseReleaseEvent(QMouseEvent *event, const QPointF &startPos);
   virtual void mouseDoubleClickEvent(QMouseEvent *event, const QVariant &details);
   virtual void wheelEvent(QWheelEvent *event);
-
+  
   // non-property methods:
   void initializeParentPlot(QCustomPlot *parentPlot);
   void setParentLayerable(QCPLayerable* parentLayerable);
   bool moveToLayer(QCPLayer *layer, bool prepend);
   void applyAntialiasingHint(QCPPainter *painter, bool localAntialiased, QCP::AntialiasedElement overrideElement) const;
-
+  
 private:
   Q_DISABLE_COPY(QCPLayerable)
-
+  
   friend class QCustomPlot;
   friend class QCPLayer;
   friend class QCPAxisRect;
@@ -767,19 +772,19 @@ private:
 
 
 /* including file 'src/axis/range.h', size 5280                              */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPRange
 {
 public:
   double lower, upper;
-
+  
   QCPRange();
   QCPRange(double lower, double upper);
-
+  
   bool operator==(const QCPRange& other) const { return lower == other.lower && upper == other.upper; }
   bool operator!=(const QCPRange& other) const { return !(*this == other); }
-
+  
   QCPRange &operator+=(const double& value) { lower+=value; upper+=value; return *this; }
   QCPRange &operator-=(const double& value) { lower-=value; upper-=value; return *this; }
   QCPRange &operator*=(const double& value) { lower*=value; upper*=value; return *this; }
@@ -790,7 +795,7 @@ public:
   friend inline const QCPRange operator*(const QCPRange& range, double value);
   friend inline const QCPRange operator*(double value, const QCPRange& range);
   friend inline const QCPRange operator/(const QCPRange& range, double value);
-
+  
   double size() const { return upper-lower; }
   double center() const { return (upper+lower)*0.5; }
   void normalize() { if (lower > upper) qSwap(lower, upper); }
@@ -802,12 +807,12 @@ public:
   QCPRange sanitizedForLogScale() const;
   QCPRange sanitizedForLinScale() const;
   bool contains(double value) const { return value >= lower && value <= upper; }
-
+  
   static bool validRange(double lower, double upper);
   static bool validRange(const QCPRange &range);
   static const double minRange;
   static const double maxRange;
-
+  
 };
 Q_DECLARE_TYPEINFO(QCPRange, Q_MOVABLE_TYPE);
 
@@ -884,28 +889,28 @@ inline const QCPRange operator/(const QCPRange& range, double value)
 /* end of 'src/axis/range.h' */
 
 
-/* including file 'src/selection.h', size 8579                               */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/selection.h', size 8569                               */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPDataRange
 {
 public:
   QCPDataRange();
   QCPDataRange(int begin, int end);
-
+  
   bool operator==(const QCPDataRange& other) const { return mBegin == other.mBegin && mEnd == other.mEnd; }
   bool operator!=(const QCPDataRange& other) const { return !(*this == other); }
-
+  
   // getters:
   int begin() const { return mBegin; }
   int end() const { return mEnd; }
   int size() const { return mEnd-mBegin; }
   int length() const { return size(); }
-
+  
   // setters:
   void setBegin(int begin) { mBegin = begin; }
   void setEnd(int end)  { mEnd = end; }
-
+  
   // non-property methods:
   bool isValid() const { return (mEnd >= mBegin) && (mBegin >= 0); }
   bool isEmpty() const { return length() == 0; }
@@ -915,7 +920,7 @@ public:
   QCPDataRange adjusted(int changeBegin, int changeEnd) const { return QCPDataRange(mBegin+changeBegin, mEnd+changeEnd); }
   bool intersects(const QCPDataRange &other) const;
   bool contains(const QCPDataRange &other) const;
-
+  
 private:
   // property members:
   int mBegin, mEnd;
@@ -929,7 +934,7 @@ class QCP_LIB_DECL QCPDataSelection
 public:
   explicit QCPDataSelection();
   explicit QCPDataSelection(const QCPDataRange &range);
-
+  
   bool operator==(const QCPDataSelection& other) const;
   bool operator!=(const QCPDataSelection& other) const { return !(*this == other); }
   QCPDataSelection &operator+=(const QCPDataSelection& other);
@@ -944,14 +949,14 @@ public:
   friend inline const QCPDataSelection operator-(const QCPDataRange& a, const QCPDataSelection& b);
   friend inline const QCPDataSelection operator-(const QCPDataSelection& a, const QCPDataRange& b);
   friend inline const QCPDataSelection operator-(const QCPDataRange& a, const QCPDataRange& b);
-
+  
   // getters:
   int dataRangeCount() const { return mDataRanges.size(); }
   int dataPointCount() const;
   QCPDataRange dataRange(int index=0) const;
   QList<QCPDataRange> dataRanges() const { return mDataRanges; }
   QCPDataRange span() const;
-
+  
   // non-property methods:
   void addDataRange(const QCPDataRange &dataRange, bool simplify=true);
   void clear();
@@ -962,11 +967,11 @@ public:
   QCPDataSelection intersection(const QCPDataRange &other) const;
   QCPDataSelection intersection(const QCPDataSelection &other) const;
   QCPDataSelection inverse(const QCPDataRange &outerRange) const;
-
+  
 private:
   // property members:
   QList<QCPDataRange> mDataRanges;
-
+  
   inline static bool lessThanDataRangeBegin(const QCPDataRange &a, const QCPDataRange &b) { return a.begin() < b.begin(); }
 };
 Q_DECLARE_METATYPE(QCPDataSelection)
@@ -1062,8 +1067,8 @@ inline const QCPDataSelection operator-(const QCPDataRange& a, const QCPDataRang
 */
 inline QDebug operator<< (QDebug d, const QCPDataRange &dataRange)
 {
-    d.nospace() << "[" << dataRange.begin() << ".." << dataRange.end()-1 << "]";
-    return d.space();
+  d.nospace() << "QCPDataRange(" << dataRange.begin() << ", " << dataRange.end() << ")";
+  return d;
 }
 
 /*! \relates QCPDataSelection
@@ -1080,7 +1085,7 @@ inline QDebug operator<< (QDebug d, const QCPDataSelection &selection)
       d << selection.dataRange(i);
     }
     d << ")";
-    return d.space();
+    return d;
 }
 
 
@@ -1089,7 +1094,7 @@ inline QDebug operator<< (QDebug d, const QCPDataSelection &selection)
 
 
 /* including file 'src/selectionrect.h', size 3338                           */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPSelectionRect : public QCPLayerable
 {
@@ -1097,27 +1102,27 @@ class QCP_LIB_DECL QCPSelectionRect : public QCPLayerable
 public:
   explicit QCPSelectionRect(QCustomPlot *parentPlot);
   virtual ~QCPSelectionRect();
-
+  
   // getters:
   QRect rect() const { return mRect; }
   QCPRange range(const QCPAxis *axis) const;
   QPen pen() const { return mPen; }
   QBrush brush() const { return mBrush; }
   bool isActive() const { return mActive; }
-
+  
   // setters:
   void setPen(const QPen &pen);
   void setBrush(const QBrush &brush);
-
+  
   // non-property methods:
   Q_SLOT void cancel();
-
+  
 signals:
   void started(QMouseEvent *event);
   void changed(const QRect &rect, QMouseEvent *event);
   void canceled(const QRect &rect, QInputEvent *event);
   void accepted(const QRect &rect, QMouseEvent *event);
-
+  
 protected:
   // property members:
   QRect mRect;
@@ -1125,17 +1130,17 @@ protected:
   QBrush mBrush;
   // non-property members:
   bool mActive;
-
+  
   // introduced virtual methods:
   virtual void startSelection(QMouseEvent *event);
   virtual void moveSelection(QMouseEvent *event);
   virtual void endSelection(QMouseEvent *event);
   virtual void keyPressEvent(QKeyEvent *event);
-
+  
   // reimplemented virtual methods
   virtual void applyDefaultAntialiasingHint(QCPPainter *painter) const Q_DECL_OVERRIDE;
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
-
+  
   friend class QCustomPlot;
 };
 
@@ -1143,7 +1148,7 @@ protected:
 
 
 /* including file 'src/layout.h', size 14224                                 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPMarginGroup : public QObject
 {
@@ -1151,27 +1156,27 @@ class QCP_LIB_DECL QCPMarginGroup : public QObject
 public:
   explicit QCPMarginGroup(QCustomPlot *parentPlot);
   virtual ~QCPMarginGroup();
-
+  
   // non-virtual methods:
   QList<QCPLayoutElement*> elements(QCP::MarginSide side) const { return mChildren.value(side); }
   bool isEmpty() const;
   void clear();
-
+  
 protected:
   // non-property members:
   QCustomPlot *mParentPlot;
   QHash<QCP::MarginSide, QList<QCPLayoutElement*> > mChildren;
-
+  
   // introduced virtual methods:
   virtual int commonMargin(QCP::MarginSide side) const;
-
+  
   // non-virtual methods:
   void addChild(QCP::MarginSide side, QCPLayoutElement *element);
   void removeChild(QCP::MarginSide side, QCPLayoutElement *element);
-
+  
 private:
   Q_DISABLE_COPY(QCPMarginGroup)
-
+  
   friend class QCPLayoutElement;
 };
 
@@ -1199,13 +1204,13 @@ public:
                      ,upLayout     ///< Final phase in which the layout system places the rects of the elements
                    };
   Q_ENUMS(UpdatePhase)
-
+  
   /*!
     Defines to which rect of a layout element the size constraints that can be set via \ref
     setMinimumSize and \ref setMaximumSize apply. The outer rect (\ref outerRect) includes the
     margins (e.g. in the case of a QCPAxisRect the axis labels), whereas the inner rect (\ref rect)
     does not.
-
+    
     \see setSizeConstraintRect
   */
   enum SizeConstraintRect { scrInnerRect ///< Minimum/Maximum size constraints apply to inner rect
@@ -1215,7 +1220,7 @@ public:
 
   explicit QCPLayoutElement(QCustomPlot *parentPlot=0);
   virtual ~QCPLayoutElement();
-
+  
   // getters:
   QCPLayout *layout() const { return mParentLayout; }
   QRect rect() const { return mRect; }
@@ -1228,7 +1233,7 @@ public:
   SizeConstraintRect sizeConstraintRect() const { return mSizeConstraintRect; }
   QCPMarginGroup *marginGroup(QCP::MarginSide side) const { return mMarginGroups.value(side, (QCPMarginGroup*)0); }
   QHash<QCP::MarginSide, QCPMarginGroup*> marginGroups() const { return mMarginGroups; }
-
+  
   // setters:
   void setOuterRect(const QRect &rect);
   void setMargins(const QMargins &margins);
@@ -1240,16 +1245,16 @@ public:
   void setMaximumSize(int width, int height);
   void setSizeConstraintRect(SizeConstraintRect constraintRect);
   void setMarginGroup(QCP::MarginSides sides, QCPMarginGroup *group);
-
+  
   // introduced virtual methods:
   virtual void update(UpdatePhase phase);
   virtual QSize minimumOuterSizeHint() const;
   virtual QSize maximumOuterSizeHint() const;
   virtual QList<QCPLayoutElement*> elements(bool recursive) const;
-
+  
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
-
+  
 protected:
   // property members:
   QCPLayout *mParentLayout;
@@ -1259,11 +1264,11 @@ protected:
   QMargins mMargins, mMinimumMargins;
   QCP::MarginSides mAutoMargins;
   QHash<QCP::MarginSide, QCPMarginGroup*> mMarginGroups;
-
+  
   // introduced virtual methods:
   virtual int calculateAutoMargin(QCP::MarginSide side);
   virtual void layoutChanged();
-
+  
   // reimplemented virtual methods:
   virtual void applyDefaultAntialiasingHint(QCPPainter *painter) const Q_DECL_OVERRIDE { Q_UNUSED(painter) }
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE { Q_UNUSED(painter) }
@@ -1271,7 +1276,7 @@ protected:
 
 private:
   Q_DISABLE_COPY(QCPLayoutElement)
-
+  
   friend class QCustomPlot;
   friend class QCPLayout;
   friend class QCPMarginGroup;
@@ -1284,27 +1289,27 @@ class QCP_LIB_DECL QCPLayout : public QCPLayoutElement
   Q_OBJECT
 public:
   explicit QCPLayout();
-
+  
   // reimplemented virtual methods:
   virtual void update(UpdatePhase phase) Q_DECL_OVERRIDE;
   virtual QList<QCPLayoutElement*> elements(bool recursive) const Q_DECL_OVERRIDE;
-
+  
   // introduced virtual methods:
   virtual int elementCount() const = 0;
   virtual QCPLayoutElement* elementAt(int index) const = 0;
   virtual QCPLayoutElement* takeAt(int index) = 0;
   virtual bool take(QCPLayoutElement* element) = 0;
   virtual void simplify();
-
+  
   // non-virtual methods:
   bool removeAt(int index);
   bool remove(QCPLayoutElement* element);
   void clear();
-
+  
 protected:
   // introduced virtual methods:
   virtual void updateLayout();
-
+  
   // non-virtual methods:
   void sizeConstraintsChanged() const;
   void adoptElement(QCPLayoutElement *el);
@@ -1312,7 +1317,7 @@ protected:
   QVector<int> getSectionSizes(QVector<int> maxSizes, QVector<int> minSizes, QVector<double> stretchFactors, int totalSize) const;
   static QSize getFinalMinimumOuterSize(const QCPLayoutElement *el);
   static QSize getFinalMaximumOuterSize(const QCPLayoutElement *el);
-
+  
 private:
   Q_DISABLE_COPY(QCPLayout)
   friend class QCPLayoutElement;
@@ -1333,7 +1338,7 @@ class QCP_LIB_DECL QCPLayoutGrid : public QCPLayout
   Q_PROPERTY(int wrap READ wrap WRITE setWrap)
   /// \endcond
 public:
-
+  
   /*!
     Defines in which direction the grid is filled when using \ref addElement(QCPLayoutElement*).
     The column/row at which wrapping into the next row/column occurs can be specified with \ref
@@ -1345,10 +1350,10 @@ public:
                   ,foColumnsFirst ///< Columns are filled first, and a new element is wrapped to the next row if the column count would exceed \ref setWrap.
                 };
   Q_ENUMS(FillOrder)
-
+  
   explicit QCPLayoutGrid();
   virtual ~QCPLayoutGrid();
-
+  
   // getters:
   int rowCount() const { return mElements.size(); }
   int columnCount() const { return mElements.size() > 0 ? mElements.first().size() : 0; }
@@ -1358,7 +1363,7 @@ public:
   int rowSpacing() const { return mRowSpacing; }
   int wrap() const { return mWrap; }
   FillOrder fillOrder() const { return mFillOrder; }
-
+  
   // setters:
   void setColumnStretchFactor(int column, double factor);
   void setColumnStretchFactors(const QList<double> &factors);
@@ -1368,7 +1373,7 @@ public:
   void setRowSpacing(int pixels);
   void setWrap(int count);
   void setFillOrder(FillOrder order, bool rearrange=true);
-
+  
   // reimplemented virtual methods:
   virtual void updateLayout() Q_DECL_OVERRIDE;
   virtual int elementCount() const Q_DECL_OVERRIDE { return rowCount()*columnCount(); }
@@ -1379,7 +1384,7 @@ public:
   virtual void simplify() Q_DECL_OVERRIDE;
   virtual QSize minimumOuterSizeHint() const Q_DECL_OVERRIDE;
   virtual QSize maximumOuterSizeHint() const Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   QCPLayoutElement *element(int row, int column) const;
   bool addElement(int row, int column, QCPLayoutElement *element);
@@ -1390,7 +1395,7 @@ public:
   void insertColumn(int newIndex);
   int rowColToIndex(int row, int column) const;
   void indexToRowCol(int index, int &row, int &column) const;
-
+  
 protected:
   // property members:
   QList<QList<QCPLayoutElement*> > mElements;
@@ -1399,11 +1404,11 @@ protected:
   int mColumnSpacing, mRowSpacing;
   int mWrap;
   FillOrder mFillOrder;
-
+  
   // non-virtual methods:
   void getMinimumRowColSizes(QVector<int> *minColWidths, QVector<int> *minRowHeights) const;
   void getMaximumRowColSizes(QVector<int> *maxColWidths, QVector<int> *maxRowHeights) const;
-
+  
 private:
   Q_DISABLE_COPY(QCPLayoutGrid)
 };
@@ -1421,20 +1426,20 @@ public:
                         ,ipBorderAligned  ///< The element is aligned to one of the layout sides, see \ref setInsetAlignment
                       };
   Q_ENUMS(InsetPlacement)
-
+  
   explicit QCPLayoutInset();
   virtual ~QCPLayoutInset();
-
+  
   // getters:
   InsetPlacement insetPlacement(int index) const;
   Qt::Alignment insetAlignment(int index) const;
   QRectF insetRect(int index) const;
-
+  
   // setters:
   void setInsetPlacement(int index, InsetPlacement placement);
   void setInsetAlignment(int index, Qt::Alignment alignment);
   void setInsetRect(int index, const QRectF &rect);
-
+  
   // reimplemented virtual methods:
   virtual void updateLayout() Q_DECL_OVERRIDE;
   virtual int elementCount() const Q_DECL_OVERRIDE;
@@ -1443,18 +1448,18 @@ public:
   virtual bool take(QCPLayoutElement* element) Q_DECL_OVERRIDE;
   virtual void simplify() Q_DECL_OVERRIDE {}
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   void addElement(QCPLayoutElement *element, Qt::Alignment alignment);
   void addElement(QCPLayoutElement *element, const QRectF &rect);
-
+  
 protected:
   // property members:
   QList<QCPLayoutElement*> mElements;
   QList<InsetPlacement> mInsetPlacement;
   QList<Qt::Alignment> mInsetAlignment;
   QList<QRectF> mInsetRect;
-
+  
 private:
   Q_DISABLE_COPY(QCPLayoutInset)
 };
@@ -1464,7 +1469,7 @@ Q_DECLARE_METATYPE(QCPLayoutInset::InsetPlacement)
 
 
 /* including file 'src/lineending.h', size 4426                              */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPLineEnding
 {
@@ -1472,13 +1477,13 @@ class QCP_LIB_DECL QCPLineEnding
 public:
   /*!
     Defines the type of ending decoration for line-like items, e.g. an arrow.
-
+    
     \image html QCPLineEnding.png
-
+    
     The width and length of these decorations can be controlled with the functions \ref setWidth
     and \ref setLength. Some decorations like \ref esDisc, \ref esSquare, \ref esDiamond and \ref esBar only
     support a width, the length property is ignored.
-
+    
     \see QCPItemLine::setHead, QCPItemLine::setTail, QCPItemCurve::setHead, QCPItemCurve::setTail, QCPAxis::setLowerEnding, QCPAxis::setUpperEnding
   */
   enum EndingStyle { esNone          ///< No ending decoration
@@ -1493,28 +1498,28 @@ public:
                      ,esSkewedBar    ///< A bar that is skewed (skew controllable via \ref setLength)
                    };
   Q_ENUMS(EndingStyle)
-
+  
   QCPLineEnding();
   QCPLineEnding(EndingStyle style, double width=8, double length=10, bool inverted=false);
-
+  
   // getters:
   EndingStyle style() const { return mStyle; }
   double width() const { return mWidth; }
   double length() const { return mLength; }
   bool inverted() const { return mInverted; }
-
+  
   // setters:
   void setStyle(EndingStyle style);
   void setWidth(double width);
   void setLength(double length);
   void setInverted(bool inverted);
-
+  
   // non-property methods:
   double boundingDistance() const;
   double realLength() const;
   void draw(QCPPainter *painter, const QCPVector2D &pos, const QCPVector2D &dir) const;
   void draw(QCPPainter *painter, const QCPVector2D &pos, double angle) const;
-
+  
 protected:
   // property members:
   EndingStyle mStyle;
@@ -1527,8 +1532,8 @@ Q_DECLARE_METATYPE(QCPLineEnding::EndingStyle)
 /* end of 'src/lineending.h' */
 
 
-/* including file 'src/axis/axisticker.h', size 4177                         */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/axis/axisticker.h', size 4224                         */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPAxisTicker
 {
@@ -1536,7 +1541,7 @@ class QCP_LIB_DECL QCPAxisTicker
 public:
   /*!
     Defines the strategies that the axis ticker may follow when choosing the size of the tick step.
-
+    
     \see setTickStepStrategy
   */
   enum TickStepStrategy
@@ -1545,29 +1550,29 @@ public:
     ,tssMeetTickCount ///< Less readable tick steps are allowed which in turn facilitates getting closer to the requested tick count
   };
   Q_ENUMS(TickStepStrategy)
-
+  
   QCPAxisTicker();
   virtual ~QCPAxisTicker();
-
+  
   // getters:
   TickStepStrategy tickStepStrategy() const { return mTickStepStrategy; }
   int tickCount() const { return mTickCount; }
   double tickOrigin() const { return mTickOrigin; }
-
+  
   // setters:
   void setTickStepStrategy(TickStepStrategy strategy);
   void setTickCount(int count);
   void setTickOrigin(double origin);
-
+  
   // introduced virtual methods:
   virtual void generate(const QCPRange &range, const QLocale &locale, QChar formatChar, int precision, QVector<double> &ticks, QVector<double> *subTicks, QVector<QString> *tickLabels);
-
+  
 protected:
   // property members:
   TickStepStrategy mTickStepStrategy;
   int mTickCount;
   double mTickOrigin;
-
+  
   // introduced virtual methods:
   virtual double getTickStep(const QCPRange &range);
   virtual int getSubTickCount(double tickStep);
@@ -1575,12 +1580,16 @@ protected:
   virtual QVector<double> createTickVector(double tickStep, const QCPRange &range);
   virtual QVector<double> createSubTickVector(int subTickCount, const QVector<double> &ticks);
   virtual QVector<QString> createLabelVector(const QVector<double> &ticks, const QLocale &locale, QChar formatChar, int precision);
-
+  
   // non-virtual methods:
   void trimTicks(const QCPRange &range, QVector<double> &ticks, bool keepOneOutlier) const;
   double pickClosest(double target, const QVector<double> &candidates) const;
   double getMantissa(double input, double *magnitude=0) const;
   double cleanMantissa(double input) const;
+  
+private:
+  Q_DISABLE_COPY(QCPAxisTicker)
+  
 };
 Q_DECLARE_METATYPE(QCPAxisTicker::TickStepStrategy)
 Q_DECLARE_METATYPE(QSharedPointer<QCPAxisTicker>)
@@ -1589,36 +1598,36 @@ Q_DECLARE_METATYPE(QSharedPointer<QCPAxisTicker>)
 
 
 /* including file 'src/axis/axistickerdatetime.h', size 3289                 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPAxisTickerDateTime : public QCPAxisTicker
 {
 public:
   QCPAxisTickerDateTime();
-
+  
   // getters:
   QString dateTimeFormat() const { return mDateTimeFormat; }
   Qt::TimeSpec dateTimeSpec() const { return mDateTimeSpec; }
-
+  
   // setters:
   void setDateTimeFormat(const QString &format);
   void setDateTimeSpec(Qt::TimeSpec spec);
   void setTickOrigin(double origin); // hides base class method but calls baseclass implementation ("using" throws off IDEs and doxygen)
   void setTickOrigin(const QDateTime &origin);
-
+  
   // static methods:
   static QDateTime keyToDateTime(double key);
   static double dateTimeToKey(const QDateTime dateTime);
   static double dateTimeToKey(const QDate date);
-
+  
 protected:
   // property members:
   QString mDateTimeFormat;
   Qt::TimeSpec mDateTimeSpec;
-
+  
   // non-property members:
   enum DateStrategy {dsNone, dsUniformTimeInDay, dsUniformDayInMonth} mDateStrategy;
-
+  
   // reimplemented virtual methods:
   virtual double getTickStep(const QCPRange &range) Q_DECL_OVERRIDE;
   virtual int getSubTickCount(double tickStep) Q_DECL_OVERRIDE;
@@ -1630,7 +1639,7 @@ protected:
 
 
 /* including file 'src/axis/axistickertime.h', size 3542                     */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPAxisTickerTime : public QCPAxisTicker
 {
@@ -1638,7 +1647,7 @@ class QCP_LIB_DECL QCPAxisTickerTime : public QCPAxisTicker
 public:
   /*!
     Defines the logical units in which fractions of time spans can be expressed.
-
+    
     \see setFieldWidth, setTimeFormat
   */
   enum TimeUnit { tuMilliseconds ///< Milliseconds, one thousandth of a second (%%z in \ref setTimeFormat)
@@ -1648,31 +1657,31 @@ public:
                   ,tuDays        ///< Days (%%d in \ref setTimeFormat)
                 };
   Q_ENUMS(TimeUnit)
-
+  
   QCPAxisTickerTime();
 
   // getters:
   QString timeFormat() const { return mTimeFormat; }
   int fieldWidth(TimeUnit unit) const { return mFieldWidth.value(unit); }
-
+  
   // setters:
   void setTimeFormat(const QString &format);
   void setFieldWidth(TimeUnit unit, int width);
-
+  
 protected:
   // property members:
   QString mTimeFormat;
   QHash<TimeUnit, int> mFieldWidth;
-
+  
   // non-property members:
   TimeUnit mSmallestUnit, mBiggestUnit;
   QHash<TimeUnit, QString> mFormatPattern;
-
+  
   // reimplemented virtual methods:
   virtual double getTickStep(const QCPRange &range) Q_DECL_OVERRIDE;
   virtual int getSubTickCount(double tickStep) Q_DECL_OVERRIDE;
   virtual QString getTickLabel(double tick, const QLocale &locale, QChar formatChar, int precision) Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   void replaceUnit(QString &text, TimeUnit unit, int value) const;
 };
@@ -1682,7 +1691,7 @@ Q_DECLARE_METATYPE(QCPAxisTickerTime::TimeUnit)
 
 
 /* including file 'src/axis/axistickerfixed.h', size 3308                    */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPAxisTickerFixed : public QCPAxisTicker
 {
@@ -1691,7 +1700,7 @@ public:
   /*!
     Defines how the axis ticker may modify the specified tick step (\ref setTickStep) in order to
     control the number of ticks in the axis range.
-
+    
     \see setScaleStrategy
   */
   enum ScaleStrategy { ssNone      ///< Modifications are not allowed, the specified tick step is absolutely fixed. This might cause a high tick density and overlapping labels if the axis range is zoomed out.
@@ -1699,22 +1708,22 @@ public:
                        ,ssPowers    ///< An integer power of the specified tick step is allowed.
                      };
   Q_ENUMS(ScaleStrategy)
-
+  
   QCPAxisTickerFixed();
-
+  
   // getters:
   double tickStep() const { return mTickStep; }
   ScaleStrategy scaleStrategy() const { return mScaleStrategy; }
-
+  
   // setters:
   void setTickStep(double step);
   void setScaleStrategy(ScaleStrategy strategy);
-
+  
 protected:
   // property members:
   double mTickStep;
   ScaleStrategy mScaleStrategy;
-
+  
   // reimplemented virtual methods:
   virtual double getTickStep(const QCPRange &range) Q_DECL_OVERRIDE;
 };
@@ -1723,47 +1732,46 @@ Q_DECLARE_METATYPE(QCPAxisTickerFixed::ScaleStrategy)
 /* end of 'src/axis/axistickerfixed.h' */
 
 
-/* including file 'src/axis/axistickertext.h', size 3085                     */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/axis/axistickertext.h', size 3090                     */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPAxisTickerText : public QCPAxisTicker
 {
 public:
   QCPAxisTickerText();
-
+  
   // getters:
   QMap<double, QString> &ticks() { return mTicks; }
   int subTickCount() const { return mSubTickCount; }
-
+  
   // setters:
   void setTicks(const QMap<double, QString> &ticks);
-  void setTicks(const QVector<double> &positions, const QVector<QString> labels);
+  void setTicks(const QVector<double> &positions, const QVector<QString> &labels);
   void setSubTickCount(int subTicks);
-
+  
   // non-virtual methods:
   void clear();
-  void addTick(double position, QString label);
+  void addTick(double position, const QString &label);
   void addTicks(const QMap<double, QString> &ticks);
   void addTicks(const QVector<double> &positions, const QVector<QString> &labels);
-
+  
 protected:
   // property members:
   QMap<double, QString> mTicks;
   int mSubTickCount;
-
+  
   // reimplemented virtual methods:
   virtual double getTickStep(const QCPRange &range) Q_DECL_OVERRIDE;
   virtual int getSubTickCount(double tickStep) Q_DECL_OVERRIDE;
   virtual QString getTickLabel(double tick, const QLocale &locale, QChar formatChar, int precision) Q_DECL_OVERRIDE;
   virtual QVector<double> createTickVector(double tickStep, const QCPRange &range) Q_DECL_OVERRIDE;
-
 };
 
 /* end of 'src/axis/axistickertext.h' */
 
 
 /* including file 'src/axis/axistickerpi.h', size 3911                       */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPAxisTickerPi : public QCPAxisTicker
 {
@@ -1771,7 +1779,7 @@ class QCP_LIB_DECL QCPAxisTickerPi : public QCPAxisTicker
 public:
   /*!
     Defines how fractions should be displayed in tick labels.
-
+    
     \see setFractionStyle
   */
   enum FractionStyle { fsFloatingPoint     ///< Fractions are displayed as regular decimal floating point numbers, e.g. "0.25" or "0.125".
@@ -1779,36 +1787,36 @@ public:
                        ,fsUnicodeFractions ///< Fractions are written using sub- and superscript UTF-8 digits and the fraction symbol.
                      };
   Q_ENUMS(FractionStyle)
-
+  
   QCPAxisTickerPi();
-
+  
   // getters:
   QString piSymbol() const { return mPiSymbol; }
   double piValue() const { return mPiValue; }
   bool periodicity() const { return mPeriodicity; }
   FractionStyle fractionStyle() const { return mFractionStyle; }
-
+  
   // setters:
   void setPiSymbol(QString symbol);
   void setPiValue(double pi);
   void setPeriodicity(int multiplesOfPi);
   void setFractionStyle(FractionStyle style);
-
+  
 protected:
   // property members:
   QString mPiSymbol;
   double mPiValue;
   int mPeriodicity;
   FractionStyle mFractionStyle;
-
+  
   // non-property members:
   double mPiTickStep; // size of one tick step in units of mPiValue
-
+  
   // reimplemented virtual methods:
   virtual double getTickStep(const QCPRange &range) Q_DECL_OVERRIDE;
   virtual int getSubTickCount(double tickStep) Q_DECL_OVERRIDE;
   virtual QString getTickLabel(double tick, const QLocale &locale, QChar formatChar, int precision) Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   void simplifyFraction(int &numerator, int &denominator) const;
   QString fractionToString(int numerator, int denominator) const;
@@ -1822,29 +1830,29 @@ Q_DECLARE_METATYPE(QCPAxisTickerPi::FractionStyle)
 
 
 /* including file 'src/axis/axistickerlog.h', size 2663                      */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPAxisTickerLog : public QCPAxisTicker
 {
 public:
   QCPAxisTickerLog();
-
+  
   // getters:
   double logBase() const { return mLogBase; }
   int subTickCount() const { return mSubTickCount; }
-
+  
   // setters:
   void setLogBase(double base);
   void setSubTickCount(int subTicks);
-
+  
 protected:
   // property members:
   double mLogBase;
   int mSubTickCount;
-
+  
   // non-property members:
   double mLogBaseLnInv;
-
+  
   // reimplemented virtual methods:
   virtual double getTickStep(const QCPRange &range) Q_DECL_OVERRIDE;
   virtual int getSubTickCount(double tickStep) Q_DECL_OVERRIDE;
@@ -1854,8 +1862,8 @@ protected:
 /* end of 'src/axis/axistickerlog.h' */
 
 
-/* including file 'src/axis/axis.h', size 20634                              */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/axis/axis.h', size 20698                              */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPGrid :public QCPLayerable
 {
@@ -1870,7 +1878,7 @@ class QCP_LIB_DECL QCPGrid :public QCPLayerable
   /// \endcond
 public:
   explicit QCPGrid(QCPAxis *parentAxis);
-
+  
   // getters:
   bool subGridVisible() const { return mSubGridVisible; }
   bool antialiasedSubGrid() const { return mAntialiasedSubGrid; }
@@ -1878,7 +1886,7 @@ public:
   QPen pen() const { return mPen; }
   QPen subGridPen() const { return mSubGridPen; }
   QPen zeroLinePen() const { return mZeroLinePen; }
-
+  
   // setters:
   void setSubGridVisible(bool visible);
   void setAntialiasedSubGrid(bool enabled);
@@ -1886,24 +1894,24 @@ public:
   void setPen(const QPen &pen);
   void setSubGridPen(const QPen &pen);
   void setZeroLinePen(const QPen &pen);
-
+  
 protected:
   // property members:
   bool mSubGridVisible;
   bool mAntialiasedSubGrid, mAntialiasedZeroLine;
   QPen mPen, mSubGridPen, mZeroLinePen;
-
+  
   // non-property members:
   QCPAxis *mParentAxis;
-
+  
   // reimplemented virtual methods:
   virtual void applyDefaultAntialiasingHint(QCPPainter *painter) const Q_DECL_OVERRIDE;
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   void drawGridLines(QCPPainter *painter) const;
   void drawSubGridLines(QCPPainter *painter) const;
-
+  
   friend class QCPAxis;
 };
 
@@ -1971,7 +1979,7 @@ public:
   Q_DECLARE_FLAGS(AxisTypes, AxisType)
   /*!
     Defines on which side of the axis the tick labels (numbers) shall appear.
-
+    
     \see setTickLabelSide
   */
   enum LabelSide { lsInside    ///< Tick labels will be displayed inside the axis rect and clipped to the inner axis rect
@@ -1998,10 +2006,10 @@ public:
   Q_ENUMS(SelectablePart)
   Q_FLAGS(SelectableParts)
   Q_DECLARE_FLAGS(SelectableParts, SelectablePart)
-
+  
   explicit QCPAxis(QCPAxisRect *parent, AxisType type);
   virtual ~QCPAxis();
-
+  
   // getters:
   AxisType axisType() const { return mAxisType; }
   QCPAxisRect *axisRect() const { return mAxisRect; }
@@ -2046,7 +2054,7 @@ public:
   QCPLineEnding lowerEnding() const;
   QCPLineEnding upperEnding() const;
   QCPGrid *grid() const { return mGrid; }
-
+  
   // setters:
   Q_SLOT void setScaleType(QCPAxis::ScaleType type);
   Q_SLOT void setRange(const QCPRange &range);
@@ -2092,10 +2100,10 @@ public:
   Q_SLOT void setSelectedParts(const QCPAxis::SelectableParts &selectedParts);
   void setLowerEnding(const QCPLineEnding &ending);
   void setUpperEnding(const QCPLineEnding &ending);
-
+  
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
-
+  
   // non-property methods:
   Qt::Orientation orientation() const { return mOrientation; }
   int pixelOrientation() const { return rangeReversed() != (orientation()==Qt::Vertical) ? -1 : 1; }
@@ -2110,11 +2118,11 @@ public:
   QList<QCPAbstractPlottable*> plottables() const;
   QList<QCPGraph*> graphs() const;
   QList<QCPAbstractItem*> items() const;
-
+  
   static AxisType marginSideToAxisType(QCP::MarginSide side);
   static Qt::Orientation orientation(AxisType type) { return type==atBottom||type==atTop ? Qt::Horizontal : Qt::Vertical; }
   static AxisType opposite(AxisType type);
-
+  
 signals:
   void rangeChanged(const QCPRange &newRange);
   void rangeChanged(const QCPRange &newRange, const QCPRange &oldRange);
@@ -2158,7 +2166,7 @@ protected:
   QCPRange mRange;
   bool mRangeReversed;
   ScaleType mScaleType;
-
+  
   // non-property members:
   QCPGrid *mGrid;
   QCPAxisPainterPrivate *mAxisPainter;
@@ -2171,10 +2179,10 @@ protected:
   bool mDragging;
   QCPRange mDragStartRange;
   QCP::AntialiasedElements mAADragBackup, mNotAADragBackup;
-
+  
   // introduced virtual methods:
   virtual int calculateMargin();
-
+  
   // reimplemented virtual methods:
   virtual void applyDefaultAntialiasingHint(QCPPainter *painter) const Q_DECL_OVERRIDE;
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
@@ -2183,11 +2191,11 @@ protected:
   virtual void selectEvent(QMouseEvent *event, bool additive, const QVariant &details, bool *selectionStateChanged) Q_DECL_OVERRIDE;
   virtual void deselectEvent(bool *selectionStateChanged) Q_DECL_OVERRIDE;
   // mouse events:
-  void mousePressEvent(QMouseEvent *event, const QVariant &details) override;
-  void mouseMoveEvent(QMouseEvent *event, const QPointF &startPos) override;
-  void mouseReleaseEvent(QMouseEvent *event, const QPointF &startPos) override;
-  void wheelEvent(QWheelEvent *event) override;
-
+  virtual void mousePressEvent(QMouseEvent *event, const QVariant &details) Q_DECL_OVERRIDE;
+  virtual void mouseMoveEvent(QMouseEvent *event, const QPointF &startPos) Q_DECL_OVERRIDE;
+  virtual void mouseReleaseEvent(QMouseEvent *event, const QPointF &startPos) Q_DECL_OVERRIDE;
+  virtual void wheelEvent(QWheelEvent *event) Q_DECL_OVERRIDE;
+  
   // non-virtual methods:
   void setupTickVectors();
   QPen getBasePen() const;
@@ -2197,10 +2205,10 @@ protected:
   QFont getLabelFont() const;
   QColor getTickLabelColor() const;
   QColor getLabelColor() const;
-
+  
 private:
   Q_DISABLE_COPY(QCPAxis)
-
+  
   friend class QCustomPlot;
   friend class QCPGrid;
   friend class QCPAxisRect;
@@ -2218,15 +2226,15 @@ class QCPAxisPainterPrivate
 public:
   explicit QCPAxisPainterPrivate(QCustomPlot *parentPlot);
   virtual ~QCPAxisPainterPrivate();
-
+  
   virtual void draw(QCPPainter *painter);
   virtual int size() const;
   void clearCache();
-
+  
   QRect axisSelectionBox() const { return mAxisSelectionBox; }
   QRect tickLabelsSelectionBox() const { return mTickLabelsSelectionBox; }
   QRect labelSelectionBox() const { return mLabelSelectionBox; }
-
+  
   // public property members:
   QCPAxis::AxisType type;
   QPen basePen;
@@ -2248,11 +2256,11 @@ public:
   double offset; // directly accessed by QCPAxis setters/getters
   bool abbreviateDecimalPowers;
   bool reversedEndings;
-
+  
   QVector<double> subTickPositions;
   QVector<double> tickPositions;
   QVector<QString> tickLabels;
-
+  
 protected:
   struct CachedLabel
   {
@@ -2269,9 +2277,9 @@ protected:
   QByteArray mLabelParameterHash; // to determine whether mLabelCache needs to be cleared due to changed parameters
   QCache<QString, CachedLabel> mLabelCache;
   QRect mAxisSelectionBox, mTickLabelsSelectionBox, mLabelSelectionBox;
-
+  
   virtual QByteArray generateLabelParameterHash() const;
-
+  
   virtual void placeTickLabel(QCPPainter *painter, double position, int distanceToAxis, const QString &text, QSize *tickLabelsSize);
   virtual void drawTickLabel(QCPPainter *painter, double x, double y, const TickLabelData &labelData) const;
   virtual TickLabelData getTickLabelData(const QFont &font, const QString &text) const;
@@ -2283,7 +2291,7 @@ protected:
 
 
 /* including file 'src/scatterstyle.h', size 7275                            */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPScatterStyle
 {
@@ -2343,7 +2351,7 @@ public:
   QCPScatterStyle(ScatterShape shape, const QPen &pen, const QBrush &brush, double size);
   QCPScatterStyle(const QPixmap &pixmap);
   QCPScatterStyle(const QPainterPath &customPath, const QPen &pen, const QBrush &brush=Qt::NoBrush, double size=6);
-
+  
   // getters:
   double size() const { return mSize; }
   ScatterShape shape() const { return mShape; }
@@ -2377,7 +2385,7 @@ protected:
   QBrush mBrush;
   QPixmap mPixmap;
   QPainterPath mCustomPath;
-
+  
   // non-property members:
   bool mPenDefined;
 };
@@ -2390,7 +2398,7 @@ Q_DECLARE_METATYPE(QCPScatterStyle::ScatterShape)
 
 
 /* including file 'src/datacontainer.h', size 4596                           */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 /*! \relates QCPDataContainer
   Returns whether the sort key of \a a is less than the sort key of \a b.
@@ -2406,17 +2414,17 @@ class QCPDataContainer // no QCP_LIB_DECL, template class ends up in header (cpp
 public:
   typedef typename QVector<DataType>::const_iterator const_iterator;
   typedef typename QVector<DataType>::iterator iterator;
-
+  
   QCPDataContainer();
-
+  
   // getters:
   int size() const { return mData.size()-mPreallocSize; }
   bool isEmpty() const { return size() == 0; }
   bool autoSqueeze() const { return mAutoSqueeze; }
-
+  
   // setters:
   void setAutoSqueeze(bool enabled);
-
+  
   // non-virtual methods:
   void set(const QCPDataContainer<DataType> &data);
   void set(const QVector<DataType> &data, bool alreadySorted=false);
@@ -2430,7 +2438,7 @@ public:
   void clear();
   void sort();
   void squeeze(bool preAllocation=true, bool postAllocation=true);
-
+  
   const_iterator constBegin() const { return mData.constBegin()+mPreallocSize; }
   const_iterator constEnd() const { return mData.constEnd(); }
   iterator begin() { return mData.begin()+mPreallocSize; }
@@ -2442,16 +2450,16 @@ public:
   QCPRange valueRange(bool &foundRange, QCP::SignDomain signDomain=QCP::sdBoth, const QCPRange &inKeyRange=QCPRange());
   QCPDataRange dataRange() const { return QCPDataRange(0, size()); }
   void limitIteratorsToDataRange(const_iterator &begin, const_iterator &end, const QCPDataRange &dataRange) const;
-
+  
 protected:
   // property members:
   bool mAutoSqueeze;
-
+  
   // non-property memebers:
   QVector<DataType> mData;
   int mPreallocSize;
   int mPreallocIteration;
-
+  
   // non-virtual methods:
   void preallocateGrow(int minimumPreallocSize);
   void performAutoSqueeze();
@@ -2460,7 +2468,7 @@ protected:
 // include implementation in header since it is a class template:
 
 /* including file 'src/datacontainer.cpp', size 31349                        */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPDataContainer
@@ -2536,27 +2544,27 @@ protected:
 /* start documentation of inline functions */
 
 /*! \fn int QCPDataContainer<DataType>::size() const
-
+  
   Returns the number of data points in the container.
 */
 
 /*! \fn bool QCPDataContainer<DataType>::isEmpty() const
-
+  
   Returns whether this container holds no data points.
 */
 
 /*! \fn QCPDataContainer::const_iterator QCPDataContainer<DataType>::constBegin() const
-
+  
   Returns a const iterator to the first data point in this container.
 */
 
 /*! \fn QCPDataContainer::const_iterator QCPDataContainer<DataType>::constEnd() const
-
+  
   Returns a const iterator to the element past the last data point in this container.
 */
 
 /*! \fn QCPDataContainer::iterator QCPDataContainer<DataType>::begin() const
-
+  
   Returns a non-const iterator to the first data point in this container.
 
   You can manipulate the data points in-place through the non-const iterators, but great care must
@@ -2565,9 +2573,9 @@ protected:
 */
 
 /*! \fn QCPDataContainer::iterator QCPDataContainer<DataType>::end() const
-
+  
   Returns a non-const iterator to the element past the last data point in this container.
-
+  
   You can manipulate the data points in-place through the non-const iterators, but great care must
   be taken when manipulating the sort key of a data point, see \ref sort, or the detailed
   description of this class.
@@ -2607,7 +2615,7 @@ QCPDataContainer<DataType>::QCPDataContainer() :
   Sets whether the container automatically decides when to release memory from its post- and
   preallocation pools when data points are removed. By default this is enabled and for typical
   applications shouldn't be changed.
-
+  
   If auto squeeze is disabled, you can manually decide when to release pre-/postallocation with
   \ref squeeze.
 */
@@ -2623,9 +2631,9 @@ void QCPDataContainer<DataType>::setAutoSqueeze(bool enabled)
 }
 
 /*! \overload
-
+  
   Replaces the current data in this container with the provided \a data.
-
+  
   \see add, remove
 */
 template <class DataType>
@@ -2636,12 +2644,12 @@ void QCPDataContainer<DataType>::set(const QCPDataContainer<DataType> &data)
 }
 
 /*! \overload
-
+  
   Replaces the current data in this container with the provided \a data
 
   If you can guarantee that the data points in \a data have ascending order with respect to the
   DataType's sort key, set \a alreadySorted to true to avoid an unnecessary sorting run.
-
+  
   \see add, remove
 */
 template <class DataType>
@@ -2655,9 +2663,9 @@ void QCPDataContainer<DataType>::set(const QVector<DataType> &data, bool already
 }
 
 /*! \overload
-
+  
   Adds the provided \a data to the current data in this container.
-
+  
   \see set, remove
 */
 template <class DataType>
@@ -2665,10 +2673,10 @@ void QCPDataContainer<DataType>::add(const QCPDataContainer<DataType> &data)
 {
   if (data.isEmpty())
     return;
-
+  
   const int n = data.size();
   const int oldSize = size();
-
+  
   if (oldSize > 0 && !qcpLessThanSortKey<DataType>(*constBegin(), *(data.constEnd()-1))) // prepend if new data keys are all smaller than or equal to existing ones
   {
     if (mPreallocSize < n)
@@ -2686,10 +2694,10 @@ void QCPDataContainer<DataType>::add(const QCPDataContainer<DataType> &data)
 
 /*!
   Adds the provided data points in \a data to the current data.
-
+  
   If you can guarantee that the data points in \a data have ascending order with respect to the
   DataType's sort key, set \a alreadySorted to true to avoid an unnecessary sorting run.
-
+  
   \see set, remove
 */
 template <class DataType>
@@ -2702,10 +2710,10 @@ void QCPDataContainer<DataType>::add(const QVector<DataType> &data, bool already
     set(data, alreadySorted);
     return;
   }
-
+  
   const int n = data.size();
   const int oldSize = size();
-
+  
   if (alreadySorted && oldSize > 0 && !qcpLessThanSortKey<DataType>(*constBegin(), *(data.constEnd()-1))) // prepend if new data is sorted and keys are all smaller than or equal to existing ones
   {
     if (mPreallocSize < n)
@@ -2724,9 +2732,9 @@ void QCPDataContainer<DataType>::add(const QVector<DataType> &data, bool already
 }
 
 /*! \overload
-
+  
   Adds the provided single data point to the current data.
-
+  
   \see remove
 */
 template <class DataType>
@@ -2750,7 +2758,7 @@ void QCPDataContainer<DataType>::add(const DataType &data)
 
 /*!
   Removes all data points with (sort-)keys smaller than or equal to \a sortKey.
-
+  
   \see removeAfter, remove, clear
 */
 template <class DataType>
@@ -2782,7 +2790,7 @@ void QCPDataContainer<DataType>::removeAfter(double sortKey)
   Removes all data points with (sort-)keys between \a sortKeyFrom and \a sortKeyTo. if \a
   sortKeyFrom is greater or equal to \a sortKeyTo, the function does nothing. To remove a single
   data point with known (sort-)key, use \ref remove(double sortKey).
-
+  
   \see removeBefore, removeAfter, clear
 */
 template <class DataType>
@@ -2790,7 +2798,7 @@ void QCPDataContainer<DataType>::remove(double sortKeyFrom, double sortKeyTo)
 {
   if (sortKeyFrom >= sortKeyTo || isEmpty())
     return;
-
+  
   QCPDataContainer<DataType>::iterator it = std::lower_bound(begin(), end(), DataType::fromSortKey(sortKeyFrom), qcpLessThanSortKey<DataType>);
   QCPDataContainer<DataType>::iterator itEnd = std::upper_bound(it, end(), DataType::fromSortKey(sortKeyTo), qcpLessThanSortKey<DataType>);
   mData.erase(it, itEnd);
@@ -2799,12 +2807,12 @@ void QCPDataContainer<DataType>::remove(double sortKeyFrom, double sortKeyTo)
 }
 
 /*! \overload
-
+  
   Removes a single data point at \a sortKey. If the position is not known with absolute (binary)
   precision, consider using \ref remove(double sortKeyFrom, double sortKeyTo) with a small
   fuzziness interval around the suspected position, depeding on the precision with which the
   (sort-)key is known.
-
+  
   \see removeBefore, removeAfter, clear
 */
 template <class DataType>
@@ -2824,7 +2832,7 @@ void QCPDataContainer<DataType>::remove(double sortKey)
 
 /*!
   Removes all data points.
-
+  
   \see remove, removeAfter, removeBefore
 */
 template <class DataType>
@@ -2854,11 +2862,11 @@ void QCPDataContainer<DataType>::sort()
 
 /*!
   Frees all unused memory that is currently in the preallocation and postallocation pools.
-
+  
   Note that QCPDataContainer automatically decides whether squeezing is necessary, if \ref
   setAutoSqueeze is left enabled. It should thus not be necessary to use this method for typical
   applications.
-
+  
   The parameters \a preAllocation and \a postAllocation control whether pre- and/or post allocation
   should be freed, respectively.
 */
@@ -2899,7 +2907,7 @@ typename QCPDataContainer<DataType>::const_iterator QCPDataContainer<DataType>::
 {
   if (isEmpty())
     return constEnd();
-
+  
   QCPDataContainer<DataType>::const_iterator it = std::lower_bound(constBegin(), constEnd(), DataType::fromSortKey(sortKey), qcpLessThanSortKey<DataType>);
   if (expandedRange && it != constBegin()) // also covers it == constEnd case, and we know --constEnd is valid because mData isn't empty
     --it;
@@ -2926,7 +2934,7 @@ typename QCPDataContainer<DataType>::const_iterator QCPDataContainer<DataType>::
 {
   if (isEmpty())
     return constEnd();
-
+  
   QCPDataContainer<DataType>::const_iterator it = std::upper_bound(constBegin(), constEnd(), DataType::fromSortKey(sortKey), qcpLessThanSortKey<DataType>);
   if (expandedRange && it != constEnd())
     ++it;
@@ -2938,14 +2946,14 @@ typename QCPDataContainer<DataType>::const_iterator QCPDataContainer<DataType>::
   parameter \a foundRange indicates whether a sensible range was found. If this is false, you
   should not use the returned QCPRange (e.g. the data container is empty or all points have the
   same key).
-
+  
   Use \a signDomain to control which sign of the key coordinates should be considered. This is
   relevant e.g. for logarithmic plots which can mathematically only display one sign domain at a
   time.
-
+  
   If the DataType reports that its main key is equal to the sort key (\a sortKeyIsMainKey), as is
   the case for most plottables, this method uses this fact and finds the range very quickly.
-
+  
   \see valueRange
 */
 template <class DataType>
@@ -2960,7 +2968,7 @@ QCPRange QCPDataContainer<DataType>::keyRange(bool &foundRange, QCP::SignDomain 
   bool haveLower = false;
   bool haveUpper = false;
   double current;
-
+  
   QCPDataContainer<DataType>::const_iterator it = constBegin();
   QCPDataContainer<DataType>::const_iterator itEnd = constEnd();
   if (signDomain == QCP::sdBoth) // range may be anywhere
@@ -3050,7 +3058,7 @@ QCPRange QCPDataContainer<DataType>::keyRange(bool &foundRange, QCP::SignDomain 
       ++it;
     }
   }
-
+  
   foundRange = haveLower && haveUpper;
   return range;
 }
@@ -3146,7 +3154,7 @@ QCPRange QCPDataContainer<DataType>::valueRange(bool &foundRange, QCP::SignDomai
       }
     }
   }
-
+  
   foundRange = haveLower && haveUpper;
   return range;
 }
@@ -3155,7 +3163,7 @@ QCPRange QCPDataContainer<DataType>::valueRange(bool &foundRange, QCP::SignDomai
   Makes sure \a begin and \a end mark a data range that is both within the bounds of this data
   container's data, as well as within the specified \a dataRange. The initial range described by
   the passed iterators \a begin and \a end is never expanded, only contracted if necessary.
-
+  
   This function doesn't require for \a dataRange to be within the bounds of this data container's
   valid range.
 */
@@ -3169,11 +3177,11 @@ void QCPDataContainer<DataType>::limitIteratorsToDataRange(const_iterator &begin
 }
 
 /*! \internal
-
+  
   Increases the preallocation pool to have a size of at least \a minimumPreallocSize. Depending on
   the preallocation history, the container will grow by more than requested, to speed up future
   consecutive size increases.
-
+  
   if \a minimumPreallocSize is smaller than or equal to the current preallocation pool size, this
   method does nothing.
 */
@@ -3182,11 +3190,11 @@ void QCPDataContainer<DataType>::preallocateGrow(int minimumPreallocSize)
 {
   if (minimumPreallocSize <= mPreallocSize)
     return;
-
+  
   int newPreallocSize = minimumPreallocSize;
   newPreallocSize += (1u<<qBound(4, mPreallocIteration+4, 15)) - 12; // do 4 up to 32768-12 preallocation, doubling in each intermediate iteration
   ++mPreallocIteration;
-
+  
   int sizeDifference = newPreallocSize-mPreallocSize;
   mData.resize(mData.size()+sizeDifference);
   std::copy_backward(mData.begin()+mPreallocSize, mData.end()-sizeDifference, mData.end());
@@ -3194,14 +3202,14 @@ void QCPDataContainer<DataType>::preallocateGrow(int minimumPreallocSize)
 }
 
 /*! \internal
-
+  
   This method decides, depending on the total allocation size and the size of the unused pre- and
   postallocation pools, whether it is sensible to reduce the pools in order to free up unused
   memory. It then possibly calls \ref squeeze to do the deallocation.
-
+  
   If \ref setAutoSqueeze is enabled, this method is called automatically each time data points are
   removed from the container (e.g. \ref remove).
-
+  
   \note when changing the decision parameters, care must be taken not to cause a back-and-forth
   between squeezing and reallocation due to the growth strategy of the internal QVector and \ref
   preallocateGrow. The hysteresis between allocation and deallocation should be made high enough
@@ -3224,7 +3232,7 @@ void QCPDataContainer<DataType>::performAutoSqueeze()
     shrinkPostAllocation = postAllocSize > usedSize*5;
     shrinkPreAllocation = mPreallocSize > usedSize*1.5; // preallocation can grow into postallocation, so can be smaller
   }
-
+  
   if (shrinkPreAllocation || shrinkPostAllocation)
     squeeze(shrinkPreAllocation, shrinkPostAllocation);
 }
@@ -3234,8 +3242,8 @@ void QCPDataContainer<DataType>::performAutoSqueeze()
 /* end of 'src/datacontainer.h' */
 
 
-/* including file 'src/plottable.h', size 8312                               */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/plottable.h', size 8433                               */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPSelectionDecorator
 {
@@ -3243,28 +3251,28 @@ class QCP_LIB_DECL QCPSelectionDecorator
 public:
   QCPSelectionDecorator();
   virtual ~QCPSelectionDecorator();
-
+  
   // getters:
   QPen pen() const { return mPen; }
   QBrush brush() const { return mBrush; }
   QCPScatterStyle scatterStyle() const { return mScatterStyle; }
   QCPScatterStyle::ScatterProperties usedScatterProperties() const { return mUsedScatterProperties; }
-
+  
   // setters:
   void setPen(const QPen &pen);
   void setBrush(const QBrush &brush);
   void setScatterStyle(const QCPScatterStyle &scatterStyle, QCPScatterStyle::ScatterProperties usedProperties=QCPScatterStyle::spPen);
   void setUsedScatterProperties(const QCPScatterStyle::ScatterProperties &properties);
-
+  
   // non-virtual methods:
   void applyPen(QCPPainter *painter) const;
   void applyBrush(QCPPainter *painter) const;
   QCPScatterStyle getFinalScatterStyle(const QCPScatterStyle &unselectedStyle) const;
-
+  
   // introduced virtual methods:
   virtual void copyFrom(const QCPSelectionDecorator *other);
   virtual void drawDecoration(QCPPainter *painter, QCPDataSelection selection);
-
+  
 protected:
   // property members:
   QPen mPen;
@@ -3273,10 +3281,10 @@ protected:
   QCPScatterStyle::ScatterProperties mUsedScatterProperties;
   // non-property members:
   QCPAbstractPlottable *mPlottable;
-
+  
   // introduced virtual methods:
   virtual bool registerWithPlottable(QCPAbstractPlottable *plottable);
-
+  
 private:
   Q_DISABLE_COPY(QCPSelectionDecorator)
   friend class QCPAbstractPlottable;
@@ -3302,7 +3310,7 @@ class QCP_LIB_DECL QCPAbstractPlottable : public QCPLayerable
 public:
   QCPAbstractPlottable(QCPAxis *keyAxis, QCPAxis *valueAxis);
   virtual ~QCPAbstractPlottable();
-
+  
   // getters:
   QString name() const { return mName; }
   bool antialiasedFill() const { return mAntialiasedFill; }
@@ -3315,7 +3323,7 @@ public:
   bool selected() const { return !mSelection.isEmpty(); }
   QCPDataSelection selection() const { return mSelection; }
   QCPSelectionDecorator *selectionDecorator() const { return mSelectionDecorator; }
-
+  
   // setters:
   void setName(const QString &name);
   void setAntialiasedFill(bool enabled);
@@ -3329,11 +3337,11 @@ public:
   void setSelectionDecorator(QCPSelectionDecorator *decorator);
 
   // introduced virtual methods:
-  virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const override = 0;
+  virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE = 0; // actually introduced in QCPLayerable as non-pure, but we want to force reimplementation for plottables
   virtual QCPPlottableInterface1D *interface1D() { return 0; }
   virtual QCPRange getKeyRange(bool &foundRange, QCP::SignDomain inSignDomain=QCP::sdBoth) const = 0;
   virtual QCPRange getValueRange(bool &foundRange, QCP::SignDomain inSignDomain=QCP::sdBoth, const QCPRange &inKeyRange=QCPRange()) const = 0;
-
+  
   // non-property methods:
   void coordsToPixels(double key, double value, double &x, double &y) const;
   const QPointF coordsToPixels(double key, double value) const;
@@ -3346,12 +3354,12 @@ public:
   bool addToLegend();
   bool removeFromLegend(QCPLegend *legend) const;
   bool removeFromLegend() const;
-
+  
 signals:
   void selectionChanged(bool selected);
   void selectionChanged(const QCPDataSelection &selection);
   void selectableChanged(QCP::SelectionType selectable);
-
+  
 protected:
   // property members:
   QString mName;
@@ -3362,7 +3370,7 @@ protected:
   QCP::SelectionType mSelectable;
   QCPDataSelection mSelection;
   QCPSelectionDecorator *mSelectionDecorator;
-
+  
   // reimplemented virtual methods:
   virtual QRect clipRect() const Q_DECL_OVERRIDE;
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE = 0;
@@ -3371,17 +3379,17 @@ protected:
   // events:
   virtual void selectEvent(QMouseEvent *event, bool additive, const QVariant &details, bool *selectionStateChanged) Q_DECL_OVERRIDE;
   virtual void deselectEvent(bool *selectionStateChanged) Q_DECL_OVERRIDE;
-
+  
   // introduced virtual methods:
   virtual void drawLegendIcon(QCPPainter *painter, const QRectF &rect) const = 0;
-
+  
   // non-virtual methods:
   void applyFillAntialiasingHint(QCPPainter *painter) const;
   void applyScattersAntialiasingHint(QCPPainter *painter) const;
 
 private:
   Q_DISABLE_COPY(QCPAbstractPlottable)
-
+  
   friend class QCustomPlot;
   friend class QCPAxis;
   friend class QCPPlottableLegendItem;
@@ -3392,7 +3400,7 @@ private:
 
 
 /* including file 'src/item.h', size 9384                                    */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPItemAnchor
 {
@@ -3400,33 +3408,33 @@ class QCP_LIB_DECL QCPItemAnchor
 public:
   QCPItemAnchor(QCustomPlot *parentPlot, QCPAbstractItem *parentItem, const QString &name, int anchorId=-1);
   virtual ~QCPItemAnchor();
-
+  
   // getters:
   QString name() const { return mName; }
   virtual QPointF pixelPosition() const;
-
+  
 protected:
   // property members:
   QString mName;
-
+  
   // non-property members:
   QCustomPlot *mParentPlot;
   QCPAbstractItem *mParentItem;
   int mAnchorId;
   QSet<QCPItemPosition*> mChildrenX, mChildrenY;
-
+  
   // introduced virtual methods:
   virtual QCPItemPosition *toQCPItemPosition() { return 0; }
-
+  
   // non-virtual methods:
   void addChildX(QCPItemPosition* pos); // called from pos when this anchor is set as parent
   void removeChildX(QCPItemPosition *pos); // called from pos when its parent anchor is reset or pos deleted
   void addChildY(QCPItemPosition* pos); // called from pos when this anchor is set as parent
   void removeChildY(QCPItemPosition *pos); // called from pos when its parent anchor is reset or pos deleted
-
+  
 private:
   Q_DISABLE_COPY(QCPItemAnchor)
-
+  
   friend class QCPItemPosition;
 };
 
@@ -3439,7 +3447,7 @@ public:
   /*!
     Defines the ways an item position can be specified. Thus it defines what the numbers passed to
     \ref setCoords actually mean.
-
+    
     \see setType
   */
   enum PositionType { ptAbsolute        ///< Static positioning in pixels, starting from the top left corner of the viewport/widget.
@@ -3452,10 +3460,10 @@ public:
                       ,ptPlotCoords     ///< Dynamic positioning at a plot coordinate defined by two axes (see \ref setAxes).
                     };
   Q_ENUMS(PositionType)
-
+  
   QCPItemPosition(QCustomPlot *parentPlot, QCPAbstractItem *parentItem, const QString &name);
   virtual ~QCPItemPosition();
-
+  
   // getters:
   PositionType type() const { return typeX(); }
   PositionType typeX() const { return mPositionTypeX; }
@@ -3470,7 +3478,7 @@ public:
   QCPAxis *valueAxis() const { return mValueAxis.data(); }
   QCPAxisRect *axisRect() const;
   virtual QPointF pixelPosition() const Q_DECL_OVERRIDE;
-
+  
   // setters:
   void setType(PositionType type);
   void setTypeX(PositionType type);
@@ -3483,7 +3491,7 @@ public:
   void setAxes(QCPAxis* keyAxis, QCPAxis* valueAxis);
   void setAxisRect(QCPAxisRect *axisRect);
   void setPixelPosition(const QPointF &pixelPosition);
-
+  
 protected:
   // property members:
   PositionType mPositionTypeX, mPositionTypeY;
@@ -3491,13 +3499,13 @@ protected:
   QPointer<QCPAxisRect> mAxisRect;
   double mKey, mValue;
   QCPItemAnchor *mParentAnchorX, *mParentAnchorY;
-
+  
   // reimplemented virtual methods:
   virtual QCPItemPosition *toQCPItemPosition() Q_DECL_OVERRIDE { return this; }
-
+  
 private:
   Q_DISABLE_COPY(QCPItemPosition)
-
+  
 };
 Q_DECLARE_METATYPE(QCPItemPosition::PositionType)
 
@@ -3514,33 +3522,33 @@ class QCP_LIB_DECL QCPAbstractItem : public QCPLayerable
 public:
   explicit QCPAbstractItem(QCustomPlot *parentPlot);
   virtual ~QCPAbstractItem();
-
+  
   // getters:
   bool clipToAxisRect() const { return mClipToAxisRect; }
   QCPAxisRect *clipAxisRect() const;
   bool selectable() const { return mSelectable; }
   bool selected() const { return mSelected; }
-
+  
   // setters:
   void setClipToAxisRect(bool clip);
   void setClipAxisRect(QCPAxisRect *rect);
   Q_SLOT void setSelectable(bool selectable);
   Q_SLOT void setSelected(bool selected);
-
+  
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE = 0;
-
+  
   // non-virtual methods:
   QList<QCPItemPosition*> positions() const { return mPositions; }
   QList<QCPItemAnchor*> anchors() const { return mAnchors; }
   QCPItemPosition *position(const QString &name) const;
   QCPItemAnchor *anchor(const QString &name) const;
   bool hasAnchor(const QString &name) const;
-
+  
 signals:
   void selectionChanged(bool selected);
   void selectableChanged(bool selectable);
-
+  
 protected:
   // property members:
   bool mClipToAxisRect;
@@ -3548,7 +3556,7 @@ protected:
   QList<QCPItemPosition*> mPositions;
   QList<QCPItemAnchor*> mAnchors;
   bool mSelectable, mSelected;
-
+  
   // reimplemented virtual methods:
   virtual QCP::Interaction selectionCategory() const Q_DECL_OVERRIDE;
   virtual QRect clipRect() const Q_DECL_OVERRIDE;
@@ -3557,18 +3565,18 @@ protected:
   // events:
   virtual void selectEvent(QMouseEvent *event, bool additive, const QVariant &details, bool *selectionStateChanged) Q_DECL_OVERRIDE;
   virtual void deselectEvent(bool *selectionStateChanged) Q_DECL_OVERRIDE;
-
+  
   // introduced virtual methods:
   virtual QPointF anchorPixelPosition(int anchorId) const;
-
+  
   // non-virtual methods:
   double rectDistance(const QRectF &rect, const QPointF &pos, bool filledRect) const;
   QCPItemPosition *createPosition(const QString &name);
   QCPItemAnchor *createAnchor(const QString &name, int anchorId);
-
+  
 private:
   Q_DISABLE_COPY(QCPAbstractItem)
-
+  
   friend class QCustomPlot;
   friend class QCPItemAnchor;
 };
@@ -3577,7 +3585,7 @@ private:
 
 
 /* including file 'src/core.h', size 14886                                   */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCustomPlot : public QWidget
 {
@@ -3604,7 +3612,7 @@ public:
                          ,limAbove ///< Layer is inserted above other layer
                        };
   Q_ENUMS(LayerInsertMode)
-
+  
   /*!
     Defines with what timing the QCustomPlot surface is refreshed after a replot.
 
@@ -3616,10 +3624,10 @@ public:
                          ,rpQueuedReplot    ///< Queues the entire replot for the next event loop iteration. This way multiple redundant replots can be avoided. The actual replot is then done with \ref rpRefreshHint priority.
                        };
   Q_ENUMS(RefreshPriority)
-
+  
   explicit QCustomPlot(QWidget *parent = 0);
   virtual ~QCustomPlot();
-
+  
   // getters:
   QRect viewport() const { return mViewport; }
   double bufferDevicePixelRatio() const { return mBufferDevicePixelRatio; }
@@ -3638,7 +3646,7 @@ public:
   QCP::SelectionRectMode selectionRectMode() const { return mSelectionRectMode; }
   QCPSelectionRect *selectionRect() const { return mSelectionRect; }
   bool openGl() const { return mOpenGl; }
-
+  
   // setters:
   void setViewport(const QRect &rect);
   void setBufferDevicePixelRatio(double ratio);
@@ -3662,7 +3670,7 @@ public:
   void setSelectionRectMode(QCP::SelectionRectMode mode);
   void setSelectionRect(QCPSelectionRect *selectionRect);
   void setOpenGl(bool enabled, int multisampling=16);
-
+  
   // non-property methods:
   // plottable interface:
   QCPAbstractPlottable *plottable(int index);
@@ -3674,7 +3682,7 @@ public:
   QList<QCPAbstractPlottable*> selectedPlottables() const;
   QCPAbstractPlottable *plottableAt(const QPointF &pos, bool onlySelectable=false) const;
   bool hasPlottable(QCPAbstractPlottable *plottable) const;
-
+ 
   // specialized interface for QCPGraph:
   QCPGraph *graph(int index) const;
   QCPGraph *graph() const;
@@ -3695,7 +3703,7 @@ public:
   QList<QCPAbstractItem*> selectedItems() const;
   QCPAbstractItem *itemAt(const QPointF &pos, bool onlySelectable=false) const;
   bool hasItem(QCPAbstractItem *item) const;
-
+  
   // layer interface:
   QCPLayer *layer(const QString &name) const;
   QCPLayer *layer(int index) const;
@@ -3706,7 +3714,7 @@ public:
   bool addLayer(const QString &name, QCPLayer *otherLayer=0, LayerInsertMode insertMode=limAbove);
   bool removeLayer(QCPLayer *layer);
   bool moveLayer(QCPLayer *layer, QCPLayer *otherLayer, LayerInsertMode insertMode=limAbove);
-
+  
   // axis rect/layout interface:
   int axisRectCount() const;
   QCPAxisRect* axisRect(int index=0) const;
@@ -3714,11 +3722,11 @@ public:
   QCPLayoutElement* layoutElementAt(const QPointF &pos) const;
   QCPAxisRect* axisRectAt(const QPointF &pos) const;
   Q_SLOT void rescaleAxes(bool onlyVisiblePlottables=false);
-
+  
   QList<QCPAxis*> selectedAxes() const;
   QList<QCPLegend*> selectedLegends() const;
   Q_SLOT void deselectAll();
-
+  
   bool savePdf(const QString &fileName, int width=0, int height=0, QCP::ExportPen exportPen=QCP::epAllowCosmetic, const QString &pdfCreator=QString(), const QString &pdfTitle=QString());
   bool savePng(const QString &fileName, int width=0, int height=0, double scale=1.0, int quality=-1, int resolution=96, QCP::ResolutionUnit resolutionUnit=QCP::ruDotsPerInch);
   bool saveJpg(const QString &fileName, int width=0, int height=0, double scale=1.0, int quality=-1, int resolution=96, QCP::ResolutionUnit resolutionUnit=QCP::ruDotsPerInch);
@@ -3727,17 +3735,17 @@ public:
   QPixmap toPixmap(int width=0, int height=0, double scale=1.0);
   void toPainter(QCPPainter *painter, int width=0, int height=0);
   Q_SLOT void replot(QCustomPlot::RefreshPriority refreshPriority=QCustomPlot::rpRefreshHint);
-
+  
   QCPAxis *xAxis, *yAxis, *xAxis2, *yAxis2;
   QCPLegend *legend;
-
+  
 signals:
   void mouseDoubleClick(QMouseEvent *event);
   void mousePress(QMouseEvent *event);
   void mouseMove(QMouseEvent *event);
   void mouseRelease(QMouseEvent *event);
   void mouseWheel(QWheelEvent *event);
-
+  
   void plottableClick(QCPAbstractPlottable *plottable, int dataIndex, QMouseEvent *event);
   void plottableDoubleClick(QCPAbstractPlottable *plottable, int dataIndex, QMouseEvent *event);
   void itemClick(QCPAbstractItem *item, QMouseEvent *event);
@@ -3746,11 +3754,11 @@ signals:
   void axisDoubleClick(QCPAxis *axis, QCPAxis::SelectablePart part, QMouseEvent *event);
   void legendClick(QCPLegend *legend, QCPAbstractLegendItem *item, QMouseEvent *event);
   void legendDoubleClick(QCPLegend *legend,  QCPAbstractLegendItem *item, QMouseEvent *event);
-
+  
   void selectionChangedByUser();
   void beforeReplot();
   void afterReplot();
-
+  
 protected:
   // property members:
   QRect mViewport;
@@ -3776,7 +3784,7 @@ protected:
   QCP::SelectionRectMode mSelectionRectMode;
   QCPSelectionRect *mSelectionRect;
   bool mOpenGl;
-
+  
   // non-property members:
   QList<QSharedPointer<QCPAbstractPaintBuffer> > mPaintBuffers;
   QPoint mMousePressPos;
@@ -3795,7 +3803,7 @@ protected:
   QSharedPointer<QSurface> mGlSurface;
   QSharedPointer<QOpenGLPaintDevice> mGlPaintDevice;
 #endif
-
+  
   // reimplemented virtual methods:
   virtual QSize minimumSizeHint() const Q_DECL_OVERRIDE;
   virtual QSize sizeHint() const Q_DECL_OVERRIDE;
@@ -3806,7 +3814,7 @@ protected:
   virtual void mouseMoveEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
   virtual void mouseReleaseEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
   virtual void wheelEvent(QWheelEvent *event) Q_DECL_OVERRIDE;
-
+  
   // introduced virtual methods:
   virtual void draw(QCPPainter *painter);
   virtual void updateLayout();
@@ -3815,7 +3823,7 @@ protected:
   Q_SLOT virtual void processRectSelection(QRect rect, QMouseEvent *event);
   Q_SLOT virtual void processRectZoom(QRect rect, QMouseEvent *event);
   Q_SLOT virtual void processPointSelection(QMouseEvent *event);
-
+  
   // non-virtual methods:
   bool registerPlottable(QCPAbstractPlottable *plottable);
   bool registerGraph(QCPGraph *graph);
@@ -3829,7 +3837,7 @@ protected:
   bool hasInvalidatedPaintBuffers();
   bool setupOpenGl();
   void freeOpenGl();
-
+  
   friend class QCPLegend;
   friend class QCPAxis;
   friend class QCPLayer;
@@ -3845,7 +3853,7 @@ Q_DECLARE_METATYPE(QCustomPlot::RefreshPriority)
 
 
 /* including file 'src/plottable1d.h', size 4544                             */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCPPlottableInterface1D
 {
@@ -3868,11 +3876,11 @@ template <class DataType>
 class QCPAbstractPlottable1D : public QCPAbstractPlottable, public QCPPlottableInterface1D // no QCP_LIB_DECL, template class ends up in header (cpp included below)
 {
   // No Q_OBJECT macro due to template class
-
+  
 public:
   QCPAbstractPlottable1D(QCPAxis *keyAxis, QCPAxis *valueAxis);
   virtual ~QCPAbstractPlottable1D();
-
+  
   // virtual methods of 1d plottable interface:
   virtual int dataCount() const Q_DECL_OVERRIDE;
   virtual double dataMainKey(int index) const Q_DECL_OVERRIDE;
@@ -3884,28 +3892,28 @@ public:
   virtual QCPDataSelection selectTestRect(const QRectF &rect, bool onlySelectable) const Q_DECL_OVERRIDE;
   virtual int findBegin(double sortKey, bool expandedRange=true) const Q_DECL_OVERRIDE;
   virtual int findEnd(double sortKey, bool expandedRange=true) const Q_DECL_OVERRIDE;
-
+  
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
   virtual QCPPlottableInterface1D *interface1D() Q_DECL_OVERRIDE { return this; }
-
+  
 protected:
   // property members:
   QSharedPointer<QCPDataContainer<DataType> > mDataContainer;
-
+  
   // helpers for subclasses:
   void getDataSegments(QList<QCPDataRange> &selectedSegments, QList<QCPDataRange> &unselectedSegments) const;
   void drawPolyline(QCPPainter *painter, const QVector<QPointF> &lineData) const;
 
 private:
   Q_DISABLE_COPY(QCPAbstractPlottable1D)
-
+  
 };
 
 // include implementation in header since it is a class template:
 
-/* including file 'src/plottable1d.cpp', size 22240                          */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/plottable1d.cpp', size 22361                          */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// QCPPlottableInterface1D
@@ -3937,55 +3945,55 @@ private:
 /* start documentation of pure virtual functions */
 
 /*! \fn virtual int QCPPlottableInterface1D::dataCount() const = 0;
-
+  
   Returns the number of data points of the plottable.
 */
 
 /*! \fn virtual QCPDataSelection QCPPlottableInterface1D::selectTestRect(const QRectF &rect, bool onlySelectable) const = 0;
-
+  
   Returns a data selection containing all the data points of this plottable which are contained (or
   hit by) \a rect. This is used mainly in the selection rect interaction for data selection (\ref
   dataselection "data selection mechanism").
-
+  
   If \a onlySelectable is true, an empty QCPDataSelection is returned if this plottable is not
   selectable (i.e. if \ref QCPAbstractPlottable::setSelectable is \ref QCP::stNone).
-
+  
   \note \a rect must be a normalized rect (positive or zero width and height). This is especially
   important when using the rect of \ref QCPSelectionRect::accepted, which is not necessarily
   normalized. Use <tt>QRect::normalized()</tt> when passing a rect which might not be normalized.
 */
 
 /*! \fn virtual double QCPPlottableInterface1D::dataMainKey(int index) const = 0
-
+  
   Returns the main key of the data point at the given \a index.
-
+  
   What the main key is, is defined by the plottable's data type. See the \ref
   qcpdatacontainer-datatype "QCPDataContainer DataType" documentation for details about this naming
   convention.
 */
 
 /*! \fn virtual double QCPPlottableInterface1D::dataSortKey(int index) const = 0
-
+  
   Returns the sort key of the data point at the given \a index.
-
+  
   What the sort key is, is defined by the plottable's data type. See the \ref
   qcpdatacontainer-datatype "QCPDataContainer DataType" documentation for details about this naming
   convention.
 */
 
 /*! \fn virtual double QCPPlottableInterface1D::dataMainValue(int index) const = 0
-
+  
   Returns the main value of the data point at the given \a index.
-
+  
   What the main value is, is defined by the plottable's data type. See the \ref
   qcpdatacontainer-datatype "QCPDataContainer DataType" documentation for details about this naming
   convention.
 */
 
 /*! \fn virtual QCPRange QCPPlottableInterface1D::dataValueRange(int index) const = 0
-
+  
   Returns the value range of the data point at the given \a index.
-
+  
   What the value range is, is defined by the plottable's data type. See the \ref
   qcpdatacontainer-datatype "QCPDataContainer DataType" documentation for details about this naming
   convention.
@@ -4079,10 +4087,10 @@ private:
 /* start documentation of inline functions */
 
 /*! \fn QCPPlottableInterface1D *QCPAbstractPlottable1D::interface1D()
-
+  
   Returns a \ref QCPPlottableInterface1D pointer to this plottable, providing access to its 1D
   interface.
-
+  
   \seebaseclassmethod
 */
 
@@ -4218,7 +4226,7 @@ QCPDataSelection QCPAbstractPlottable1D<DataType>::selectTestRect(const QRectF &
     return result;
   if (!mKeyAxis || !mValueAxis)
     return result;
-
+  
   // convert rect given in pixels to ranges given in plot coordinates:
   double key1, value1, key2, value2;
   pixelsToCoords(rect.topLeft(), key1, value1);
@@ -4234,7 +4242,7 @@ QCPDataSelection QCPAbstractPlottable1D<DataType>::selectTestRect(const QRectF &
   }
   if (begin == end)
     return result;
-
+  
   int currentSegmentBegin = -1; // -1 means we're currently not in a segment that's contained in rect
   for (typename QCPDataContainer<DataType>::const_iterator it=begin; it!=end; ++it)
   {
@@ -4251,7 +4259,7 @@ QCPDataSelection QCPAbstractPlottable1D<DataType>::selectTestRect(const QRectF &
   // process potential last segment:
   if (currentSegmentBegin != -1)
     result.addDataRange(QCPDataRange(currentSegmentBegin, end-mDataContainer->constBegin()), false);
-
+  
   result.simplify();
   return result;
 }
@@ -4279,6 +4287,9 @@ int QCPAbstractPlottable1D<DataType>::findEnd(double sortKey, bool expandedRange
   point-like. Most subclasses will want to reimplement this method again, to provide a more
   accurate hit test based on the true data visualization geometry.
 
+  If \a details is not 0, it will be set to a \ref QCPDataSelection, describing the closest data point
+  to \a pos.
+  
   \seebaseclassmethod
 */
 template <class DataType>
@@ -4288,11 +4299,11 @@ double QCPAbstractPlottable1D<DataType>::selectTest(const QPointF &pos, bool onl
     return -1;
   if (!mKeyAxis || !mValueAxis)
     return -1;
-
+  
   QCPDataSelection selectionResult;
-  double minDistSqr = std::numeric_limits<double>::max();
+  double minDistSqr = (std::numeric_limits<double>::max)();
   int minDistIndex = mDataContainer->size();
-
+  
   typename QCPDataContainer<DataType>::const_iterator begin = mDataContainer->constBegin();
   typename QCPDataContainer<DataType>::const_iterator end = mDataContainer->constEnd();
   if (DataType::sortKeyIsMainKey()) // we can assume that data is sorted by main key, so can reduce the searched key interval:
@@ -4326,7 +4337,7 @@ double QCPAbstractPlottable1D<DataType>::selectTest(const QPointF &pos, bool onl
   }
   if (minDistIndex != mDataContainer->size())
     selectionResult.addDataRange(QCPDataRange(minDistIndex, minDistIndex+1), false);
-
+  
   selectionResult.simplify();
   if (details)
     details->setValue(selectionResult);
@@ -4425,7 +4436,7 @@ void QCPAbstractPlottable1D<DataType>::drawPolyline(QCPPainter *painter, const Q
 
 
 /* including file 'src/colorgradient.h', size 6243                           */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPColorGradient
 {
@@ -4433,14 +4444,14 @@ class QCP_LIB_DECL QCPColorGradient
 public:
   /*!
     Defines the color spaces in which color interpolation between gradient stops can be performed.
-
+    
     \see setColorInterpolation
   */
   enum ColorInterpolation { ciRGB  ///< Color channels red, green and blue are linearly interpolated
                             ,ciHSV ///< Color channels hue, saturation and value are linearly interpolated (The hue is interpolated over the shortest angle distance)
                           };
   Q_ENUMS(ColorInterpolation)
-
+  
   /*!
     Defines the available presets that can be loaded with \ref loadPreset. See the documentation
     there for an image of the presets.
@@ -4459,25 +4470,25 @@ public:
                         ,gpHues      ///< Full hue cycle, with highest and lowest color red (suitable for periodic data, such as angles and phases, see \ref setPeriodic)
                       };
   Q_ENUMS(GradientPreset)
-
+  
   QCPColorGradient();
   QCPColorGradient(GradientPreset preset);
   bool operator==(const QCPColorGradient &other) const;
   bool operator!=(const QCPColorGradient &other) const { return !(*this == other); }
-
+  
   // getters:
   int levelCount() const { return mLevelCount; }
   QMap<double, QColor> colorStops() const { return mColorStops; }
   ColorInterpolation colorInterpolation() const { return mColorInterpolation; }
   bool periodic() const { return mPeriodic; }
-
+  
   // setters:
   void setLevelCount(int n);
   void setColorStops(const QMap<double, QColor> &colorStops);
   void setColorStopAt(double position, const QColor &color);
   void setColorInterpolation(ColorInterpolation interpolation);
   void setPeriodic(bool enabled);
-
+  
   // non-property methods:
   void colorize(const double *data, const QCPRange &range, QRgb *scanLine, int n, int dataIndexFactor=1, bool logarithmic=false);
   void colorize(const double *data, const unsigned char *alpha, const QCPRange &range, QRgb *scanLine, int n, int dataIndexFactor=1, bool logarithmic=false);
@@ -4485,18 +4496,18 @@ public:
   void loadPreset(GradientPreset preset);
   void clearColorStops();
   QCPColorGradient inverted() const;
-
+  
 protected:
   // property members:
   int mLevelCount;
   QMap<double, QColor> mColorStops;
   ColorInterpolation mColorInterpolation;
   bool mPeriodic;
-
+  
   // non-property members:
   QVector<QRgb> mColorBuffer; // have colors premultiplied with alpha (for usage with QImage::Format_ARGB32_Premultiplied)
   bool mColorBufferInvalidated;
-
+  
   // non-virtual methods:
   bool stopsUseAlpha() const;
   void updateColorBuffer();
@@ -4508,16 +4519,16 @@ Q_DECLARE_METATYPE(QCPColorGradient::GradientPreset)
 
 
 /* including file 'src/selectiondecorator-bracket.h', size 4442              */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPSelectionDecoratorBracket : public QCPSelectionDecorator
 {
   Q_GADGET
 public:
-
+  
   /*!
     Defines which shape is drawn at the boundaries of selected data ranges.
-
+    
     Some of the bracket styles further allow specifying a height and/or width, see \ref
     setBracketHeight and \ref setBracketWidth.
   */
@@ -4528,10 +4539,10 @@ public:
                       ,bsUserStyle    ///< Start custom bracket styles at this index when subclassing and reimplementing \ref drawBracket.
   };
   Q_ENUMS(BracketStyle)
-
+  
   QCPSelectionDecoratorBracket();
   virtual ~QCPSelectionDecoratorBracket();
-
+  
   // getters:
   QPen bracketPen() const { return mBracketPen; }
   QBrush bracketBrush() const { return mBracketBrush; }
@@ -4540,7 +4551,7 @@ public:
   BracketStyle bracketStyle() const { return mBracketStyle; }
   bool tangentToData() const { return mTangentToData; }
   int tangentAverage() const { return mTangentAverage; }
-
+  
   // setters:
   void setBracketPen(const QPen &pen);
   void setBracketBrush(const QBrush &brush);
@@ -4549,13 +4560,13 @@ public:
   void setBracketStyle(BracketStyle style);
   void setTangentToData(bool enabled);
   void setTangentAverage(int pointCount);
-
+  
   // introduced virtual methods:
   virtual void drawBracket(QCPPainter *painter, int direction) const;
-
+  
   // virtual methods:
   virtual void drawDecoration(QCPPainter *painter, QCPDataSelection selection) Q_DECL_OVERRIDE;
-
+  
 protected:
   // property members:
   QPen mBracketPen;
@@ -4565,11 +4576,11 @@ protected:
   BracketStyle mBracketStyle;
   bool mTangentToData;
   int mTangentAverage;
-
+  
   // non-virtual methods:
   double getTangentAngle(const QCPPlottableInterface1D *interface1d, int dataIndex, int direction) const;
   QPointF getPixelCoordinates(const QCPPlottableInterface1D *interface1d, int dataIndex) const;
-
+  
 };
 Q_DECLARE_METATYPE(QCPSelectionDecoratorBracket::BracketStyle)
 
@@ -4577,7 +4588,7 @@ Q_DECLARE_METATYPE(QCPSelectionDecoratorBracket::BracketStyle)
 
 
 /* including file 'src/layoutelements/layoutelement-axisrect.h', size 7507   */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPAxisRect : public QCPLayoutElement
 {
@@ -4592,7 +4603,7 @@ class QCP_LIB_DECL QCPAxisRect : public QCPLayoutElement
 public:
   explicit QCPAxisRect(QCustomPlot *parentPlot, bool setupDefaultAxes=true);
   virtual ~QCPAxisRect();
-
+  
   // getters:
   QPixmap background() const { return mBackgroundPixmap; }
   QBrush backgroundBrush() const { return mBackgroundBrush; }
@@ -4605,7 +4616,7 @@ public:
   QList<QCPAxis*> rangeDragAxes(Qt::Orientation orientation);
   QList<QCPAxis*> rangeZoomAxes(Qt::Orientation orientation);
   double rangeZoomFactor(Qt::Orientation orientation);
-
+  
   // setters:
   void setBackground(const QPixmap &pm);
   void setBackground(const QPixmap &pm, bool scaled, Qt::AspectRatioMode mode=Qt::KeepAspectRatioByExpanding);
@@ -4622,7 +4633,7 @@ public:
   void setRangeZoomAxes(QList<QCPAxis*> horizontal, QList<QCPAxis*> vertical);
   void setRangeZoomFactor(double horizontalFactor, double verticalFactor);
   void setRangeZoomFactor(double factor);
-
+  
   // non-property methods:
   int axisCount(QCPAxis::AxisType type) const;
   QCPAxis *axis(QCPAxis::AxisType type, int index=0) const;
@@ -4632,14 +4643,14 @@ public:
   QList<QCPAxis*> addAxes(QCPAxis::AxisTypes types);
   bool removeAxis(QCPAxis *axis);
   QCPLayoutInset *insetLayout() const { return mInsetLayout; }
-
+  
   void zoom(const QRectF &pixelRect);
   void zoom(const QRectF &pixelRect, const QList<QCPAxis*> &affectedAxes);
   void setupFullAxesBox(bool connectRanges=false);
   QList<QCPAbstractPlottable*> plottables() const;
   QList<QCPGraph*> graphs() const;
   QList<QCPAbstractItem*> items() const;
-
+  
   // read-only interface imitating a QRect:
   int left() const { return mRect.left(); }
   int right() const { return mRect.right(); }
@@ -4653,7 +4664,7 @@ public:
   QPoint bottomLeft() const { return mRect.bottomLeft(); }
   QPoint bottomRight() const { return mRect.bottomRight(); }
   QPoint center() const { return mRect.center(); }
-
+  
   // reimplemented virtual methods:
   virtual void update(UpdatePhase phase) Q_DECL_OVERRIDE;
   virtual QList<QCPLayoutElement*> elements(bool recursive) const Q_DECL_OVERRIDE;
@@ -4670,13 +4681,13 @@ protected:
   QList<QPointer<QCPAxis> > mRangeDragHorzAxis, mRangeDragVertAxis;
   QList<QPointer<QCPAxis> > mRangeZoomHorzAxis, mRangeZoomVertAxis;
   double mRangeZoomFactorHorz, mRangeZoomFactorVert;
-
+  
   // non-property members:
   QList<QCPRange> mDragStartHorzRange, mDragStartVertRange;
   QCP::AntialiasedElements mAADragBackup, mNotAADragBackup;
   bool mDragging;
   QHash<QCPAxis::AxisType, QList<QCPAxis*> > mAxes;
-
+  
   // reimplemented virtual methods:
   virtual void applyDefaultAntialiasingHint(QCPPainter *painter) const Q_DECL_OVERRIDE;
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
@@ -4687,14 +4698,14 @@ protected:
   virtual void mouseMoveEvent(QMouseEvent *event, const QPointF &startPos) Q_DECL_OVERRIDE;
   virtual void mouseReleaseEvent(QMouseEvent *event, const QPointF &startPos) Q_DECL_OVERRIDE;
   virtual void wheelEvent(QWheelEvent *event) Q_DECL_OVERRIDE;
-
+  
   // non-property methods:
   void drawBackground(QCPPainter *painter);
   void updateAxesOffset(QCPAxis::AxisType type);
-
+  
 private:
   Q_DISABLE_COPY(QCPAxisRect)
-
+  
   friend class QCustomPlot;
 };
 
@@ -4703,7 +4714,7 @@ private:
 
 
 /* including file 'src/layoutelements/layoutelement-legend.h', size 10397    */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPAbstractLegendItem : public QCPLayoutElement
 {
@@ -4719,7 +4730,7 @@ class QCP_LIB_DECL QCPAbstractLegendItem : public QCPLayoutElement
   /// \endcond
 public:
   explicit QCPAbstractLegendItem(QCPLegend *parent);
-
+  
   // getters:
   QCPLegend *parentLegend() const { return mParentLegend; }
   QFont font() const { return mFont; }
@@ -4728,7 +4739,7 @@ public:
   QColor selectedTextColor() const { return mSelectedTextColor; }
   bool selectable() const { return mSelectable; }
   bool selected() const { return mSelected; }
-
+  
   // setters:
   void setFont(const QFont &font);
   void setTextColor(const QColor &color);
@@ -4736,14 +4747,14 @@ public:
   void setSelectedTextColor(const QColor &color);
   Q_SLOT void setSelectable(bool selectable);
   Q_SLOT void setSelected(bool selected);
-
+  
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
-
+  
 signals:
   void selectionChanged(bool selected);
   void selectableChanged(bool selectable);
-
+  
 protected:
   // property members:
   QCPLegend *mParentLegend;
@@ -4752,7 +4763,7 @@ protected:
   QFont mSelectedFont;
   QColor mSelectedTextColor;
   bool mSelectable, mSelected;
-
+  
   // reimplemented virtual methods:
   virtual QCP::Interaction selectionCategory() const Q_DECL_OVERRIDE;
   virtual void applyDefaultAntialiasingHint(QCPPainter *painter) const Q_DECL_OVERRIDE;
@@ -4761,10 +4772,10 @@ protected:
   // events:
   virtual void selectEvent(QMouseEvent *event, bool additive, const QVariant &details, bool *selectionStateChanged) Q_DECL_OVERRIDE;
   virtual void deselectEvent(bool *selectionStateChanged) Q_DECL_OVERRIDE;
-
+  
 private:
   Q_DISABLE_COPY(QCPAbstractLegendItem)
-
+  
   friend class QCPLegend;
 };
 
@@ -4774,18 +4785,18 @@ class QCP_LIB_DECL QCPPlottableLegendItem : public QCPAbstractLegendItem
   Q_OBJECT
 public:
   QCPPlottableLegendItem(QCPLegend *parent, QCPAbstractPlottable *plottable);
-
+  
   // getters:
   QCPAbstractPlottable *plottable() { return mPlottable; }
-
+  
 protected:
   // property members:
   QCPAbstractPlottable *mPlottable;
-
+  
   // reimplemented virtual methods:
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
   virtual QSize minimumOuterSizeHint() const Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   QPen getIconBorderPen() const;
   QColor getTextColor() const;
@@ -4815,7 +4826,7 @@ class QCP_LIB_DECL QCPLegend : public QCPLayoutGrid
 public:
   /*!
     Defines the selectable parts of a legend
-
+    
     \see setSelectedParts, setSelectableParts
   */
   enum SelectablePart { spNone        = 0x000 ///< <tt>0x000</tt> None
@@ -4825,10 +4836,10 @@ public:
   Q_ENUMS(SelectablePart)
   Q_FLAGS(SelectableParts)
   Q_DECLARE_FLAGS(SelectableParts, SelectablePart)
-
+  
   explicit QCPLegend();
   virtual ~QCPLegend();
-
+  
   // getters:
   QPen borderPen() const { return mBorderPen; }
   QBrush brush() const { return mBrush; }
@@ -4844,7 +4855,7 @@ public:
   QBrush selectedBrush() const { return mSelectedBrush; }
   QFont selectedFont() const { return mSelectedFont; }
   QColor selectedTextColor() const { return mSelectedTextColor; }
-
+  
   // setters:
   void setBorderPen(const QPen &pen);
   void setBrush(const QBrush &brush);
@@ -4861,10 +4872,10 @@ public:
   void setSelectedBrush(const QBrush &brush);
   void setSelectedFont(const QFont &font);
   void setSelectedTextColor(const QColor &color);
-
+  
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   QCPAbstractLegendItem *item(int index) const;
   QCPPlottableLegendItem *itemWithPlottable(const QCPAbstractPlottable *plottable) const;
@@ -4876,11 +4887,11 @@ public:
   bool removeItem(QCPAbstractLegendItem *item);
   void clearItems();
   QList<QCPAbstractLegendItem*> selectedItems() const;
-
+  
 signals:
   void selectionChanged(QCPLegend::SelectableParts parts);
   void selectableChanged(QCPLegend::SelectableParts parts);
-
+  
 protected:
   // property members:
   QPen mBorderPen, mIconBorderPen;
@@ -4894,7 +4905,7 @@ protected:
   QBrush mSelectedBrush;
   QFont mSelectedFont;
   QColor mSelectedTextColor;
-
+  
   // reimplemented virtual methods:
   virtual void parentPlotInitialized(QCustomPlot *parentPlot) Q_DECL_OVERRIDE;
   virtual QCP::Interaction selectionCategory() const Q_DECL_OVERRIDE;
@@ -4903,14 +4914,14 @@ protected:
   // events:
   virtual void selectEvent(QMouseEvent *event, bool additive, const QVariant &details, bool *selectionStateChanged) Q_DECL_OVERRIDE;
   virtual void deselectEvent(bool *selectionStateChanged) Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   QPen getBorderPen() const;
   QBrush getBrush() const;
-
+  
 private:
   Q_DISABLE_COPY(QCPLegend)
-
+  
   friend class QCustomPlot;
   friend class QCPAbstractLegendItem;
 };
@@ -4921,7 +4932,7 @@ Q_DECLARE_METATYPE(QCPLegend::SelectablePart)
 
 
 /* including file 'src/layoutelements/layoutelement-textelement.h', size 5353 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200  */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200  */
 
 class QCP_LIB_DECL QCPTextElement : public QCPLayoutElement
 {
@@ -4941,7 +4952,7 @@ public:
   QCPTextElement(QCustomPlot *parentPlot, const QString &text, double pointSize);
   QCPTextElement(QCustomPlot *parentPlot, const QString &text, const QString &fontFamily, double pointSize);
   QCPTextElement(QCustomPlot *parentPlot, const QString &text, const QFont &font);
-
+  
   // getters:
   QString text() const { return mText; }
   int textFlags() const { return mTextFlags; }
@@ -4951,7 +4962,7 @@ public:
   QColor selectedTextColor() const { return mSelectedTextColor; }
   bool selectable() const { return mSelectable; }
   bool selected() const { return mSelected; }
-
+  
   // setters:
   void setText(const QString &text);
   void setTextFlags(int flags);
@@ -4961,19 +4972,19 @@ public:
   void setSelectedTextColor(const QColor &color);
   Q_SLOT void setSelectable(bool selectable);
   Q_SLOT void setSelected(bool selected);
-
+  
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
   virtual void mousePressEvent(QMouseEvent *event, const QVariant &details) Q_DECL_OVERRIDE;
   virtual void mouseReleaseEvent(QMouseEvent *event, const QPointF &startPos) Q_DECL_OVERRIDE;
   virtual void mouseDoubleClickEvent(QMouseEvent *event, const QVariant &details) Q_DECL_OVERRIDE;
-
+  
 signals:
   void selectionChanged(bool selected);
   void selectableChanged(bool selectable);
   void clicked(QMouseEvent *event);
   void doubleClicked(QMouseEvent *event);
-
+  
 protected:
   // property members:
   QString mText;
@@ -4984,7 +4995,7 @@ protected:
   QColor mSelectedTextColor;
   QRect mTextBoundingRect;
   bool mSelectable, mSelected;
-
+  
   // reimplemented virtual methods:
   virtual void applyDefaultAntialiasingHint(QCPPainter *painter) const Q_DECL_OVERRIDE;
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
@@ -4993,11 +5004,11 @@ protected:
   // events:
   virtual void selectEvent(QMouseEvent *event, bool additive, const QVariant &details, bool *selectionStateChanged) Q_DECL_OVERRIDE;
   virtual void deselectEvent(bool *selectionStateChanged) Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   QFont mainFont() const;
   QColor mainTextColor() const;
-
+  
 private:
   Q_DISABLE_COPY(QCPTextElement)
 };
@@ -5008,7 +5019,7 @@ private:
 
 
 /* including file 'src/layoutelements/layoutelement-colorscale.h', size 5923 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 
 class QCPColorScaleAxisRectPrivate : public QCPAxisRect
@@ -5051,7 +5062,7 @@ class QCP_LIB_DECL QCPColorScale : public QCPLayoutElement
 public:
   explicit QCPColorScale(QCustomPlot *parentPlot);
   virtual ~QCPColorScale();
-
+  
   // getters:
   QCPAxis *axis() const { return mColorAxis.data(); }
   QCPAxis::AxisType type() const { return mType; }
@@ -5062,7 +5073,7 @@ public:
   int barWidth () const { return mBarWidth; }
   bool rangeDrag() const;
   bool rangeZoom() const;
-
+  
   // setters:
   void setType(QCPAxis::AxisType type);
   Q_SLOT void setDataRange(const QCPRange &dataRange);
@@ -5072,14 +5083,14 @@ public:
   void setBarWidth(int width);
   void setRangeDrag(bool enabled);
   void setRangeZoom(bool enabled);
-
+  
   // non-property methods:
   QList<QCPColorMap*> colorMaps() const;
   void rescaleDataRange(bool onlyVisibleMaps);
-
+  
   // reimplemented virtual methods:
   virtual void update(UpdatePhase phase) Q_DECL_OVERRIDE;
-
+  
 signals:
   void dataRangeChanged(const QCPRange &newRange);
   void dataScaleTypeChanged(QCPAxis::ScaleType scaleType);
@@ -5092,11 +5103,11 @@ protected:
   QCPAxis::ScaleType mDataScaleType;
   QCPColorGradient mGradient;
   int mBarWidth;
-
+  
   // non-property members:
   QPointer<QCPColorScaleAxisRectPrivate> mAxisRect;
   QPointer<QCPAxis> mColorAxis;
-
+  
   // reimplemented virtual methods:
   virtual void applyDefaultAntialiasingHint(QCPPainter *painter) const Q_DECL_OVERRIDE;
   // events:
@@ -5104,10 +5115,10 @@ protected:
   virtual void mouseMoveEvent(QMouseEvent *event, const QPointF &startPos) Q_DECL_OVERRIDE;
   virtual void mouseReleaseEvent(QMouseEvent *event, const QPointF &startPos) Q_DECL_OVERRIDE;
   virtual void wheelEvent(QWheelEvent *event) Q_DECL_OVERRIDE;
-
+  
 private:
   Q_DISABLE_COPY(QCPColorScale)
-
+  
   friend class QCPColorScaleAxisRectPrivate;
 };
 
@@ -5116,35 +5127,35 @@ private:
 
 
 /* including file 'src/plottables/plottable-graph.h', size 9294              */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPGraphData
 {
 public:
   QCPGraphData();
   QCPGraphData(double key, double value);
-
+  
   inline double sortKey() const { return key; }
   inline static QCPGraphData fromSortKey(double sortKey) { return QCPGraphData(sortKey, 0); }
   inline static bool sortKeyIsMainKey() { return true; }
-
+  
   inline double mainKey() const { return key; }
   inline double mainValue() const { return value; }
-
+  
   inline QCPRange valueRange() const { return QCPRange(value, value); }
-
+  
   double key, value;
 };
 Q_DECLARE_TYPEINFO(QCPGraphData, Q_PRIMITIVE_TYPE);
 
 
 /*! \typedef QCPGraphDataContainer
-
+  
   Container for storing \ref QCPGraphData points. The data is stored sorted by \a key.
-
+  
   This template instantiation is the container in which QCPGraph holds its data. For details about
   the generic container, see the documentation of the class template \ref QCPDataContainer.
-
+  
   \see QCPGraphData, QCPGraph::setData
 */
 typedef QCPDataContainer<QCPGraphData> QCPGraphDataContainer;
@@ -5174,10 +5185,10 @@ public:
                    ,lsImpulse    ///< each data point is represented by a line parallel to the value axis, which reaches from the data point to the zero-value-line
                  };
   Q_ENUMS(LineStyle)
-
+  
   explicit QCPGraph(QCPAxis *keyAxis, QCPAxis *valueAxis);
   virtual ~QCPGraph();
-
+  
   // getters:
   QSharedPointer<QCPGraphDataContainer> data() const { return mDataContainer; }
   LineStyle lineStyle() const { return mLineStyle; }
@@ -5185,7 +5196,7 @@ public:
   int scatterSkip() const { return mScatterSkip; }
   QCPGraph *channelFillGraph() const { return mChannelFillGraph.data(); }
   bool adaptiveSampling() const { return mAdaptiveSampling; }
-
+  
   // setters:
   void setData(QSharedPointer<QCPGraphDataContainer> data);
   void setData(const QVector<double> &keys, const QVector<double> &values, bool alreadySorted=false);
@@ -5194,16 +5205,16 @@ public:
   void setScatterSkip(int skip);
   void setChannelFillGraph(QCPGraph *targetGraph);
   void setAdaptiveSampling(bool enabled);
-
+  
   // non-property methods:
   void addData(const QVector<double> &keys, const QVector<double> &values, bool alreadySorted=false);
   void addData(double key, double value);
-
+  
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
   virtual QCPRange getKeyRange(bool &foundRange, QCP::SignDomain inSignDomain=QCP::sdBoth) const Q_DECL_OVERRIDE;
   virtual QCPRange getValueRange(bool &foundRange, QCP::SignDomain inSignDomain=QCP::sdBoth, const QCPRange &inKeyRange=QCPRange()) const Q_DECL_OVERRIDE;
-
+  
 protected:
   // property members:
   LineStyle mLineStyle;
@@ -5211,20 +5222,20 @@ protected:
   int mScatterSkip;
   QPointer<QCPGraph> mChannelFillGraph;
   bool mAdaptiveSampling;
-
+  
   // reimplemented virtual methods:
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
   virtual void drawLegendIcon(QCPPainter *painter, const QRectF &rect) const Q_DECL_OVERRIDE;
-
+  
   // introduced virtual methods:
   virtual void drawFill(QCPPainter *painter, QVector<QPointF> *lines) const;
   virtual void drawScatterPlot(QCPPainter *painter, const QVector<QPointF> &scatters, const QCPScatterStyle &style) const;
   virtual void drawLinePlot(QCPPainter *painter, const QVector<QPointF> &lines) const;
   virtual void drawImpulsePlot(QCPPainter *painter, const QVector<QPointF> &lines) const;
-
+  
   virtual void getOptimizedLineData(QVector<QCPGraphData> *lineData, const QCPGraphDataContainer::const_iterator &begin, const QCPGraphDataContainer::const_iterator &end) const;
   virtual void getOptimizedScatterData(QVector<QCPGraphData> *scatterData, QCPGraphDataContainer::const_iterator begin, QCPGraphDataContainer::const_iterator end) const;
-
+  
   // non-virtual methods:
   void getVisibleDataBounds(QCPGraphDataContainer::const_iterator &begin, QCPGraphDataContainer::const_iterator &end, const QCPDataRange &rangeRestriction) const;
   void getLines(QVector<QPointF> *lines, const QCPDataRange &dataRange) const;
@@ -5245,7 +5256,7 @@ protected:
   int findIndexBelowY(const QVector<QPointF> *data, double y) const;
   int findIndexAboveY(const QVector<QPointF> *data, double y) const;
   double pointDistance(const QPointF &pixelPoint, QCPGraphDataContainer::const_iterator &closestData) const;
-
+  
   friend class QCustomPlot;
   friend class QCPLegend;
 };
@@ -5255,36 +5266,36 @@ Q_DECLARE_METATYPE(QCPGraph::LineStyle)
 
 
 /* including file 'src/plottables/plottable-curve.h', size 7409              */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPCurveData
 {
 public:
   QCPCurveData();
   QCPCurveData(double t, double key, double value);
-
+  
   inline double sortKey() const { return t; }
   inline static QCPCurveData fromSortKey(double sortKey) { return QCPCurveData(sortKey, 0, 0); }
   inline static bool sortKeyIsMainKey() { return false; }
-
+  
   inline double mainKey() const { return key; }
   inline double mainValue() const { return value; }
-
+  
   inline QCPRange valueRange() const { return QCPRange(value, value); }
-
+  
   double t, key, value;
 };
 Q_DECLARE_TYPEINFO(QCPCurveData, Q_PRIMITIVE_TYPE);
 
 
 /*! \typedef QCPCurveDataContainer
-
+  
   Container for storing \ref QCPCurveData points. The data is stored sorted by \a t, so the \a
   sortKey() (returning \a t) is different from \a mainKey() (returning \a key).
-
+  
   This template instantiation is the container in which QCPCurve holds its data. For details about
   the generic container, see the documentation of the class template \ref QCPDataContainer.
-
+  
   \see QCPCurveData, QCPCurve::setData
 */
 typedef QCPDataContainer<QCPCurveData> QCPCurveDataContainer;
@@ -5307,16 +5318,16 @@ public:
                    ,lsLine ///< Data points are connected with a straight line
                  };
   Q_ENUMS(LineStyle)
-
+  
   explicit QCPCurve(QCPAxis *keyAxis, QCPAxis *valueAxis);
   virtual ~QCPCurve();
-
+  
   // getters:
   QSharedPointer<QCPCurveDataContainer> data() const { return mDataContainer; }
   QCPScatterStyle scatterStyle() const { return mScatterStyle; }
   int scatterSkip() const { return mScatterSkip; }
   LineStyle lineStyle() const { return mLineStyle; }
-
+  
   // setters:
   void setData(QSharedPointer<QCPCurveDataContainer> data);
   void setData(const QVector<double> &t, const QVector<double> &keys, const QVector<double> &values, bool alreadySorted=false);
@@ -5324,32 +5335,32 @@ public:
   void setScatterStyle(const QCPScatterStyle &style);
   void setScatterSkip(int skip);
   void setLineStyle(LineStyle style);
-
+  
   // non-property methods:
   void addData(const QVector<double> &t, const QVector<double> &keys, const QVector<double> &values, bool alreadySorted=false);
   void addData(const QVector<double> &keys, const QVector<double> &values);
   void addData(double t, double key, double value);
   void addData(double key, double value);
-
+  
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
   virtual QCPRange getKeyRange(bool &foundRange, QCP::SignDomain inSignDomain=QCP::sdBoth) const Q_DECL_OVERRIDE;
   virtual QCPRange getValueRange(bool &foundRange, QCP::SignDomain inSignDomain=QCP::sdBoth, const QCPRange &inKeyRange=QCPRange()) const Q_DECL_OVERRIDE;
-
+  
 protected:
   // property members:
   QCPScatterStyle mScatterStyle;
   int mScatterSkip;
   LineStyle mLineStyle;
-
+  
   // reimplemented virtual methods:
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
   virtual void drawLegendIcon(QCPPainter *painter, const QRectF &rect) const Q_DECL_OVERRIDE;
-
+  
   // introduced virtual methods:
   virtual void drawCurveLine(QCPPainter *painter, const QVector<QPointF> &lines) const;
   virtual void drawScatterPlot(QCPPainter *painter, const QVector<QPointF> &points, const QCPScatterStyle &style) const;
-
+  
   // non-virtual methods:
   void getCurveLines(QVector<QPointF> *lines, const QCPDataRange &dataRange, double penWidth) const;
   void getScatters(QVector<QPointF> *scatters, const QCPDataRange &dataRange, double scatterWidth) const;
@@ -5360,7 +5371,7 @@ protected:
   bool getTraverse(double prevKey, double prevValue, double key, double value, double keyMin, double valueMax, double keyMax, double valueMin, QPointF &crossA, QPointF &crossB) const;
   void getTraverseCornerPoints(int prevRegion, int currentRegion, double keyMin, double valueMax, double keyMax, double valueMin, QVector<QPointF> &beforeTraverse, QVector<QPointF> &afterTraverse) const;
   double pointDistance(const QPointF &pixelPoint, QCPCurveDataContainer::const_iterator &closestData) const;
-
+  
   friend class QCustomPlot;
   friend class QCPLegend;
 };
@@ -5369,8 +5380,8 @@ Q_DECLARE_METATYPE(QCPCurve::LineStyle)
 /* end of 'src/plottables/plottable-curve.h' */
 
 
-/* including file 'src/plottables/plottable-bars.h', size 8924               */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* including file 'src/plottables/plottable-bars.h', size 8933               */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPBarsGroup : public QObject
 {
@@ -5383,7 +5394,7 @@ public:
   /*!
     Defines the ways the spacing between bars in the group can be specified. Thus it defines what
     the number passed to \ref setSpacing actually means.
-
+    
     \see setSpacingType, setSpacing
   */
   enum SpacingType { stAbsolute       ///< Bar spacing is in absolute pixels
@@ -5391,18 +5402,18 @@ public:
                      ,stPlotCoords    ///< Bar spacing is in key coordinates and thus scales with the key axis range
                    };
   Q_ENUMS(SpacingType)
-
-  QCPBarsGroup(QCustomPlot *parentPlot);
+  
+  explicit QCPBarsGroup(QCustomPlot *parentPlot);
   virtual ~QCPBarsGroup();
-
+  
   // getters:
   SpacingType spacingType() const { return mSpacingType; }
   double spacing() const { return mSpacing; }
-
+  
   // setters:
   void setSpacingType(SpacingType spacingType);
   void setSpacing(double spacing);
-
+  
   // non-virtual methods:
   QList<QCPBars*> bars() const { return mBars; }
   QCPBars* bars(int index) const;
@@ -5413,25 +5424,25 @@ public:
   void append(QCPBars *bars);
   void insert(int i, QCPBars *bars);
   void remove(QCPBars *bars);
-
+  
 protected:
   // non-property members:
   QCustomPlot *mParentPlot;
   SpacingType mSpacingType;
   double mSpacing;
   QList<QCPBars*> mBars;
-
+  
   // non-virtual methods:
   void registerBars(QCPBars *bars);
   void unregisterBars(QCPBars *bars);
-
+  
   // virtual methods:
   double keyPixelOffset(const QCPBars *bars, double keyCoord);
   double getPixelSpacing(const QCPBars *bars, double keyCoord);
-
+  
 private:
   Q_DISABLE_COPY(QCPBarsGroup)
-
+  
   friend class QCPBars;
 };
 Q_DECLARE_METATYPE(QCPBarsGroup::SpacingType)
@@ -5442,28 +5453,28 @@ class QCP_LIB_DECL QCPBarsData
 public:
   QCPBarsData();
   QCPBarsData(double key, double value);
-
+  
   inline double sortKey() const { return key; }
   inline static QCPBarsData fromSortKey(double sortKey) { return QCPBarsData(sortKey, 0); }
-  inline static bool sortKeyIsMainKey() { return true; }
-
+  inline static bool sortKeyIsMainKey() { return true; } 
+  
   inline double mainKey() const { return key; }
   inline double mainValue() const { return value; }
-
+  
   inline QCPRange valueRange() const { return QCPRange(value, value); } // note that bar base value isn't held in each QCPBarsData and thus can't/shouldn't be returned here
-
+  
   double key, value;
 };
 Q_DECLARE_TYPEINFO(QCPBarsData, Q_PRIMITIVE_TYPE);
 
 
 /*! \typedef QCPBarsDataContainer
-
+  
   Container for storing \ref QCPBarsData points. The data is stored sorted by \a key.
-
+  
   This template instantiation is the container in which QCPBars holds its data. For details about
   the generic container, see the documentation of the class template \ref QCPDataContainer.
-
+  
   \see QCPBarsData, QCPBars::setData
 */
 typedef QCPDataContainer<QCPBarsData> QCPBarsDataContainer;
@@ -5484,7 +5495,7 @@ public:
   /*!
     Defines the ways the width of the bar can be specified. Thus it defines what the number passed
     to \ref setWidth actually means.
-
+    
     \see setWidthType, setWidth
   */
   enum WidthType { wtAbsolute       ///< Bar width is in absolute pixels
@@ -5492,10 +5503,10 @@ public:
                    ,wtPlotCoords    ///< Bar width is in key coordinates and thus scales with the key axis range
                  };
   Q_ENUMS(WidthType)
-
+  
   explicit QCPBars(QCPAxis *keyAxis, QCPAxis *valueAxis);
   virtual ~QCPBars();
-
+  
   // getters:
   double width() const { return mWidth; }
   WidthType widthType() const { return mWidthType; }
@@ -5505,7 +5516,7 @@ public:
   QCPBars *barBelow() const { return mBarBelow.data(); }
   QCPBars *barAbove() const { return mBarAbove.data(); }
   QSharedPointer<QCPBarsDataContainer> data() const { return mDataContainer; }
-
+  
   // setters:
   void setData(QSharedPointer<QCPBarsDataContainer> data);
   void setData(const QVector<double> &keys, const QVector<double> &values, bool alreadySorted=false);
@@ -5514,20 +5525,20 @@ public:
   void setBarsGroup(QCPBarsGroup *barsGroup);
   void setBaseValue(double baseValue);
   void setStackingGap(double pixels);
-
+  
   // non-property methods:
   void addData(const QVector<double> &keys, const QVector<double> &values, bool alreadySorted=false);
   void addData(double key, double value);
   void moveBelow(QCPBars *bars);
   void moveAbove(QCPBars *bars);
-
+  
   // reimplemented virtual methods:
   virtual QCPDataSelection selectTestRect(const QRectF &rect, bool onlySelectable) const Q_DECL_OVERRIDE;
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
   virtual QCPRange getKeyRange(bool &foundRange, QCP::SignDomain inSignDomain=QCP::sdBoth) const Q_DECL_OVERRIDE;
   virtual QCPRange getValueRange(bool &foundRange, QCP::SignDomain inSignDomain=QCP::sdBoth, const QCPRange &inKeyRange=QCPRange()) const Q_DECL_OVERRIDE;
   virtual QPointF dataPixelPosition(int index) const Q_DECL_OVERRIDE;
-
+  
 protected:
   // property members:
   double mWidth;
@@ -5536,18 +5547,18 @@ protected:
   double mBaseValue;
   double mStackingGap;
   QPointer<QCPBars> mBarBelow, mBarAbove;
-
+  
   // reimplemented virtual methods:
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
   virtual void drawLegendIcon(QCPPainter *painter, const QRectF &rect) const Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   void getVisibleDataBounds(QCPBarsDataContainer::const_iterator &begin, QCPBarsDataContainer::const_iterator &end) const;
   QRectF getBarRect(double key, double value) const;
   void getPixelWidth(double key, double &lower, double &upper) const;
   double getStackedBaseValue(double key, bool positive) const;
   static void connectBars(QCPBars* lower, QCPBars* upper);
-
+  
   friend class QCustomPlot;
   friend class QCPLegend;
   friend class QCPBarsGroup;
@@ -5558,21 +5569,21 @@ Q_DECLARE_METATYPE(QCPBars::WidthType)
 
 
 /* including file 'src/plottables/plottable-statisticalbox.h', size 7516     */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPStatisticalBoxData
 {
 public:
   QCPStatisticalBoxData();
   QCPStatisticalBoxData(double key, double minimum, double lowerQuartile, double median, double upperQuartile, double maximum, const QVector<double>& outliers=QVector<double>());
-
+  
   inline double sortKey() const { return key; }
   inline static QCPStatisticalBoxData fromSortKey(double sortKey) { return QCPStatisticalBoxData(sortKey, 0, 0, 0, 0, 0); }
   inline static bool sortKeyIsMainKey() { return true; }
-
+  
   inline double mainKey() const { return key; }
   inline double mainValue() const { return median; }
-
+  
   inline QCPRange valueRange() const
   {
     QCPRange result(minimum, maximum);
@@ -5580,7 +5591,7 @@ public:
       result.expand(*it);
     return result;
   }
-
+  
   double key, minimum, lowerQuartile, median, upperQuartile, maximum;
   QVector<double> outliers;
 };
@@ -5588,13 +5599,13 @@ Q_DECLARE_TYPEINFO(QCPStatisticalBoxData, Q_MOVABLE_TYPE);
 
 
 /*! \typedef QCPStatisticalBoxDataContainer
-
+  
   Container for storing \ref QCPStatisticalBoxData points. The data is stored sorted by \a key.
-
+  
   This template instantiation is the container in which QCPStatisticalBox holds its data. For
   details about the generic container, see the documentation of the class template \ref
   QCPDataContainer.
-
+  
   \see QCPStatisticalBoxData, QCPStatisticalBox::setData
 */
 typedef QCPDataContainer<QCPStatisticalBoxData> QCPStatisticalBoxDataContainer;
@@ -5613,7 +5624,7 @@ class QCP_LIB_DECL QCPStatisticalBox : public QCPAbstractPlottable1D<QCPStatisti
   /// \endcond
 public:
   explicit QCPStatisticalBox(QCPAxis *keyAxis, QCPAxis *valueAxis);
-
+  
   // getters:
   QSharedPointer<QCPStatisticalBoxDataContainer> data() const { return mDataContainer; }
   double width() const { return mWidth; }
@@ -5634,17 +5645,17 @@ public:
   void setWhiskerAntialiased(bool enabled);
   void setMedianPen(const QPen &pen);
   void setOutlierStyle(const QCPScatterStyle &style);
-
+  
   // non-property methods:
   void addData(const QVector<double> &keys, const QVector<double> &minimum, const QVector<double> &lowerQuartile, const QVector<double> &median, const QVector<double> &upperQuartile, const QVector<double> &maximum, bool alreadySorted=false);
   void addData(double key, double minimum, double lowerQuartile, double median, double upperQuartile, double maximum, const QVector<double> &outliers=QVector<double>());
-
+  
   // reimplemented virtual methods:
   virtual QCPDataSelection selectTestRect(const QRectF &rect, bool onlySelectable) const Q_DECL_OVERRIDE;
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
   virtual QCPRange getKeyRange(bool &foundRange, QCP::SignDomain inSignDomain=QCP::sdBoth) const Q_DECL_OVERRIDE;
   virtual QCPRange getValueRange(bool &foundRange, QCP::SignDomain inSignDomain=QCP::sdBoth, const QCPRange &inKeyRange=QCPRange()) const Q_DECL_OVERRIDE;
-
+  
 protected:
   // property members:
   double mWidth;
@@ -5653,20 +5664,20 @@ protected:
   bool mWhiskerAntialiased;
   QPen mMedianPen;
   QCPScatterStyle mOutlierStyle;
-
+  
   // reimplemented virtual methods:
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
   virtual void drawLegendIcon(QCPPainter *painter, const QRectF &rect) const Q_DECL_OVERRIDE;
-
+  
   // introduced virtual methods:
   virtual void drawStatisticalBox(QCPPainter *painter, QCPStatisticalBoxDataContainer::const_iterator it, const QCPScatterStyle &outlierStyle) const;
-
+  
   // non-virtual methods:
   void getVisibleDataBounds(QCPStatisticalBoxDataContainer::const_iterator &begin, QCPStatisticalBoxDataContainer::const_iterator &end) const;
   QRectF getQuartileBox(QCPStatisticalBoxDataContainer::const_iterator it) const;
   QVector<QLineF> getWhiskerBackboneLines(QCPStatisticalBoxDataContainer::const_iterator it) const;
   QVector<QLineF> getWhiskerBarLines(QCPStatisticalBoxDataContainer::const_iterator it) const;
-
+  
   friend class QCustomPlot;
   friend class QCPLegend;
 };
@@ -5675,7 +5686,7 @@ protected:
 
 
 /* including file 'src/plottables/plottable-colormap.h', size 7070           */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPColorMapData
 {
@@ -5684,7 +5695,7 @@ public:
   ~QCPColorMapData();
   QCPColorMapData(const QCPColorMapData &other);
   QCPColorMapData &operator=(const QCPColorMapData &other);
-
+  
   // getters:
   int keySize() const { return mKeySize; }
   int valueSize() const { return mValueSize; }
@@ -5694,7 +5705,7 @@ public:
   double data(double key, double value);
   double cell(int keyIndex, int valueIndex);
   unsigned char alpha(int keyIndex, int valueIndex);
-
+  
   // setters:
   void setSize(int keySize, int valueSize);
   void setKeySize(int keySize);
@@ -5705,7 +5716,7 @@ public:
   void setData(double key, double value, double z);
   void setCell(int keyIndex, int valueIndex, double z);
   void setAlpha(int keyIndex, int valueIndex, unsigned char alpha);
-
+  
   // non-property methods:
   void recalculateDataBounds();
   void clear();
@@ -5715,21 +5726,21 @@ public:
   bool isEmpty() const { return mIsEmpty; }
   void coordToCell(double key, double value, int *keyIndex, int *valueIndex) const;
   void cellToCoord(int keyIndex, int valueIndex, double *key, double *value) const;
-
+  
 protected:
   // property members:
   int mKeySize, mValueSize;
   QCPRange mKeyRange, mValueRange;
   bool mIsEmpty;
-
+  
   // non-property members:
   double *mData;
   unsigned char *mAlpha;
   QCPRange mDataBounds;
   bool mDataModified;
-
+  
   bool createAlpha(bool initializeOpaque=true);
-
+  
   friend class QCPColorMap;
 };
 
@@ -5748,7 +5759,7 @@ class QCP_LIB_DECL QCPColorMap : public QCPAbstractPlottable
 public:
   explicit QCPColorMap(QCPAxis *keyAxis, QCPAxis *valueAxis);
   virtual ~QCPColorMap();
-
+  
   // getters:
   QCPColorMapData *data() const { return mMapData; }
   QCPRange dataRange() const { return mDataRange; }
@@ -5757,7 +5768,7 @@ public:
   bool tightBoundary() const { return mTightBoundary; }
   QCPColorGradient gradient() const { return mGradient; }
   QCPColorScale *colorScale() const { return mColorScale.data(); }
-
+  
   // setters:
   void setData(QCPColorMapData *data, bool copy=false);
   Q_SLOT void setDataRange(const QCPRange &dataRange);
@@ -5766,21 +5777,21 @@ public:
   void setInterpolate(bool enabled);
   void setTightBoundary(bool enabled);
   void setColorScale(QCPColorScale *colorScale);
-
+  
   // non-property methods:
   void rescaleDataRange(bool recalculateDataBounds=false);
   Q_SLOT void updateLegendIcon(Qt::TransformationMode transformMode=Qt::SmoothTransformation, const QSize &thumbSize=QSize(32, 18));
-
+  
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
   virtual QCPRange getKeyRange(bool &foundRange, QCP::SignDomain inSignDomain=QCP::sdBoth) const Q_DECL_OVERRIDE;
   virtual QCPRange getValueRange(bool &foundRange, QCP::SignDomain inSignDomain=QCP::sdBoth, const QCPRange &inKeyRange=QCPRange()) const Q_DECL_OVERRIDE;
-
+  
 signals:
   void dataRangeChanged(const QCPRange &newRange);
   void dataScaleTypeChanged(QCPAxis::ScaleType scaleType);
   void gradientChanged(const QCPColorGradient &newGradient);
-
+  
 protected:
   // property members:
   QCPRange mDataRange;
@@ -5790,19 +5801,19 @@ protected:
   bool mInterpolate;
   bool mTightBoundary;
   QPointer<QCPColorScale> mColorScale;
-
+  
   // non-property members:
   QImage mMapImage, mUndersampledMapImage;
   QPixmap mLegendIcon;
   bool mMapImageInvalidated;
-
+  
   // introduced virtual methods:
   virtual void updateMapImage();
-
+  
   // reimplemented virtual methods:
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
   virtual void drawLegendIcon(QCPPainter *painter, const QRectF &rect) const Q_DECL_OVERRIDE;
-
+  
   friend class QCustomPlot;
   friend class QCPLegend;
 };
@@ -5811,35 +5822,35 @@ protected:
 
 
 /* including file 'src/plottables/plottable-financial.h', size 8622          */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPFinancialData
 {
 public:
   QCPFinancialData();
   QCPFinancialData(double key, double open, double high, double low, double close);
-
+  
   inline double sortKey() const { return key; }
   inline static QCPFinancialData fromSortKey(double sortKey) { return QCPFinancialData(sortKey, 0, 0, 0, 0); }
-  inline static bool sortKeyIsMainKey() { return true; }
-
+  inline static bool sortKeyIsMainKey() { return true; } 
+  
   inline double mainKey() const { return key; }
   inline double mainValue() const { return open; }
-
+  
   inline QCPRange valueRange() const { return QCPRange(low, high); } // open and close must lie between low and high, so we don't need to check them
-
+  
   double key, open, high, low, close;
 };
 Q_DECLARE_TYPEINFO(QCPFinancialData, Q_PRIMITIVE_TYPE);
 
 
 /*! \typedef QCPFinancialDataContainer
-
+  
   Container for storing \ref QCPFinancialData points. The data is stored sorted by \a key.
-
+  
   This template instantiation is the container in which QCPFinancial holds its data. For details
   about the generic container, see the documentation of the class template \ref QCPDataContainer.
-
+  
   \see QCPFinancialData, QCPFinancial::setData
 */
 typedef QCPDataContainer<QCPFinancialData> QCPFinancialDataContainer;
@@ -5869,20 +5880,20 @@ public:
                    ,wtPlotCoords    ///< width is in key coordinates and thus scales with the key axis range
                  };
   Q_ENUMS(WidthType)
-
+  
   /*!
     Defines the possible representations of OHLC data in the plot.
-
+    
     \see setChartStyle
   */
   enum ChartStyle { csOhlc         ///< Open-High-Low-Close bar representation
                    ,csCandlestick  ///< Candlestick representation
                   };
   Q_ENUMS(ChartStyle)
-
+  
   explicit QCPFinancial(QCPAxis *keyAxis, QCPAxis *valueAxis);
   virtual ~QCPFinancial();
-
+  
   // getters:
   QSharedPointer<QCPFinancialDataContainer> data() const { return mDataContainer; }
   ChartStyle chartStyle() const { return mChartStyle; }
@@ -5893,7 +5904,7 @@ public:
   QBrush brushNegative() const { return mBrushNegative; }
   QPen penPositive() const { return mPenPositive; }
   QPen penNegative() const { return mPenNegative; }
-
+  
   // setters:
   void setData(QSharedPointer<QCPFinancialDataContainer> data);
   void setData(const QVector<double> &keys, const QVector<double> &open, const QVector<double> &high, const QVector<double> &low, const QVector<double> &close, bool alreadySorted=false);
@@ -5905,20 +5916,20 @@ public:
   void setBrushNegative(const QBrush &brush);
   void setPenPositive(const QPen &pen);
   void setPenNegative(const QPen &pen);
-
+  
   // non-property methods:
   void addData(const QVector<double> &keys, const QVector<double> &open, const QVector<double> &high, const QVector<double> &low, const QVector<double> &close, bool alreadySorted=false);
   void addData(double key, double open, double high, double low, double close);
-
+  
   // reimplemented virtual methods:
   virtual QCPDataSelection selectTestRect(const QRectF &rect, bool onlySelectable) const Q_DECL_OVERRIDE;
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
   virtual QCPRange getKeyRange(bool &foundRange, QCP::SignDomain inSignDomain=QCP::sdBoth) const Q_DECL_OVERRIDE;
   virtual QCPRange getValueRange(bool &foundRange, QCP::SignDomain inSignDomain=QCP::sdBoth, const QCPRange &inKeyRange=QCPRange()) const Q_DECL_OVERRIDE;
-
+  
   // static methods:
   static QCPFinancialDataContainer timeSeriesToOhlc(const QVector<double> &time, const QVector<double> &value, double timeBinSize, double timeBinOffset = 0);
-
+  
 protected:
   // property members:
   ChartStyle mChartStyle;
@@ -5927,11 +5938,11 @@ protected:
   bool mTwoColored;
   QBrush mBrushPositive, mBrushNegative;
   QPen mPenPositive, mPenNegative;
-
+  
   // reimplemented virtual methods:
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
   virtual void drawLegendIcon(QCPPainter *painter, const QRectF &rect) const Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   void drawOhlcPlot(QCPPainter *painter, const QCPFinancialDataContainer::const_iterator &begin, const QCPFinancialDataContainer::const_iterator &end, bool isSelected);
   void drawCandlestickPlot(QCPPainter *painter, const QCPFinancialDataContainer::const_iterator &begin, const QCPFinancialDataContainer::const_iterator &end, bool isSelected);
@@ -5940,7 +5951,7 @@ protected:
   double candlestickSelectTest(const QPointF &pos, const QCPFinancialDataContainer::const_iterator &begin, const QCPFinancialDataContainer::const_iterator &end, QCPFinancialDataContainer::const_iterator &closestDataPoint) const;
   void getVisibleDataBounds(QCPFinancialDataContainer::const_iterator &begin, QCPFinancialDataContainer::const_iterator &end) const;
   QRectF selectionHitBox(QCPFinancialDataContainer::const_iterator it) const;
-
+  
   friend class QCustomPlot;
   friend class QCPLegend;
 };
@@ -5950,7 +5961,7 @@ Q_DECLARE_METATYPE(QCPFinancial::ChartStyle)
 
 
 /* including file 'src/plottables/plottable-errorbar.h', size 7727           */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPErrorBarsData
 {
@@ -5958,7 +5969,7 @@ public:
   QCPErrorBarsData();
   explicit QCPErrorBarsData(double error);
   QCPErrorBarsData(double errorMinus, double errorPlus);
-
+  
   double errorMinus, errorPlus;
 };
 Q_DECLARE_TYPEINFO(QCPErrorBarsData, Q_PRIMITIVE_TYPE);
@@ -5992,7 +6003,7 @@ class QCP_LIB_DECL QCPErrorBars : public QCPAbstractPlottable, public QCPPlottab
   Q_PROPERTY(double symbolGap READ symbolGap WRITE setSymbolGap)
   /// \endcond
 public:
-
+  
   /*!
     Defines in which orientation the error bars shall appear. If your data needs both error
     dimensions, create two \ref QCPErrorBars with different \ref ErrorType.
@@ -6003,7 +6014,7 @@ public:
                    ,etValueError ///< The errors are for the value dimension (bars appear parallel to the value axis)
   };
   Q_ENUMS(ErrorType)
-
+  
   explicit QCPErrorBars(QCPAxis *keyAxis, QCPAxis *valueAxis);
   virtual ~QCPErrorBars();
   // getters:
@@ -6012,7 +6023,7 @@ public:
   ErrorType errorType() const { return mErrorType; }
   double whiskerWidth() const { return mWhiskerWidth; }
   double symbolGap() const { return mSymbolGap; }
-
+  
   // setters:
   void setData(QSharedPointer<QCPErrorBarsDataContainer> data);
   void setData(const QVector<double> &error);
@@ -6021,13 +6032,13 @@ public:
   void setErrorType(ErrorType type);
   void setWhiskerWidth(double pixels);
   void setSymbolGap(double pixels);
-
+  
   // non-property methods:
   void addData(const QVector<double> &error);
   void addData(const QVector<double> &errorMinus, const QVector<double> &errorPlus);
   void addData(double error);
   void addData(double errorMinus, double errorPlus);
-
+  
   // virtual methods of 1d plottable interface:
   virtual int dataCount() const Q_DECL_OVERRIDE;
   virtual double dataMainKey(int index) const Q_DECL_OVERRIDE;
@@ -6039,11 +6050,11 @@ public:
   virtual QCPDataSelection selectTestRect(const QRectF &rect, bool onlySelectable) const Q_DECL_OVERRIDE;
   virtual int findBegin(double sortKey, bool expandedRange=true) const Q_DECL_OVERRIDE;
   virtual int findEnd(double sortKey, bool expandedRange=true) const Q_DECL_OVERRIDE;
-
+  
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
   virtual QCPPlottableInterface1D *interface1D() Q_DECL_OVERRIDE { return this; }
-
+  
 protected:
   // property members:
   QSharedPointer<QCPErrorBarsDataContainer> mDataContainer;
@@ -6051,13 +6062,13 @@ protected:
   ErrorType mErrorType;
   double mWhiskerWidth;
   double mSymbolGap;
-
+  
   // reimplemented virtual methods:
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
   virtual void drawLegendIcon(QCPPainter *painter, const QRectF &rect) const Q_DECL_OVERRIDE;
   virtual QCPRange getKeyRange(bool &foundRange, QCP::SignDomain inSignDomain=QCP::sdBoth) const Q_DECL_OVERRIDE;
   virtual QCPRange getValueRange(bool &foundRange, QCP::SignDomain inSignDomain=QCP::sdBoth, const QCPRange &inKeyRange=QCPRange()) const Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   void getErrorBarLines(QCPErrorBarsDataContainer::const_iterator it, QVector<QLineF> &backbones, QVector<QLineF> &whiskers) const;
   void getVisibleDataBounds(QCPErrorBarsDataContainer::const_iterator &begin, QCPErrorBarsDataContainer::const_iterator &end, const QCPDataRange &rangeRestriction) const;
@@ -6066,7 +6077,7 @@ protected:
   void getDataSegments(QList<QCPDataRange> &selectedSegments, QList<QCPDataRange> &unselectedSegments) const;
   bool errorBarVisible(int index) const;
   bool rectIntersectsLine(const QRectF &pixelRect, const QLineF &line) const;
-
+  
   friend class QCustomPlot;
   friend class QCPLegend;
 };
@@ -6075,7 +6086,7 @@ protected:
 
 
 /* including file 'src/items/item-straightline.h', size 3117                 */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPItemStraightLine : public QCPAbstractItem
 {
@@ -6087,28 +6098,28 @@ class QCP_LIB_DECL QCPItemStraightLine : public QCPAbstractItem
 public:
   explicit QCPItemStraightLine(QCustomPlot *parentPlot);
   virtual ~QCPItemStraightLine();
-
+  
   // getters:
   QPen pen() const { return mPen; }
   QPen selectedPen() const { return mSelectedPen; }
-
+  
   // setters;
   void setPen(const QPen &pen);
   void setSelectedPen(const QPen &pen);
-
+  
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
-
+  
   QCPItemPosition * const point1;
   QCPItemPosition * const point2;
-
+  
 protected:
   // property members:
   QPen mPen, mSelectedPen;
-
+  
   // reimplemented virtual methods:
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   QLineF getRectClippedStraightLine(const QCPVector2D &point1, const QCPVector2D &vec, const QRect &rect) const;
   QPen mainPen() const;
@@ -6118,7 +6129,7 @@ protected:
 
 
 /* including file 'src/items/item-line.h', size 3407                         */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPItemLine : public QCPAbstractItem
 {
@@ -6132,33 +6143,33 @@ class QCP_LIB_DECL QCPItemLine : public QCPAbstractItem
 public:
   explicit QCPItemLine(QCustomPlot *parentPlot);
   virtual ~QCPItemLine();
-
+  
   // getters:
   QPen pen() const { return mPen; }
   QPen selectedPen() const { return mSelectedPen; }
   QCPLineEnding head() const { return mHead; }
   QCPLineEnding tail() const { return mTail; }
-
+  
   // setters;
   void setPen(const QPen &pen);
   void setSelectedPen(const QPen &pen);
   void setHead(const QCPLineEnding &head);
   void setTail(const QCPLineEnding &tail);
-
+  
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
-
+  
   QCPItemPosition * const start;
   QCPItemPosition * const end;
-
+  
 protected:
   // property members:
   QPen mPen, mSelectedPen;
   QCPLineEnding mHead, mTail;
-
+  
   // reimplemented virtual methods:
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   QLineF getRectClippedLine(const QCPVector2D &start, const QCPVector2D &end, const QRect &rect) const;
   QPen mainPen() const;
@@ -6168,7 +6179,7 @@ protected:
 
 
 /* including file 'src/items/item-curve.h', size 3379                        */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPItemCurve : public QCPAbstractItem
 {
@@ -6182,35 +6193,35 @@ class QCP_LIB_DECL QCPItemCurve : public QCPAbstractItem
 public:
   explicit QCPItemCurve(QCustomPlot *parentPlot);
   virtual ~QCPItemCurve();
-
+  
   // getters:
   QPen pen() const { return mPen; }
   QPen selectedPen() const { return mSelectedPen; }
   QCPLineEnding head() const { return mHead; }
   QCPLineEnding tail() const { return mTail; }
-
+  
   // setters;
   void setPen(const QPen &pen);
   void setSelectedPen(const QPen &pen);
   void setHead(const QCPLineEnding &head);
   void setTail(const QCPLineEnding &tail);
-
+  
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
-
+  
   QCPItemPosition * const start;
   QCPItemPosition * const startDir;
   QCPItemPosition * const endDir;
   QCPItemPosition * const end;
-
+  
 protected:
   // property members:
   QPen mPen, mSelectedPen;
   QCPLineEnding mHead, mTail;
-
+  
   // reimplemented virtual methods:
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   QPen mainPen() const;
 };
@@ -6219,7 +6230,7 @@ protected:
 
 
 /* including file 'src/items/item-rect.h', size 3688                         */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPItemRect : public QCPAbstractItem
 {
@@ -6233,22 +6244,22 @@ class QCP_LIB_DECL QCPItemRect : public QCPAbstractItem
 public:
   explicit QCPItemRect(QCustomPlot *parentPlot);
   virtual ~QCPItemRect();
-
+  
   // getters:
   QPen pen() const { return mPen; }
   QPen selectedPen() const { return mSelectedPen; }
   QBrush brush() const { return mBrush; }
   QBrush selectedBrush() const { return mSelectedBrush; }
-
+  
   // setters;
   void setPen(const QPen &pen);
   void setSelectedPen(const QPen &pen);
   void setBrush(const QBrush &brush);
   void setSelectedBrush(const QBrush &brush);
-
+  
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
-
+  
   QCPItemPosition * const topLeft;
   QCPItemPosition * const bottomRight;
   QCPItemAnchor * const top;
@@ -6257,18 +6268,18 @@ public:
   QCPItemAnchor * const bottom;
   QCPItemAnchor * const bottomLeft;
   QCPItemAnchor * const left;
-
+  
 protected:
   enum AnchorIndex {aiTop, aiTopRight, aiRight, aiBottom, aiBottomLeft, aiLeft};
-
+  
   // property members:
   QPen mPen, mSelectedPen;
   QBrush mBrush, mSelectedBrush;
-
+  
   // reimplemented virtual methods:
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
   virtual QPointF anchorPixelPosition(int anchorId) const Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   QPen mainPen() const;
   QBrush mainBrush() const;
@@ -6278,7 +6289,7 @@ protected:
 
 
 /* including file 'src/items/item-text.h', size 5554                         */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPItemText : public QCPAbstractItem
 {
@@ -6301,7 +6312,7 @@ class QCP_LIB_DECL QCPItemText : public QCPAbstractItem
 public:
   explicit QCPItemText(QCustomPlot *parentPlot);
   virtual ~QCPItemText();
-
+  
   // getters:
   QColor color() const { return mColor; }
   QColor selectedColor() const { return mSelectedColor; }
@@ -6316,7 +6327,7 @@ public:
   Qt::Alignment textAlignment() const { return mTextAlignment; }
   double rotation() const { return mRotation; }
   QMargins padding() const { return mPadding; }
-
+  
   // setters;
   void setColor(const QColor &color);
   void setSelectedColor(const QColor &color);
@@ -6331,10 +6342,10 @@ public:
   void setTextAlignment(Qt::Alignment alignment);
   void setRotation(double degrees);
   void setPadding(const QMargins &padding);
-
+  
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
-
+  
   QCPItemPosition * const position;
   QCPItemAnchor * const topLeft;
   QCPItemAnchor * const top;
@@ -6344,10 +6355,10 @@ public:
   QCPItemAnchor * const bottom;
   QCPItemAnchor * const bottomLeft;
   QCPItemAnchor * const left;
-
+  
 protected:
   enum AnchorIndex {aiTopLeft, aiTop, aiTopRight, aiRight, aiBottomRight, aiBottom, aiBottomLeft, aiLeft};
-
+  
   // property members:
   QColor mColor, mSelectedColor;
   QPen mPen, mSelectedPen;
@@ -6358,11 +6369,11 @@ protected:
   Qt::Alignment mTextAlignment;
   double mRotation;
   QMargins mPadding;
-
+  
   // reimplemented virtual methods:
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
   virtual QPointF anchorPixelPosition(int anchorId) const Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   QPointF getTextDrawPoint(const QPointF &pos, const QRectF &rect, Qt::Alignment positionAlignment) const;
   QFont mainFont() const;
@@ -6375,7 +6386,7 @@ protected:
 
 
 /* including file 'src/items/item-ellipse.h', size 3868                      */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPItemEllipse : public QCPAbstractItem
 {
@@ -6389,22 +6400,22 @@ class QCP_LIB_DECL QCPItemEllipse : public QCPAbstractItem
 public:
   explicit QCPItemEllipse(QCustomPlot *parentPlot);
   virtual ~QCPItemEllipse();
-
+  
   // getters:
   QPen pen() const { return mPen; }
   QPen selectedPen() const { return mSelectedPen; }
   QBrush brush() const { return mBrush; }
   QBrush selectedBrush() const { return mSelectedBrush; }
-
+  
   // setters;
   void setPen(const QPen &pen);
   void setSelectedPen(const QPen &pen);
   void setBrush(const QBrush &brush);
   void setSelectedBrush(const QBrush &brush);
-
+  
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
-
+  
   QCPItemPosition * const topLeft;
   QCPItemPosition * const bottomRight;
   QCPItemAnchor * const topLeftRim;
@@ -6416,18 +6427,18 @@ public:
   QCPItemAnchor * const bottomLeftRim;
   QCPItemAnchor * const left;
   QCPItemAnchor * const center;
-
+  
 protected:
   enum AnchorIndex {aiTopLeftRim, aiTop, aiTopRightRim, aiRight, aiBottomRightRim, aiBottom, aiBottomLeftRim, aiLeft, aiCenter};
-
+  
   // property members:
   QPen mPen, mSelectedPen;
   QBrush mBrush, mSelectedBrush;
-
+  
   // reimplemented virtual methods:
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
   virtual QPointF anchorPixelPosition(int anchorId) const Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   QPen mainPen() const;
   QBrush mainBrush() const;
@@ -6437,7 +6448,7 @@ protected:
 
 
 /* including file 'src/items/item-pixmap.h', size 4373                       */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPItemPixmap : public QCPAbstractItem
 {
@@ -6453,7 +6464,7 @@ class QCP_LIB_DECL QCPItemPixmap : public QCPAbstractItem
 public:
   explicit QCPItemPixmap(QCustomPlot *parentPlot);
   virtual ~QCPItemPixmap();
-
+  
   // getters:
   QPixmap pixmap() const { return mPixmap; }
   bool scaled() const { return mScaled; }
@@ -6461,16 +6472,16 @@ public:
   Qt::TransformationMode transformationMode() const { return mTransformationMode; }
   QPen pen() const { return mPen; }
   QPen selectedPen() const { return mSelectedPen; }
-
+  
   // setters;
   void setPixmap(const QPixmap &pixmap);
   void setScaled(bool scaled, Qt::AspectRatioMode aspectRatioMode=Qt::KeepAspectRatio, Qt::TransformationMode transformationMode=Qt::SmoothTransformation);
   void setPen(const QPen &pen);
   void setSelectedPen(const QPen &pen);
-
+  
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
-
+  
   QCPItemPosition * const topLeft;
   QCPItemPosition * const bottomRight;
   QCPItemAnchor * const top;
@@ -6479,10 +6490,10 @@ public:
   QCPItemAnchor * const bottom;
   QCPItemAnchor * const bottomLeft;
   QCPItemAnchor * const left;
-
+  
 protected:
   enum AnchorIndex {aiTop, aiTopRight, aiRight, aiBottom, aiBottomLeft, aiLeft};
-
+  
   // property members:
   QPixmap mPixmap;
   QPixmap mScaledPixmap;
@@ -6491,11 +6502,11 @@ protected:
   Qt::AspectRatioMode mAspectRatioMode;
   Qt::TransformationMode mTransformationMode;
   QPen mPen, mSelectedPen;
-
+  
   // reimplemented virtual methods:
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
   virtual QPointF anchorPixelPosition(int anchorId) const Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   void updateScaledPixmap(QRect finalRect=QRect(), bool flipHorz=false, bool flipVert=false);
   QRect getFinalRect(bool *flippedHorz=0, bool *flippedVert=0) const;
@@ -6506,7 +6517,7 @@ protected:
 
 
 /* including file 'src/items/item-tracer.h', size 4762                       */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPItemTracer : public QCPAbstractItem
 {
@@ -6525,7 +6536,7 @@ class QCP_LIB_DECL QCPItemTracer : public QCPAbstractItem
 public:
   /*!
     The different visual appearances a tracer item can have. Some styles size may be controlled with \ref setSize.
-
+    
     \see setStyle
   */
   enum TracerStyle { tsNone        ///< The tracer is not visible
@@ -6563,7 +6574,7 @@ public:
 
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   void updatePosition();
 
@@ -6592,7 +6603,7 @@ Q_DECLARE_METATYPE(QCPItemTracer::TracerStyle)
 
 
 /* including file 'src/items/item-bracket.h', size 3969                      */
-/* commit 9868e55d3b412f2f89766bb482fcf299e93a0988 2017-09-04 01:56:22 +0200 */
+/* commit ce344b3f96a62e5f652585e55f1ae7c7883cd45b 2018-06-25 01:03:39 +0200 */
 
 class QCP_LIB_DECL QCPItemBracket : public QCPAbstractItem
 {
@@ -6607,7 +6618,7 @@ public:
   /*!
     Defines the various visual shapes of the bracket item. The appearance can be further modified
     by \ref setLength and \ref setPen.
-
+    
     \see setStyle
   */
   enum BracketStyle { bsSquare  ///< A brace with angled edges
@@ -6619,37 +6630,37 @@ public:
 
   explicit QCPItemBracket(QCustomPlot *parentPlot);
   virtual ~QCPItemBracket();
-
+  
   // getters:
   QPen pen() const { return mPen; }
   QPen selectedPen() const { return mSelectedPen; }
   double length() const { return mLength; }
   BracketStyle style() const { return mStyle; }
-
+  
   // setters;
   void setPen(const QPen &pen);
   void setSelectedPen(const QPen &pen);
   void setLength(double length);
   void setStyle(BracketStyle style);
-
+  
   // reimplemented virtual methods:
   virtual double selectTest(const QPointF &pos, bool onlySelectable, QVariant *details=0) const Q_DECL_OVERRIDE;
-
+  
   QCPItemPosition * const left;
   QCPItemPosition * const right;
   QCPItemAnchor * const center;
-
+  
 protected:
   // property members:
   enum AnchorIndex {aiCenter};
   QPen mPen, mSelectedPen;
   double mLength;
   BracketStyle mStyle;
-
+  
   // reimplemented virtual methods:
   virtual void draw(QCPPainter *painter) Q_DECL_OVERRIDE;
   virtual QPointF anchorPixelPosition(int anchorId) const Q_DECL_OVERRIDE;
-
+  
   // non-virtual methods:
   QPen mainPen() const;
 };

--- a/ThirdParty/GUI/qt-manhattan-style/stylehelper.cpp
+++ b/ThirdParty/GUI/qt-manhattan-style/stylehelper.cpp
@@ -181,9 +181,15 @@ void StyleHelper::verticalGradient(QPainter *painter, const QRect &spanRect, con
     if (StyleHelper::usePixmapCache()) {
         QString key;
         QColor keyColor = baseColor(lightColored);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        key = QString("mh_vertical %d %d %d %d %d").arg(
+            spanRect.width(), spanRect.height(), clipRect.width(),
+            clipRect.height(), keyColor.rgb());
+#else
         key.sprintf("mh_vertical %d %d %d %d %d",
             spanRect.width(), spanRect.height(), clipRect.width(),
             clipRect.height(), keyColor.rgb());
+#endif
 
         QPixmap pixmap;
 #if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
@@ -243,9 +249,15 @@ void StyleHelper::horizontalGradient(QPainter *painter, const QRect &spanRect, c
     if (StyleHelper::usePixmapCache()) {
         QString key;
         QColor keyColor = baseColor(lightColored);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        key.asprintf("mh_horizontal %d %d %d %d %d %d",
+            spanRect.width(), spanRect.height(), clipRect.width(),
+            clipRect.height(), keyColor.rgb(), spanRect.x());
+#else
         key.sprintf("mh_horizontal %d %d %d %d %d %d",
             spanRect.width(), spanRect.height(), clipRect.width(),
             clipRect.height(), keyColor.rgb(), spanRect.x());
+#endif
 
         QPixmap pixmap;
 #if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
@@ -287,10 +299,18 @@ void StyleHelper::drawArrow(QStyle::PrimitiveElement element, QPainter *painter,
     int size = qMin(r.height(), r.width());
     QPixmap pixmap;
     QString pixmapName;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    pixmapName.asprintf("arrow-%s-%d-%d-%d-%lld",
+                       "$qt_ia",
+                       uint(option->state), element,
+                       size, option->palette.cacheKey());
+#else
     pixmapName.sprintf("arrow-%s-%d-%d-%d-%lld",
                        "$qt_ia",
                        uint(option->state), element,
                        size, option->palette.cacheKey());
+#endif
+
 #if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
         if (!QPixmapCache::find(pixmapName, &pixmap)) {
 #else
@@ -335,7 +355,6 @@ void StyleHelper::drawArrow(QStyle::PrimitiveElement element, QPainter *painter,
         imagePainter.translate(sx + bsx, sy + bsy);
 
         if (!(option->state & QStyle::State_Enabled)) {
-            QColor foreGround(150, 150, 150, 150);
             imagePainter.setBrush(option->palette.mid().color());
             imagePainter.setPen(option->palette.mid().color());
         } else {
@@ -363,9 +382,15 @@ void StyleHelper::menuGradient(QPainter *painter, const QRect &spanRect, const Q
 {
     if (StyleHelper::usePixmapCache()) {
         QString key;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        key.asprintf("mh_menu %d %d %d %d %d",
+            spanRect.width(), spanRect.height(), clipRect.width(),
+            clipRect.height(), StyleHelper::baseColor().rgb());
+#else
         key.sprintf("mh_menu %d %d %d %d %d",
             spanRect.width(), spanRect.height(), clipRect.width(),
             clipRect.height(), StyleHelper::baseColor().rgb());
+#endif
 
         QPixmap pixmap;
 #if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)


### PR DESCRIPTION
+ Resolve warnings generated by Qt5.14 "deprecated" macro.
+ Decrease the number of compiler warnings under GCC 9.3.

The total number of warnings has dropped from 160 to 76. The remainings are mostly from SWIG.