### PR TITLE
Appveyor upgrade

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 matrix:
   fast_finish: true
@@ -9,13 +9,13 @@ platform:
 # http://www.appveyor.com/docs/installed-software
 environment:
   APPVEYOR_RDP_PASSWORD: 7bKajQWvq4uhfpvc!
-  BOOSTDIR: C:\Libraries\boost_1_67_0
-  PYTHONDIR: "C:\\Python36-x64"
-  QTDIR: "C:\\Qt\\5.11\\msvc2017_64"
-  PATH: "%QTDIR%\\bin;%PYTHONDIR%;%PYTHONDIR%\\Scripts;%BOOSTDIR%\\lib64-msvc-14.1;%PATH%"
+  BOOSTDIR: C:\Libraries\boost_1_73_0
+  PYTHONDIR: "C:\\Python38-x64"
+  QTDIR: "C:\\Qt\\5.14\\msvc2017_64"
+  PATH: "%QTDIR%\\bin;%PYTHONDIR%;%PYTHONDIR%\\Scripts;%BOOSTDIR%\\lib64-msvc-16.0;%PATH%"
   PYTHONPATH: "%PYTHONDIR%;%PYTHONDIR%\\Lib;%PYTHONDIR%\\Lib\\site-packages;%PYTHONDIR%\\DLLs"
   PYEXE: "%PYTHONDIR%\\python.exe"
-  PYLIB: "%PYTHONDIR%\\libs\\python36.lib"
+  PYLIB: "%PYTHONDIR%\\libs\\python38.lib"
 build:
   parallel: true
 
@@ -28,6 +28,7 @@ install:
 
 before_build:
 - echo "BornAgain before_build" %CD%
+- dir  C:\Python38-x64\libs
 - python -m pip install --upgrade pip
 - python -m pip install numpy
 - mkdir C:\projects\deps
@@ -60,7 +61,7 @@ build_script:
 - mkdir build
 - cd build
 - cmake --version
-- cmake -G "Visual Studio 15 2017 Win64" -DBOOST_ROOT=%BOOSTDIR% -DPython_LIBRARIES=%PYLIB% -DPython_EXECUTABLE=%PYEXE% -DCMAKE_INCLUDE_PATH=C:/projects/deps/include ..
+- cmake -G "Visual Studio 16 2019" -DBOOST_ROOT=%BOOSTDIR% -DPython_LIBRARY=%PYLIB% -DPython_EXECUTABLE=%PYEXE% -DCMAKE_INCLUDE_PATH=C:/projects/deps/include ..
 - cmake --build . --config Release
 
 test_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -80,5 +80,6 @@ test_script:
     }
 
 on_failure:
-- echo "Going RDP"
-- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+- appveyor PushArtifact Testing/Temporary/LastTest.log
+#- echo "Going RDP"
+#- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,7 @@ environment:
   BOOSTDIR: C:\Libraries\boost_1_73_0
   PYTHONDIR: "C:\\Python38-x64"
   QTDIR: "C:\\Qt\\5.14\\msvc2017_64"
-  PATH: "%QTDIR%\\bin;%PYTHONDIR%;%PYTHONDIR%\\Scripts;%BOOSTDIR%\\lib64-msvc-16.0;%PATH%"
+  PATH: "%QTDIR%\\bin;%PYTHONDIR%;%PYTHONDIR%\\Scripts;%BOOSTDIR%\\lib64-msvc-14.2;%PATH%"
   PYTHONPATH: "%PYTHONDIR%;%PYTHONDIR%\\Lib;%PYTHONDIR%\\Lib\\site-packages;%PYTHONDIR%\\DLLs"
   PYEXE: "%PYTHONDIR%\\python.exe"
   PYLIB: "%PYTHONDIR%\\libs\\python38.lib"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,12 +9,12 @@ platform:
 # http://www.appveyor.com/docs/installed-software
 environment:
   BOOSTDIR: C:\Libraries\boost_1_73_0
-  PYTHONDIR: "C:\\Python38-x64"
+  PYTHONDIR: "C:\\Python37-x64"
   QTDIR: "C:\\Qt\\5.14\\msvc2017_64"
   PATH: "%QTDIR%\\bin;%PYTHONDIR%;%PYTHONDIR%\\Scripts;%BOOSTDIR%\\lib64-msvc-14.2;%PATH%"
   PYTHONPATH: "%PYTHONDIR%;%PYTHONDIR%\\Lib;%PYTHONDIR%\\Lib\\site-packages;%PYTHONDIR%\\DLLs"
   PYEXE: "%PYTHONDIR%\\python.exe"
-  PYLIB: "%PYTHONDIR%\\libs\\python38.lib"
+  PYLIB: "%PYTHONDIR%\\libs\\python37.lib"
 build:
   parallel: true
 
@@ -27,7 +27,7 @@ install:
 
 before_build:
 - echo "BornAgain before_build" %CD%
-- dir  C:\Python38-x64\libs
+- dir  C:\Python37-x64\libs
 - python -m pip install --upgrade pip
 - python -m pip install numpy
 - mkdir C:\projects\deps

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,6 @@ platform:
 
 # http://www.appveyor.com/docs/installed-software
 environment:
-  APPVEYOR_RDP_PASSWORD: 7bKajQWvq4uhfpvc!
   BOOSTDIR: C:\Libraries\boost_1_73_0
   PYTHONDIR: "C:\\Python38-x64"
   QTDIR: "C:\\Qt\\5.14\\msvc2017_64"
@@ -81,5 +80,5 @@ test_script:
     }
 
 on_failure:
-- appveyor PushArtifact Testing/Temporary/LastTest.log
-#- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+- echo "Going RDP"
+- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ include(VERSION.cmake)
 
 # declare project-wide user flags, and set default values
 option(BORNAGAIN_PYTHON "Build with python support" ON)
-option(BORNAGAIN_USE_PYTHON3 "Build against python 3.x instead of 2.7" ON)
+option(BORNAGAIN_USE_PYTHON2 "Build against python 2.7" OFF)
 option(BORNAGAIN_GENERATE_BINDINGS "Generate python bindings during build (requires swig)" OFF)
 option(BORNAGAIN_GENERATE_PYTHON_DOCS "Generate python documentation from the doxygen comments" OFF)
 option(BORNAGAIN_GUI "Build a graphical user interface" ON)
@@ -53,9 +53,6 @@ include(GetFilenameComponent) # overwrite CMake command
 include(SearchInstalledSoftware)
 include(CheckCompiler)
 if(ZERO_TOLERANCE)
-    if(BORNAGAIN_USE_PYTHON3)
-        message(FATAL_ERROR "Python3 currently incompatible with ZERO_TOLERANCE")
-    endif()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wfatal-errors")
 endif()
 include(BornAgainConfiguration)

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -221,7 +221,6 @@ if(WIN32)
     endforeach()
 
     set(win_python_lib "${Python_LIBRARY_DIRS}/python${Python_VERSION_MAJOR}${Python_VERSION_MINOR}.lib")
-    message(INFO "XXXXX ${win_python_lib}")
     get_filename_component(UTF_BASE_NAME ${win_python_lib} NAME_WE)
     get_filename_component(UTF_PATH ${Python_EXECUTABLE} PATH)
     message(STATUS "Python dll: ${UTF_PATH}/${UTF_BASE_NAME}.dll")

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -220,7 +220,9 @@ if(WIN32)
             DESTINATION ${destination_lib} COMPONENT Libraries)
     endforeach()
 
-    get_filename_component(UTF_BASE_NAME ${Python_LIBRARIES} NAME_WE)
+    set(win_python_lib "${Python_LIBRARY_DIRS}/python${Python_VERSION_MAJOR}${Python_VERSION_MINOR}.lib")
+    message(INFO "XXXXX ${win_python_lib}")
+    get_filename_component(UTF_BASE_NAME ${win_python_lib} NAME_WE)
     get_filename_component(UTF_PATH ${Python_EXECUTABLE} PATH)
     message(STATUS "Python dll: ${UTF_PATH}/${UTF_BASE_NAME}.dll")
     install(FILES ${UTF_PATH}/${UTF_BASE_NAME}.dll

--- a/cmake/bornagain/modules/BornAgainConfiguration.cmake
+++ b/cmake/bornagain/modules/BornAgainConfiguration.cmake
@@ -139,7 +139,6 @@ if (WIN32)
     # Necessary to provide correct slashes in BABuild.h
     file(TO_CMAKE_PATH ${Python_EXECUTABLE} Python_EXECUTABLE)
     file(TO_CMAKE_PATH ${Python_STDLIB} Python_STDLIB)
-    # file(TO_CMAKE_PATH ${Python_LIBRARIES} Python_LIBRARIES)
     file(TO_CMAKE_PATH ${Python_STDLIB} Python_STDLIB)
     file(TO_CMAKE_PATH ${Python_INCLUDE_DIRS} Python_INCLUDE_DIRS)
     file(TO_CMAKE_PATH ${Python_NumPy_INCLUDE_DIRS} Python_NumPy_INCLUDE_DIRS)

--- a/cmake/bornagain/modules/BornAgainConfiguration.cmake
+++ b/cmake/bornagain/modules/BornAgainConfiguration.cmake
@@ -139,7 +139,7 @@ if (WIN32)
     # Necessary to provide correct slashes in BABuild.h
     file(TO_CMAKE_PATH ${Python_EXECUTABLE} Python_EXECUTABLE)
     file(TO_CMAKE_PATH ${Python_STDLIB} Python_STDLIB)
-    file(TO_CMAKE_PATH ${Python_LIBRARIES} Python_LIBRARIES)
+    # file(TO_CMAKE_PATH ${Python_LIBRARIES} Python_LIBRARIES)
     file(TO_CMAKE_PATH ${Python_STDLIB} Python_STDLIB)
     file(TO_CMAKE_PATH ${Python_INCLUDE_DIRS} Python_INCLUDE_DIRS)
     file(TO_CMAKE_PATH ${Python_NumPy_INCLUDE_DIRS} Python_NumPy_INCLUDE_DIRS)

--- a/cmake/bornagain/modules/SearchInstalledSoftware.cmake
+++ b/cmake/bornagain/modules/SearchInstalledSoftware.cmake
@@ -51,17 +51,13 @@ if (BORNAGAIN_GENERATE_BINDINGS AND BORNAGAIN_GENERATE_PYTHON_DOCS)
     find_package(Doxygen REQUIRED)
 endif()
 
-if (NOT DEFINED Python_ADDITIONAL_VERSIONS)
-    if (BORNAGAIN_USE_PYTHON3)
-        set(Python_ADDITIONAL_VERSIONS 3.7 3.6 3.5 3.4 3.3)
-    else()
-        set(Python_ADDITIONAL_VERSIONS 2.7)
-    endif()
-endif()
-message(STATUS "Requested Python versions ${Python_ADDITIONAL_VERSIONS}")
-
 if(BORNAGAIN_PYTHON OR BORNAGAIN_GUI)
-    find_package (Python COMPONENTS Interpreter Development NumPy)
+
+    if (BORNAGAIN_USE_PYTHON2)
+        find_package (Python 2.7 COMPONENTS Interpreter Development NumPy)
+    else()
+        find_package (Python COMPONENTS Interpreter Development NumPy)
+    endif()
 
     message(STATUS "  Python_VERSION              : ${Python_VERSION}")
     message(STATUS "  Python_INTERPRETER_ID       : ${Python_INTERPRETER_ID}")


### PR DESCRIPTION
+ Switch to MSVC2019, Qt5.14, and new boost-1.67 in Appveyor builds.
+ Attempt to switch to Python 3.8, then falling back to Python 3.7.

While switching to Python 3.8, Appveyor builds (and also local Windows builds) fail during the execution of the PyStandard test family. The reason is failed `import bornagain` because of "failed import of _libBornAgainCore.pyd". The reason is unclear and will be investigated later.