### PR TITLE
Update Python 3.8 dll import and switch AppVeyor to it

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,12 +9,12 @@ platform:
 # http://www.appveyor.com/docs/installed-software
 environment:
   BOOSTDIR: C:\Libraries\boost_1_73_0
-  PYTHONDIR: "C:\\Python37-x64"
+  PYTHONDIR: "C:\\Python38-x64"
   QTDIR: "C:\\Qt\\5.14\\msvc2017_64"
   PATH: "%QTDIR%\\bin;%PYTHONDIR%;%PYTHONDIR%\\Scripts;%BOOSTDIR%\\lib64-msvc-14.2;%PATH%"
   PYTHONPATH: "%PYTHONDIR%;%PYTHONDIR%\\Lib;%PYTHONDIR%\\Lib\\site-packages;%PYTHONDIR%\\DLLs"
   PYEXE: "%PYTHONDIR%\\python.exe"
-  PYLIB: "%PYTHONDIR%\\libs\\python37.lib"
+  PYLIB: "%PYTHONDIR%\\libs\\python38.lib"
 build:
   parallel: true
 
@@ -27,7 +27,7 @@ install:
 
 before_build:
 - echo "BornAgain before_build" %CD%
-- dir  C:\Python37-x64\libs
+- dir  C:\Python38-x64\libs
 - python -m pip install --upgrade pip
 - python -m pip install numpy
 - mkdir C:\projects\deps

--- a/Tests/Functional/Python/PyCore/intensitydata.py
+++ b/Tests/Functional/Python/PyCore/intensitydata.py
@@ -3,7 +3,7 @@
 import numpy, os, sys, unittest
 
 sys.path.append("@CMAKE_LIBRARY_OUTPUT_DIRECTORY@")
-import libBornAgainCore as ba
+import bornagain as ba
 
 
 class IntensityDataTest(unittest.TestCase):

--- a/Tests/Functional/Python/PyCore/intensitydata_io.py
+++ b/Tests/Functional/Python/PyCore/intensitydata_io.py
@@ -3,8 +3,8 @@
 import math, numpy, os, sys, time, unittest
 
 sys.path.append("@CMAKE_LIBRARY_OUTPUT_DIRECTORY@")
-import libBornAgainCore as ba
-from libBornAgainCore import degree, deg2rad, rad2deg
+import bornagain as ba
+from bornagain import degree, deg2rad, rad2deg
 
 def fill_data(data):
     """

--- a/Tests/Functional/Python/PyCore/intensitydata_io_tiff.py
+++ b/Tests/Functional/Python/PyCore/intensitydata_io_tiff.py
@@ -3,7 +3,7 @@
 import math, numpy, os, sys, time, unittest
 
 sys.path.append("@CMAKE_LIBRARY_OUTPUT_DIRECTORY@")
-import libBornAgainCore as ba
+import bornagain as ba
 
 
 def fill_data(data):

--- a/Tests/Functional/Python/PyCore/mesocrystal1.py
+++ b/Tests/Functional/Python/PyCore/mesocrystal1.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 import ctypes, math, numpy, os, sys, time
 
 import utils
-from libBornAgainCore import *
+from bornagain import *
 
 # ----------------------------------------------------------------------------
 # Sample builder to build mixture of cylinders and prisms on top of substrate

--- a/Tests/Functional/Python/PyCore/polmagcylinders1.py
+++ b/Tests/Functional/Python/PyCore/polmagcylinders1.py
@@ -2,8 +2,8 @@
 
 from __future__ import print_function
 import gzip, numpy, os, sys, utils
-import libBornAgainCore as ba
-from libBornAgainCore import nanometer, angstrom, degree
+import bornagain as ba
+from bornagain import nanometer, angstrom, degree
 
 
 # ----------------------------------

--- a/Tests/Functional/Python/PyCore/polmagcylinders2.py
+++ b/Tests/Functional/Python/PyCore/polmagcylinders2.py
@@ -6,7 +6,7 @@ import numpy
 import gzip
 from utils import get_difference
 
-from libBornAgainCore import *
+from bornagain import *
 
 REFERENCE_DIR = "@TEST_REFERENCE_DIR@/Core"
 

--- a/Tests/Functional/Python/PyCore/sliced_composition.py
+++ b/Tests/Functional/Python/PyCore/sliced_composition.py
@@ -7,8 +7,8 @@ from __future__ import print_function
 import os, sys, unittest
 
 import utils
-import libBornAgainCore as ba
-from libBornAgainCore import deg, kvector_t, nm
+import bornagain as ba
+from bornagain import deg, kvector_t, nm
 
 mSubstrate = ba.HomogeneousMaterial("Substrate", 3.212e-6, 3.244e-8)
 mAmbience = ba.HomogeneousMaterial("Air", 0.0, 0.0)

--- a/Tests/Functional/Python/PyCore/sliced_spheres.py
+++ b/Tests/Functional/Python/PyCore/sliced_spheres.py
@@ -7,8 +7,8 @@ from __future__ import print_function
 import os, sys, unittest
 
 import utils
-import libBornAgainCore as ba
-from libBornAgainCore import deg, kvector_t
+import bornagain as ba
+from bornagain import deg, kvector_t
 
 mSubstrate = ba.HomogeneousMaterial("Substrate", 3.212e-6, 3.244e-8)
 mAmbience = ba.HomogeneousMaterial("Air", 0.0, 0.0)

--- a/Tests/Functional/Python/PyCore/transform_BoxComposition.py
+++ b/Tests/Functional/Python/PyCore/transform_BoxComposition.py
@@ -11,7 +11,7 @@ from __future__ import print_function
 import os, sys, unittest
 
 import utils
-from libBornAgainCore import *
+from bornagain import *
 
 layer_thickness = 100.0
 comp_length = 50.0

--- a/Tests/Functional/Python/PyCore/transform_CoreShellBox.py
+++ b/Tests/Functional/Python/PyCore/transform_CoreShellBox.py
@@ -10,7 +10,7 @@ from __future__ import print_function
 import os, sys, unittest
 
 import utils
-from libBornAgainCore import *
+from bornagain import *
 
 layer_thickness = 100.0
 

--- a/Tests/Functional/Python/PyCore/transform_box.py
+++ b/Tests/Functional/Python/PyCore/transform_box.py
@@ -8,8 +8,8 @@ from __future__ import print_function
 import os, sys, unittest
 
 import utils
-import libBornAgainCore as ba
-from libBornAgainCore import deg, kvector_t
+import bornagain as ba
+from bornagain import deg, kvector_t
 
 layer_thickness = 100
 

--- a/Tests/Functional/Python/PyCore/transform_cube.py
+++ b/Tests/Functional/Python/PyCore/transform_cube.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 import os, sys, unittest
 
 import utils
-from libBornAgainCore import *
+from bornagain import *
 
 
 class RotationsCubeTest(unittest.TestCase):

--- a/Tests/Functional/Python/PyCore/utils.py
+++ b/Tests/Functional/Python/PyCore/utils.py
@@ -5,8 +5,8 @@ Collection of utils for testing
 import gzip, numpy, sys, os
 
 sys.path.append("@CMAKE_LIBRARY_OUTPUT_DIRECTORY@")
-import libBornAgainCore as ba
-from libBornAgainCore import deg, angstrom
+import bornagain as ba
+from bornagain import deg, angstrom
 
 REFERENCE_DIR = "@PYCORE_REFERENCE_DIR@"
 

--- a/Wrap/python/__init__.py.in
+++ b/Wrap/python/__init__.py.in
@@ -12,7 +12,7 @@ sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 if sys.version_info >= (3, 8, 0) and sys.platform == 'win32':
     if "PATH" in os.environ:
         for p in os.environ['PATH'].split(';'):
-            if p:
+            if p and os.path.exists(p):
                 os.add_dll_directory(p)
 
 from libBornAgainFit import *

--- a/Wrap/python/__init__.py.in
+++ b/Wrap/python/__init__.py.in
@@ -7,6 +7,14 @@ sys.path.append(os.path.abspath(
 # this line needed to fix python3 import problem
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
+# this is needed to adapt to the changed dll import in Python 3.8 and Windows
+# https://docs.python.org/3/whatsnew/3.8.html#ctypes
+if sys.version_info >= (3, 8, 0) and sys.platform == 'win32':
+    if "PATH" in os.environ:
+        for p in os.environ['PATH'].split(';'):
+            if p:
+                os.add_dll_directory(p)
+
 from libBornAgainFit import *
 from libBornAgainCore import *
 

--- a/Wrap/python/__init__.py.in
+++ b/Wrap/python/__init__.py.in
@@ -7,8 +7,8 @@ sys.path.append(os.path.abspath(
 # this line needed to fix python3 import problem
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
-# this is needed to adapt to the changed dll import in Python 3.8 and Windows
-# https://docs.python.org/3/whatsnew/3.8.html#ctypes
+# this is needed to adapt to the changes in Python 3.8 on Windows regarding dll loading
+# see https://docs.python.org/3/whatsnew/3.8.html#ctypes
 if sys.version_info >= (3, 8, 0) and sys.platform == 'win32':
     if "PATH" in os.environ:
         for p in os.environ['PATH'].split(';'):


### PR DESCRIPTION
* paths in the PATH environment variable are via `add_dll_directory` enabled to load libs
* The import in some tests is switched to the more modern bornagain module
* AppVeyor is switched to Python 3.8