### PR TITLE
Enable GitHub build actions

### DIFF
--- a/.github/workflows/ba-linux.yml
+++ b/.github/workflows/ba-linux.yml
@@ -2,11 +2,12 @@ name: Linux
 
 on:
   push:
-    branches: [ master, develop ]    
+    branches: [ master, develop]    
     paths-ignore: 
       - 'Doc/**'    
   pull_request:
     branches: [ master, develop ]
+    paths-ignore: 
       - 'Doc/**'    
 
 jobs:

--- a/.github/workflows/ba-linux.yml
+++ b/.github/workflows/ba-linux.yml
@@ -1,0 +1,90 @@
+name: Linux
+
+on:
+  push:
+    branches: [ master, develop ]    
+    paths-ignore: 
+      - 'Doc/**'    
+  pull_request:
+    branches: [ master, develop ]
+      - 'Doc/**'    
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      max-parallel: 3
+      matrix:
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+      with: 
+        submodules: true    
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: setup apt dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential\
+          gfortran cmake libgsl-dev libboost-all-dev libfftw3-dev libtiff5-dev \
+          qt5-default libqt5designercomponents5 qttools5-dev libqt5svg5-dev \
+          ccache
+    - name: Install Python packages
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install wheel setuptools
+        python -m pip install numpy matplotlib
+        
+    - name: Prepare ccache timestamp
+      id: ccache_cache_timestamp
+      shell: cmake -P {0}
+      run: |
+        string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+        message("::set-output name=timestamp::${current_date}")
+        
+    - name: ccache cache files for BornAgain
+      uses: actions/cache@v1.1.0
+      with:
+        path: .ccache
+        key: ba-linux-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+        restore-keys: |
+          ba-linux-ccache-
+          
+    - name: Build BornAgain
+      env:
+        CCACHE_DIR: $GITHUB_WORKSPACE/.ccache
+        CCACHE_COMPRESS: "true"
+        CCACHE_COMPRESSLEVEL: "6"
+        CCACHE_MAXSIZE: "400M"
+      run: |
+        cd $GITHUB_WORKSPACE && pwd && ls
+        mkdir build && cd build
+        cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ../
+        make package_source
+        make -j4
+
+    - name: Upload tarball
+      uses: actions/upload-artifact@v2
+      if: success()
+      with:
+         name: BornAgainTar
+         path: ./build/BornAgain-*.tar.gz  
+
+    - name: Testing
+      run: |
+        cd $GITHUB_WORKSPACE/build
+        ccache -s
+        ctest -LE Fullcheck --output-on-failure
+        
+    - name: Upload test logs
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+         name: LastTest.log
+         path: ./build/Testing/Temporary/LastTest.log  

--- a/.github/workflows/ba-macos.yml
+++ b/.github/workflows/ba-macos.yml
@@ -2,11 +2,12 @@ name: MacOS
 
 on:
   push:
-    branches: [ master, develop ]    
+    branches: [ master, develop]    
     paths-ignore: 
       - 'Doc/**'    
   pull_request:
     branches: [ master, develop ]
+    paths-ignore: 
       - 'Doc/**'    
 
 jobs:

--- a/.github/workflows/ba-macos.yml
+++ b/.github/workflows/ba-macos.yml
@@ -1,0 +1,106 @@
+name: MacOS
+
+on:
+  push:
+    branches: [ master, develop ]    
+    paths-ignore: 
+      - 'Doc/**'    
+  pull_request:
+    branches: [ master, develop ]
+      - 'Doc/**'    
+
+jobs:
+  build:
+    runs-on: macos-latest
+    strategy:
+      max-parallel: 3
+      matrix:
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+      with: 
+        submodules: true    
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: setup dependencies
+      run: |
+        brew install cmake fftw gsl boost qt5 libtiff ccache
+        echo "Qt5 is installed to"
+        echo $QTDIR
+    - name: Install Python packages
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install wheel setuptools
+        python -m pip install numpy scipy matplotlib
+        
+    - name: Prepare ccache timestamp
+      id: ccache_cache_timestamp
+      shell: cmake -P {0}
+      run: |
+        string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+        message("::set-output name=timestamp::${current_date}")
+        
+    - name: ccache cache files for BornAgain
+      uses: actions/cache@v1.1.0
+      with:
+        path: .ccache
+        key: ba-macos-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+        restore-keys: |
+          ba-macos-ccache-
+          
+    - name: Build BornAgain
+      env:
+        CCACHE_DIR: $GITHUB_WORKSPACE/.ccache
+        CCACHE_COMPRESS: "true"
+        CCACHE_COMPRESSLEVEL: "6"
+        CCACHE_MAXSIZE: "400M"
+        CXX: clang++
+        USE_CPP: 14
+        CMAKE_CXX_STANDARD: 14
+        PYTHON_VERSION: 3.8
+        LLVM_BC_GENERATOR: /usr/bin/clang++
+        LDFLAGS: "-L/usr/local/opt/qt/lib"
+        CPPFLAGS: "-I/usr/local/opt/qt/include"
+      run: |
+        echo 'export PATH="/usr/local/opt/qt/bin:$PATH"' >> /Users/runner/.bash_profile
+        cd $GITHUB_WORKSPACE
+        mkdir build && cd build
+        cmake -DCMAKE_PREFIX_PATH=/usr/local/opt/qt -DBORNAGAIN_APPLE_BUNDLE=ON \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ../
+        make -j4
+        
+    - name: Testing
+      shell: bash
+      run: |
+        cd $GITHUB_WORKSPACE/build
+        ccache -s
+        ctest -LE Fullcheck --output-on-failure
+        
+    - name: Upload test logs
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+         name: LastTest.log
+         path: ./build/Testing/Temporary/LastTest.log
+         
+    - name: Build package
+      env:
+        QTDIR: /usr/local/opt/qt
+      shell: bash
+      run: |
+        cd $GITHUB_WORKSPACE/build
+        echo $QTDIR
+        cpack -V
+        
+    - name: Upload package
+      uses: actions/upload-artifact@v2
+      if: success()
+      with:
+         name: BornAgainMacInstaller
+         path: ./build/*.dmg

--- a/.github/workflows/ba-windows.yml
+++ b/.github/workflows/ba-windows.yml
@@ -6,11 +6,12 @@ env:
 
 on:
   push:
-    branches: [ master, develop ]    
+    branches: [ master, develop]    
     paths-ignore: 
       - 'Doc/**'    
   pull_request:
     branches: [ master, develop ]
+    paths-ignore: 
       - 'Doc/**'    
 
 jobs:

--- a/.github/workflows/ba-windows.yml
+++ b/.github/workflows/ba-windows.yml
@@ -1,0 +1,157 @@
+name: Windows
+
+env:
+  CCACHE_VERSION: 3.7.7
+  NINJA_VERSION: 1.10.0
+
+on:
+  push:
+    branches: [ master, develop ]    
+    paths-ignore: 
+      - 'Doc/**'    
+  pull_request:
+    branches: [ master, develop ]
+      - 'Doc/**'    
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      max-parallel: 3
+      matrix:
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+      with: 
+        submodules: true    
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+        
+    - name: setup dependencies
+      shell: powershell
+      run: |
+        Get-Date -Format G
+        $Env:Path += ";C:\msys64\usr\bin"
+        cd ${{github.workspace}}
+        mkdir deps
+        Get-Date -Format G
+        wget http://apps.jcns.fz-juelich.de/src/WinLibs/bornagain_deps_20200604.zip -O ${{runner.temp}}\local_x64.zip
+        Get-Date -Format G
+        7z x ${{runner.temp}}\local_x64.zip -odeps
+        Get-Date -Format G
+        dir deps
+        dir deps/local_x64
+        
+    - name: Install Python packages
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install wheel setuptools
+        python -m pip install numpy matplotlib
+        
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: '5.14.2'
+        host: 'windows'
+        target: 'desktop'
+        arch: 'win64_msvc2017_64'
+        dir: '${{ github.workspace }}/qt5/'
+        install-deps: 'true'
+        modules: 'qtcharts qtwebengine'
+        mirror: 'http://mirrors.ocf.berkeley.edu/qt/'
+        cached: 'false'
+
+    - name: Download ccache and Ninja
+      id: ccache
+      shell: cmake -P {0}
+      run: |
+        set(ccache_url "https://github.com/cristianadam/ccache/releases/download/v$ENV{CCACHE_VERSION}/${{ runner.os }}.tar.xz")
+        file(DOWNLOAD "${ccache_url}" ./ccache.tar.xz SHOW_PROGRESS)
+        execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ccache.tar.xz)
+        
+        set(ninja_url "https://github.com/ninja-build/ninja/releases/download/v$ENV{NINJA_VERSION}/ninja-win.zip")
+        file(DOWNLOAD "${ninja_url}" ./ninja.zip SHOW_PROGRESS)
+        execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ninja.zip)
+
+    - name: Download Nsis
+      id: nsis
+      shell: cmake -P {0}
+      run: |
+        set(nsis_url "https://sourceforge.net/projects/nsis/files/NSIS%203/3.04/nsis-3.04.zip")
+        file(DOWNLOAD "${nsis_url}" ./nsis.zip SHOW_PROGRESS)
+        execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./nsis.zip)
+
+    - name: Prepare ccache timestamp
+      id: ccache_cache_timestamp
+      shell: cmake -P {0}
+      run: |
+        string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+        message("::set-output name=timestamp::${current_date}")
+        
+    - name: ccache cache files for BornAgain
+      uses: actions/cache@v1.1.0
+      with:
+        path: .ccache
+        key: ba-windows-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+        restore-keys: |
+          ba-windows-ccache-
+          
+    - name: Build BornAgain
+      shell: cmd
+      env:
+        CCACHE_BASEDIR: $GITHUB_WORKSPACE
+        CCACHE_DIR: $GITHUB_WORKSPACE/.ccache
+        CCACHE_COMPRESS: "true"
+        CCACHE_COMPRESSLEVEL: "6"
+        CCACHE_MAXSIZE: "1000M"
+      run: |
+        call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
+        set OPTLIBS=${{github.workspace}}\deps\local_x64
+        set QTDIR=${{github.workspace}}\qt5\Qt\5.14.2\msvc2017_64
+        set PATH=${{github.workspace}};%OPTLIBS%\lib;%QTDIR%\bin;%PATH%
+        cd ${{github.workspace}}
+        dir
+        mkdir build
+        cd build
+        cmake -G "Visual Studio 16 2019" -G Ninja -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_INCLUDE_PATH=%OPTLIBS%/include -DCMAKE_LIBRARY_PATH=%OPTLIBS%/lib -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" ..
+        ccache -z
+        ccache -p
+        cmake --build . --config Release -j4
+        
+    - name: Testing
+      shell: cmd
+      run: |
+        echo %QTDIR%
+        echo %OPTLIBS%
+        set OPTLIBS=${{github.workspace}}\deps\local_x64
+        set PATH=%OPTLIBS%\lib;%QTDIR%\bin;%PATH%
+        echo %PATH%
+        cd ${{github.workspace}}\build
+        ccache -s
+        ctest -LE Fullcheck --output-on-failure
+
+    - name: Upload test logs
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+         name: LastTest.log
+         path: ./build/Testing/Temporary/LastTest.log  
+
+    - name: Build package
+      if: success()
+      shell: cmd
+      run: |
+        cd ${{github.workspace}}\build
+        set PATH=${{github.workspace}}\nsis-3.04;%PATH%
+        cpack -c Release
+
+    - name: Upload package
+      uses: actions/upload-artifact@v2
+      if: success()
+      with:
+         name: BornAgainWinInstaller
+         path: ./build/BornAgain-*.exe

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 ## BornAgain project at GitHub
 
+[![Linux](https://github.com/scgmlz/BornAgain/workflows/Linux/badge.svg?branch=develop)](https://github.com/scgmlz/BornAgain/actions?query=workflow%3ALinux)
+[![Windows](https://github.com/scgmlz/BornAgain/workflows/Windows/badge.svg?branch=develop)](https://github.com/scgmlz/BornAgain/actions?query=workflow%3AWindows)
+[![Mac OS](https://github.com/scgmlz/BornAgain/workflows/MacOS/badge.svg?branch=develop)](https://github.com/scgmlz/BornAgain/actions?query=workflow%3AMacOS)
+
+
 BornAgain is a software to simulate and fit neutron and x-ray scattering at grazing incidence
 (GISANS and GISAXS), using distorted-wave Born approximation (DWBA).
 
@@ -20,15 +25,3 @@ GNU General Public License v3 or higher (see COPYING)
 ### Citation
 * See file CITATION
 * [![DOI](https://www.zenodo.org/badge/67490882.svg)](https://www.zenodo.org/badge/latestdoi/67490882)
-
-## CI Status
-
-### master:
-
-[![Travis-CI Build Status](https://travis-ci.org/scgmlz/BornAgain.svg?branch=master)](https://travis-ci.org/scgmlz/BornAgain)
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/scgmlz/BornAgain?branch=master&svg=true)](https://ci.appveyor.com/project/gpospelov/bornagain)
-
-### develop:
-
-[![Travis-CI Build Status](https://travis-ci.org/scgmlz/BornAgain.svg?branch=develop)](https://travis-ci.org/scgmlz/BornAgain)
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/scgmlz/BornAgain?branch=develop&svg=true)](https://ci.appveyor.com/project/gpospelov/bornagain)

--- a/cmake/bornagain/scripts/fix_apple_bundle.py
+++ b/cmake/bornagain/scripts/fix_apple_bundle.py
@@ -416,7 +416,7 @@ def fix_apple_bundle():
     print('-'*80)
     # # copy_python_framework()
     # FIXME provide automatic recognition of Qt dependency type (@rpath or hard coded)
-    copy_qt_libraries() # this line should be uncommented for macport based builds
+    # copy_qt_libraries() # this line should be uncommented for macport based builds
     copy_qt_plugins()
     copy_dependencies()
     validate_dependencies()


### PR DESCRIPTION
This finalizes efforts of @mganeva  and @rbeerwerth 

+ Implements GitHub actions for Windows, Mac, and Linux builds.
+ Provides parallel builds.
+ Triggered on push/pull into master and develop branches.
+ Ignores Documentation folder.
+ Support of CMake cache for all 3 platforms (build time 35 min -> 8 min)
+ Upload of functional test logs in the case of failure as build artifacts.
+ Generation and upload of *.dmg and *.exe installers as build artifacts.

Old Travis and Appveyor builds will be disabled after the merge. Configs for Travis and Appveyor I suggest to keep for a while.