### PR TITLE
Unit tests: Remove unnecessary destructors

### DIFF
--- a/Tests/UnitTests/Core/Axes/CVectorTest.cpp
+++ b/Tests/UnitTests/Core/Axes/CVectorTest.cpp
@@ -5,11 +5,7 @@
 
 class CVectorTest : public ::testing::Test
 {
-protected:
-    ~CVectorTest();
 };
-
-CVectorTest::~CVectorTest() = default;
 
 TEST_F(CVectorTest, TrivialOperations)
 {

--- a/Tests/UnitTests/Core/Axes/ConstKBinAxisTest.cpp
+++ b/Tests/UnitTests/Core/Axes/ConstKBinAxisTest.cpp
@@ -24,7 +24,6 @@ protected:
             m_boundaries.push_back(std::asin(start_sin + step * i));
         }
     }
-    ~ConstKBinAxisTest();
 
     size_t m_nbins;
     double m_start;
@@ -33,8 +32,6 @@ protected:
     std::vector<double> m_centers;
     std::vector<double> m_boundaries;
 };
-
-ConstKBinAxisTest::~ConstKBinAxisTest() = default;
 
 //[-5.0, -3.99816897832528, -2.9975609824866662, -1.99786732193833, -0.9987818274427882, 0.0,
 // 0.9987818274427874, 1.9978673219383292, 2.997560982486666, 3.998168978325279, 5.0]

--- a/Tests/UnitTests/Core/Axes/CustomBinAxisTest.cpp
+++ b/Tests/UnitTests/Core/Axes/CustomBinAxisTest.cpp
@@ -8,11 +8,8 @@ class CusomBinAxisTest : public ::testing::Test
 {
 protected:
     CusomBinAxisTest() : m_axis("name", 100, -1.0, 1.0) {}
-    ~CusomBinAxisTest();
     CustomBinAxis m_axis;
 };
-
-CusomBinAxisTest::~CusomBinAxisTest() = default;
 
 TEST_F(CusomBinAxisTest, CheckClone)
 {

--- a/Tests/UnitTests/Core/Axes/DepthProbeConverterTest.cpp
+++ b/Tests/UnitTests/Core/Axes/DepthProbeConverterTest.cpp
@@ -7,11 +7,9 @@
 
 class DepthProbeConverterTest : public ::testing::Test
 {
-public:
-    DepthProbeConverterTest();
-    ~DepthProbeConverterTest();
-
 protected:
+    DepthProbeConverterTest();
+
     void checkMainFunctionality(const DepthProbeConverter& test_object);
     void checkAlphaAxis(AxesUnits units, const DepthProbeConverter& test_object);
     void checkZAxis(AxesUnits units, const DepthProbeConverter& test_object);
@@ -32,8 +30,6 @@ DepthProbeConverterTest::DepthProbeConverterTest()
 {
     m_beam.setCentralK(1.0, 0.0, 0.0); // wavelength = 1.0 nm
 }
-
-DepthProbeConverterTest::~DepthProbeConverterTest() = default;
 
 void DepthProbeConverterTest::checkMainFunctionality(const DepthProbeConverter& test_object)
 {

--- a/Tests/UnitTests/Core/Axes/FixedBinAxisTest.cpp
+++ b/Tests/UnitTests/Core/Axes/FixedBinAxisTest.cpp
@@ -6,11 +6,7 @@
 
 class FixedBinAxisTest : public ::testing::Test
 {
-protected:
-    ~FixedBinAxisTest();
 };
-
-FixedBinAxisTest::~FixedBinAxisTest() = default;
 
 TEST_F(FixedBinAxisTest, IndexedAccessor)
 {

--- a/Tests/UnitTests/Core/Axes/Histogram1DTest.cpp
+++ b/Tests/UnitTests/Core/Axes/Histogram1DTest.cpp
@@ -5,11 +5,7 @@
 
 class Histogram1DTest : public ::testing::Test
 {
-protected:
-    ~Histogram1DTest();
 };
-
-Histogram1DTest::~Histogram1DTest() = default;
 
 TEST_F(Histogram1DTest, FixedBinConstructor)
 {

--- a/Tests/UnitTests/Core/Axes/Histogram2DTest.cpp
+++ b/Tests/UnitTests/Core/Axes/Histogram2DTest.cpp
@@ -7,9 +7,8 @@ class Histogram2DTest : public ::testing::Test
 {
 protected:
     Histogram2DTest();
-    virtual ~Histogram2DTest();
 
-    Histogram2D* hist;
+    Histogram2D hist;
 };
 
 // y
@@ -24,77 +23,70 @@ protected:
 //     -1.0  -0.5        0.5   1.0        2.0  X
 
 Histogram2DTest::Histogram2DTest()
+    : hist{4, {-1.0, -0.5, 0.5, 1.0, 2.0}, 3, {0.0, 1.0, 2.0, 4.0}}
 {
-    std::vector<double> xbin_edges = {-1.0, -0.5, 0.5, 1.0, 2.0};
-    std::vector<double> ybin_edges = {0.0, 1.0, 2.0, 4.0};
-    hist = new Histogram2D(4, xbin_edges, 3, ybin_edges);
-}
-
-Histogram2DTest::~Histogram2DTest()
-{
-    delete hist;
 }
 
 TEST_F(Histogram2DTest, VariableHist)
 {
-    hist->reset();
+    hist.reset();
 
     // basic axes check
-    EXPECT_EQ(size_t(12), hist->getTotalNumberOfBins());
-    EXPECT_EQ(hist->getRank(), size_t(2));
-    EXPECT_EQ(hist->getXaxis().getName(), std::string("x-axis"));
-    EXPECT_EQ(hist->getXaxis().size(), size_t(4));
-    EXPECT_EQ(hist->getXmin(), -1.0);
-    EXPECT_EQ(hist->getXmax(), 2.0);
-    EXPECT_EQ(hist->getYaxis().getName(), std::string("y-axis"));
-    EXPECT_EQ(hist->getYaxis().size(), size_t(3));
-    EXPECT_EQ(hist->getYmin(), 0.0);
-    EXPECT_EQ(hist->getYmax(), 4.0);
+    EXPECT_EQ(size_t(12), hist.getTotalNumberOfBins());
+    EXPECT_EQ(hist.getRank(), size_t(2));
+    EXPECT_EQ(hist.getXaxis().getName(), std::string("x-axis"));
+    EXPECT_EQ(hist.getXaxis().size(), size_t(4));
+    EXPECT_EQ(hist.getXmin(), -1.0);
+    EXPECT_EQ(hist.getXmax(), 2.0);
+    EXPECT_EQ(hist.getYaxis().getName(), std::string("y-axis"));
+    EXPECT_EQ(hist.getYaxis().size(), size_t(3));
+    EXPECT_EQ(hist.getYmin(), 0.0);
+    EXPECT_EQ(hist.getYmax(), 4.0);
 
     // globalbin -> axes indices
-    EXPECT_EQ(hist->getXaxisIndex(0), 0u);
-    EXPECT_EQ(hist->getXaxisIndex(1), 0u);
-    EXPECT_EQ(hist->getXaxisIndex(2), 0u);
-    EXPECT_EQ(hist->getXaxisIndex(3), 1u);
-    EXPECT_EQ(hist->getXaxisIndex(4), 1u);
-    EXPECT_EQ(hist->getXaxisIndex(5), 1u);
-    EXPECT_EQ(hist->getXaxisIndex(9), 3u);
-    EXPECT_EQ(hist->getXaxisIndex(10), 3u);
-    EXPECT_EQ(hist->getXaxisIndex(11), 3u);
+    EXPECT_EQ(hist.getXaxisIndex(0), 0u);
+    EXPECT_EQ(hist.getXaxisIndex(1), 0u);
+    EXPECT_EQ(hist.getXaxisIndex(2), 0u);
+    EXPECT_EQ(hist.getXaxisIndex(3), 1u);
+    EXPECT_EQ(hist.getXaxisIndex(4), 1u);
+    EXPECT_EQ(hist.getXaxisIndex(5), 1u);
+    EXPECT_EQ(hist.getXaxisIndex(9), 3u);
+    EXPECT_EQ(hist.getXaxisIndex(10), 3u);
+    EXPECT_EQ(hist.getXaxisIndex(11), 3u);
 
-    EXPECT_EQ(hist->getYaxisIndex(0), 0u);
-    EXPECT_EQ(hist->getYaxisIndex(1), 1u);
-    EXPECT_EQ(hist->getYaxisIndex(2), 2u);
-    EXPECT_EQ(hist->getYaxisIndex(3), 0u);
-    EXPECT_EQ(hist->getYaxisIndex(4), 1u);
-    EXPECT_EQ(hist->getYaxisIndex(5), 2u);
-    EXPECT_EQ(hist->getYaxisIndex(9), 0u);
-    EXPECT_EQ(hist->getYaxisIndex(10), 1u);
-    EXPECT_EQ(hist->getYaxisIndex(11), 2u);
+    EXPECT_EQ(hist.getYaxisIndex(0), 0u);
+    EXPECT_EQ(hist.getYaxisIndex(1), 1u);
+    EXPECT_EQ(hist.getYaxisIndex(2), 2u);
+    EXPECT_EQ(hist.getYaxisIndex(3), 0u);
+    EXPECT_EQ(hist.getYaxisIndex(4), 1u);
+    EXPECT_EQ(hist.getYaxisIndex(5), 2u);
+    EXPECT_EQ(hist.getYaxisIndex(9), 0u);
+    EXPECT_EQ(hist.getYaxisIndex(10), 1u);
+    EXPECT_EQ(hist.getYaxisIndex(11), 2u);
 
     // axes indices -> global bin
-    EXPECT_EQ(hist->getGlobalBin(0, 0), size_t(0));
-    EXPECT_EQ(hist->getGlobalBin(0, 2), size_t(2));
-    EXPECT_EQ(hist->getGlobalBin(1, 1), size_t(4));
-    EXPECT_EQ(hist->getGlobalBin(3, 2), size_t(11));
+    EXPECT_EQ(hist.getGlobalBin(0, 0), size_t(0));
+    EXPECT_EQ(hist.getGlobalBin(0, 2), size_t(2));
+    EXPECT_EQ(hist.getGlobalBin(1, 1), size_t(4));
+    EXPECT_EQ(hist.getGlobalBin(3, 2), size_t(11));
 
     // bin centers
-    EXPECT_EQ(hist->getXaxisValue(0), -0.75);
-    EXPECT_EQ(hist->getXaxisValue(2), -0.75);
-    EXPECT_EQ(hist->getXaxisValue(4), 0.0);
-    EXPECT_EQ(hist->getXaxisValue(10), 1.5);
-    EXPECT_EQ(hist->getXaxisValue(11), 1.5);
+    EXPECT_EQ(hist.getXaxisValue(0), -0.75);
+    EXPECT_EQ(hist.getXaxisValue(2), -0.75);
+    EXPECT_EQ(hist.getXaxisValue(4), 0.0);
+    EXPECT_EQ(hist.getXaxisValue(10), 1.5);
+    EXPECT_EQ(hist.getXaxisValue(11), 1.5);
 
-    EXPECT_EQ(hist->getYaxisValue(0), 0.5);
-    EXPECT_EQ(hist->getYaxisValue(2), 3.0);
-    EXPECT_EQ(hist->getYaxisValue(4), 1.5);
-    EXPECT_EQ(hist->getYaxisValue(10), 1.5);
-    EXPECT_EQ(hist->getYaxisValue(11), 3.0);
+    EXPECT_EQ(hist.getYaxisValue(0), 0.5);
+    EXPECT_EQ(hist.getYaxisValue(2), 3.0);
+    EXPECT_EQ(hist.getYaxisValue(4), 1.5);
+    EXPECT_EQ(hist.getYaxisValue(10), 1.5);
+    EXPECT_EQ(hist.getYaxisValue(11), 3.0);
 
     // coordinates to global bin
-    EXPECT_EQ(hist->findGlobalBin(-0.75, 0.5), size_t(0));
-    EXPECT_EQ(hist->findGlobalBin(0.0, 1.5), size_t(4));
-    EXPECT_EQ(hist->findGlobalBin(1.5, 3.0), size_t(11));
+    EXPECT_EQ(hist.findGlobalBin(-0.75, 0.5), size_t(0));
+    EXPECT_EQ(hist.findGlobalBin(0.0, 1.5), size_t(4));
+    EXPECT_EQ(hist.findGlobalBin(1.5, 3.0), size_t(11));
 }
 
 // y
@@ -110,7 +102,7 @@ TEST_F(Histogram2DTest, VariableHist)
 
 TEST_F(Histogram2DTest, VariableHistFill)
 {
-    hist->reset();
+    hist.reset();
 
     // values to fill all histogram
     std::vector<double> xvalues = {-0.75, -0.75, -0.75, 0.0, 0.0, 0.0,
@@ -119,21 +111,21 @@ TEST_F(Histogram2DTest, VariableHistFill)
 
     // put in every histogram bin one double value proportional to globalbin (globalbin*10.0)
     for (size_t i = 0; i < xvalues.size(); ++i) {
-        hist->fill(xvalues[i], yvalues[i], i * 10.0);
+        hist.fill(xvalues[i], yvalues[i], i * 10.0);
     }
 
     // check bin content using globalbin
-    for (size_t globalbin = 0; globalbin < hist->getTotalNumberOfBins(); ++globalbin) {
-        EXPECT_EQ(globalbin * 10.0, hist->getBinContent(globalbin));
-        EXPECT_EQ(1.0, hist->getBinNumberOfEntries(globalbin));
+    for (size_t globalbin = 0; globalbin < hist.getTotalNumberOfBins(); ++globalbin) {
+        EXPECT_EQ(globalbin * 10.0, hist.getBinContent(globalbin));
+        EXPECT_EQ(1.0, hist.getBinNumberOfEntries(globalbin));
     }
 
     // check bin content using axes bins
-    for (size_t binx = 0; binx < hist->getXaxis().size(); ++binx) {
-        for (size_t biny = 0; biny < hist->getYaxis().size(); ++biny) {
-            size_t globalbin = hist->getGlobalBin(binx, biny);
-            EXPECT_EQ(globalbin * 10.0, hist->getBinContent(binx, biny));
-            EXPECT_EQ(1.0, hist->getBinNumberOfEntries(binx, biny));
+    for (size_t binx = 0; binx < hist.getXaxis().size(); ++binx) {
+        for (size_t biny = 0; biny < hist.getYaxis().size(); ++biny) {
+            size_t globalbin = hist.getGlobalBin(binx, biny);
+            EXPECT_EQ(globalbin * 10.0, hist.getBinContent(binx, biny));
+            EXPECT_EQ(1.0, hist.getBinNumberOfEntries(binx, biny));
         }
     }
 }
@@ -151,7 +143,7 @@ TEST_F(Histogram2DTest, VariableHistFill)
 
 TEST_F(Histogram2DTest, projectionX)
 {
-    hist->reset();
+    hist.reset();
 
     // values to fill all histogram
     std::vector<double> xvalues = {-0.75, -0.75, -0.75, 0.0, 0.0, 0.0,
@@ -161,18 +153,18 @@ TEST_F(Histogram2DTest, projectionX)
 
     // put in every histogram bin the value from 'content' vector
     for (size_t i = 0; i < xvalues.size(); ++i) {
-        hist->fill(xvalues[i], yvalues[i], content[i]);
+        hist.fill(xvalues[i], yvalues[i], content[i]);
     }
 
     // a) create projection along X axis
-    std::unique_ptr<Histogram1D> h1(hist->projectionX());
-    EXPECT_EQ(hist->getXmin(), h1->getXmin());
-    EXPECT_EQ(hist->getXmax(), h1->getXmax());
-    EXPECT_EQ(hist->getNbinsX(), h1->getNbinsX());
-    EXPECT_EQ(hist->getXaxisValue(0), h1->getXaxisValue(0));
-    EXPECT_EQ(hist->getXaxisValue(3), h1->getXaxisValue(1));
-    EXPECT_EQ(hist->getXaxisValue(6), h1->getXaxisValue(2));
-    EXPECT_EQ(hist->getXaxisValue(9), h1->getXaxisValue(3));
+    std::unique_ptr<Histogram1D> h1(hist.projectionX());
+    EXPECT_EQ(hist.getXmin(), h1->getXmin());
+    EXPECT_EQ(hist.getXmax(), h1->getXmax());
+    EXPECT_EQ(hist.getNbinsX(), h1->getNbinsX());
+    EXPECT_EQ(hist.getXaxisValue(0), h1->getXaxisValue(0));
+    EXPECT_EQ(hist.getXaxisValue(3), h1->getXaxisValue(1));
+    EXPECT_EQ(hist.getXaxisValue(6), h1->getXaxisValue(2));
+    EXPECT_EQ(hist.getXaxisValue(9), h1->getXaxisValue(3));
 
     // check content of projections
     for (size_t binx = 0; binx < h1->getNbinsX(); ++binx) {
@@ -182,14 +174,14 @@ TEST_F(Histogram2DTest, projectionX)
     }
 
     // b) create projection along X axis at given y (slice)
-    h1.reset(hist->projectionX(1.01));
-    EXPECT_EQ(hist->getXmin(), h1->getXmin());
-    EXPECT_EQ(hist->getXmax(), h1->getXmax());
-    EXPECT_EQ(hist->getNbinsX(), h1->getNbinsX());
-    EXPECT_EQ(hist->getXaxisValue(0), h1->getXaxisValue(0));
-    EXPECT_EQ(hist->getXaxisValue(3), h1->getXaxisValue(1));
-    EXPECT_EQ(hist->getXaxisValue(6), h1->getXaxisValue(2));
-    EXPECT_EQ(hist->getXaxisValue(9), h1->getXaxisValue(3));
+    h1.reset(hist.projectionX(1.01));
+    EXPECT_EQ(hist.getXmin(), h1->getXmin());
+    EXPECT_EQ(hist.getXmax(), h1->getXmax());
+    EXPECT_EQ(hist.getNbinsX(), h1->getNbinsX());
+    EXPECT_EQ(hist.getXaxisValue(0), h1->getXaxisValue(0));
+    EXPECT_EQ(hist.getXaxisValue(3), h1->getXaxisValue(1));
+    EXPECT_EQ(hist.getXaxisValue(6), h1->getXaxisValue(2));
+    EXPECT_EQ(hist.getXaxisValue(9), h1->getXaxisValue(3));
 
     // check content of projections
     for (size_t binx = 0; binx < h1->getNbinsX(); ++binx) {
@@ -199,14 +191,14 @@ TEST_F(Histogram2DTest, projectionX)
     }
 
     // c) create projection along X for y between [ylow, yup]
-    h1.reset(hist->projectionX(0.99, 1.01));
-    EXPECT_EQ(hist->getXmin(), h1->getXmin());
-    EXPECT_EQ(hist->getXmax(), h1->getXmax());
-    EXPECT_EQ(hist->getNbinsX(), h1->getNbinsX());
-    EXPECT_EQ(hist->getXaxisValue(0), h1->getXaxisValue(0));
-    EXPECT_EQ(hist->getXaxisValue(3), h1->getXaxisValue(1));
-    EXPECT_EQ(hist->getXaxisValue(6), h1->getXaxisValue(2));
-    EXPECT_EQ(hist->getXaxisValue(9), h1->getXaxisValue(3));
+    h1.reset(hist.projectionX(0.99, 1.01));
+    EXPECT_EQ(hist.getXmin(), h1->getXmin());
+    EXPECT_EQ(hist.getXmax(), h1->getXmax());
+    EXPECT_EQ(hist.getNbinsX(), h1->getNbinsX());
+    EXPECT_EQ(hist.getXaxisValue(0), h1->getXaxisValue(0));
+    EXPECT_EQ(hist.getXaxisValue(3), h1->getXaxisValue(1));
+    EXPECT_EQ(hist.getXaxisValue(6), h1->getXaxisValue(2));
+    EXPECT_EQ(hist.getXaxisValue(9), h1->getXaxisValue(3));
 
     // check content of projections
     for (size_t binx = 0; binx < h1->getNbinsX(); ++binx) {
@@ -229,7 +221,7 @@ TEST_F(Histogram2DTest, projectionX)
 
 TEST_F(Histogram2DTest, projectionY)
 {
-    hist->reset();
+    hist.reset();
 
     // values to fill all histogram
     std::vector<double> xvalues = {-0.75, -0.75, -0.75, 0.0, 0.0, 0.0,
@@ -239,18 +231,18 @@ TEST_F(Histogram2DTest, projectionY)
 
     // put in every histogram bin the value from 'content' vector
     for (size_t i = 0; i < xvalues.size(); ++i) {
-        hist->fill(xvalues[i], yvalues[i], content[i]);
+        hist.fill(xvalues[i], yvalues[i], content[i]);
     }
 
     // a) create projection along Y axis
-    std::unique_ptr<Histogram1D> h1(hist->projectionY());
-    EXPECT_EQ(hist->getYmin(), h1->getXmin());
-    EXPECT_EQ(hist->getYmax(), h1->getXmax());
+    std::unique_ptr<Histogram1D> h1(hist.projectionY());
+    EXPECT_EQ(hist.getYmin(), h1->getXmin());
+    EXPECT_EQ(hist.getYmax(), h1->getXmax());
     EXPECT_EQ(size_t(3), h1->getNbinsX());
-    EXPECT_EQ(hist->getNbinsY(), h1->getNbinsX());
-    EXPECT_EQ(hist->getYaxisValue(3), h1->getXaxisValue(0));
-    EXPECT_EQ(hist->getYaxisValue(4), h1->getXaxisValue(1));
-    EXPECT_EQ(hist->getYaxisValue(5), h1->getXaxisValue(2));
+    EXPECT_EQ(hist.getNbinsY(), h1->getNbinsX());
+    EXPECT_EQ(hist.getYaxisValue(3), h1->getXaxisValue(0));
+    EXPECT_EQ(hist.getYaxisValue(4), h1->getXaxisValue(1));
+    EXPECT_EQ(hist.getYaxisValue(5), h1->getXaxisValue(2));
 
     // check content of projections
 
@@ -263,14 +255,14 @@ TEST_F(Histogram2DTest, projectionY)
     EXPECT_EQ(12.0, h1->getBinContent(2));
 
     // b) create projection along Y axis at given x(slice)
-    h1.reset(hist->projectionY(0.0));
-    EXPECT_EQ(hist->getYmin(), h1->getXmin());
-    EXPECT_EQ(hist->getYmax(), h1->getXmax());
+    h1.reset(hist.projectionY(0.0));
+    EXPECT_EQ(hist.getYmin(), h1->getXmin());
+    EXPECT_EQ(hist.getYmax(), h1->getXmax());
     EXPECT_EQ(size_t(3), h1->getNbinsX());
-    EXPECT_EQ(hist->getNbinsY(), h1->getNbinsX());
-    EXPECT_EQ(hist->getYaxisValue(3), h1->getXaxisValue(0));
-    EXPECT_EQ(hist->getYaxisValue(4), h1->getXaxisValue(1));
-    EXPECT_EQ(hist->getYaxisValue(5), h1->getXaxisValue(2));
+    EXPECT_EQ(hist.getNbinsY(), h1->getNbinsX());
+    EXPECT_EQ(hist.getYaxisValue(3), h1->getXaxisValue(0));
+    EXPECT_EQ(hist.getYaxisValue(4), h1->getXaxisValue(1));
+    EXPECT_EQ(hist.getYaxisValue(5), h1->getXaxisValue(2));
 
     // check content of projections
 
@@ -283,14 +275,14 @@ TEST_F(Histogram2DTest, projectionY)
     EXPECT_EQ(3.0, h1->getBinContent(2));
 
     // c) create projection along Y axis for x's between [xlow,xup]
-    h1.reset(hist->projectionY(0.0, 0.51));
-    EXPECT_EQ(hist->getYmin(), h1->getXmin());
-    EXPECT_EQ(hist->getYmax(), h1->getXmax());
+    h1.reset(hist.projectionY(0.0, 0.51));
+    EXPECT_EQ(hist.getYmin(), h1->getXmin());
+    EXPECT_EQ(hist.getYmax(), h1->getXmax());
     EXPECT_EQ(size_t(3), h1->getNbinsX());
-    EXPECT_EQ(hist->getNbinsY(), h1->getNbinsX());
-    EXPECT_EQ(hist->getYaxisValue(3), h1->getXaxisValue(0));
-    EXPECT_EQ(hist->getYaxisValue(4), h1->getXaxisValue(1));
-    EXPECT_EQ(hist->getYaxisValue(5), h1->getXaxisValue(2));
+    EXPECT_EQ(hist.getNbinsY(), h1->getNbinsX());
+    EXPECT_EQ(hist.getYaxisValue(3), h1->getXaxisValue(0));
+    EXPECT_EQ(hist.getYaxisValue(4), h1->getXaxisValue(1));
+    EXPECT_EQ(hist.getYaxisValue(5), h1->getXaxisValue(2));
 
     // check content of projections
 
@@ -316,7 +308,7 @@ TEST_F(Histogram2DTest, projectionY)
 
 TEST_F(Histogram2DTest, crop)
 {
-    hist->reset();
+    hist.reset();
 
     // values to fill all histogram
     std::vector<double> xvalues = {-0.75, -0.75, -0.75, 0.0, 0.0, 0.0,
@@ -326,10 +318,10 @@ TEST_F(Histogram2DTest, crop)
 
     // put in every histogram bin the value from 'content' vector
     for (size_t i = 0; i < xvalues.size(); ++i) {
-        hist->fill(xvalues[i], yvalues[i], content[i]);
+        hist.fill(xvalues[i], yvalues[i], content[i]);
     }
 
-    std::unique_ptr<Histogram2D> crop(hist->crop(-0.49, 0.0, 1.99, 1.9));
+    std::unique_ptr<Histogram2D> crop(hist.crop(-0.49, 0.0, 1.99, 1.9));
     EXPECT_EQ(-0.5, crop->getXmin());
     EXPECT_EQ(2.0, crop->getXmax());
     EXPECT_EQ(size_t(3), crop->getNbinsX());
@@ -354,55 +346,55 @@ TEST_F(Histogram2DTest, CreateHistogram)
         data[i] = double(i);
     }
 
-    std::unique_ptr<IHistogram> hist(IHistogram::createHistogram(data));
-    EXPECT_EQ(size_t(2), hist->getRank());
-    EXPECT_EQ(data.getAllocatedSize(), hist->getTotalNumberOfBins());
-    EXPECT_EQ(data.getAxis(0).getMin(), hist->getXmin());
-    EXPECT_EQ(data.getAxis(0).getMax(), hist->getXmax());
-    EXPECT_EQ(data.getAxis(1).getMin(), hist->getYmin());
-    EXPECT_EQ(data.getAxis(1).getMax(), hist->getYmax());
-    for (size_t i = 0; i < hist->getTotalNumberOfBins(); ++i) {
-        EXPECT_EQ(data[i], hist->getBinContent(i));
-        EXPECT_EQ(data[i], hist->getBinAverage(i));
-        EXPECT_EQ(1, hist->getBinNumberOfEntries(i));
-        EXPECT_EQ(0.0, hist->getBinError(i));
+    std::unique_ptr<IHistogram> h2(IHistogram::createHistogram(data));
+    EXPECT_EQ(size_t(2), h2->getRank());
+    EXPECT_EQ(data.getAllocatedSize(), h2->getTotalNumberOfBins());
+    EXPECT_EQ(data.getAxis(0).getMin(), h2->getXmin());
+    EXPECT_EQ(data.getAxis(0).getMax(), h2->getXmax());
+    EXPECT_EQ(data.getAxis(1).getMin(), h2->getYmin());
+    EXPECT_EQ(data.getAxis(1).getMax(), h2->getYmax());
+    for (size_t i = 0; i < h2->getTotalNumberOfBins(); ++i) {
+        EXPECT_EQ(data[i], h2->getBinContent(i));
+        EXPECT_EQ(data[i], h2->getBinAverage(i));
+        EXPECT_EQ(1, h2->getBinNumberOfEntries(i));
+        EXPECT_EQ(0.0, h2->getBinError(i));
     }
 }
 
 TEST_F(Histogram2DTest, CreateOutputData)
 {
-    Histogram2D hist(10, -5.0, 5.0, 5, -5.0, 0.0);
+    Histogram2D h2(10, -5.0, 5.0, 5, -5.0, 0.0);
 
-    for (size_t nx = 0; nx < hist.getNbinsX(); ++nx) {
-        for (size_t ny = 0; ny < hist.getNbinsY(); ++ny) {
-            double value(1.0 * ny + nx * hist.getNbinsY());
-            size_t globalbin = hist.getGlobalBin(nx, ny);
-            hist.fill(hist.getXaxisValue(globalbin), hist.getYaxisValue(globalbin), value);
+    for (size_t nx = 0; nx < h2.getNbinsX(); ++nx) {
+        for (size_t ny = 0; ny < h2.getNbinsY(); ++ny) {
+            double value(1.0 * ny + nx * h2.getNbinsY());
+            size_t globalbin = h2.getGlobalBin(nx, ny);
+            h2.fill(h2.getXaxisValue(globalbin), h2.getYaxisValue(globalbin), value);
         }
     }
 
-    std::unique_ptr<OutputData<double>> data(hist.createOutputData(IHistogram::DataType::INTEGRAL));
+    std::unique_ptr<OutputData<double>> data(h2.createOutputData(IHistogram::DataType::INTEGRAL));
     EXPECT_EQ(size_t(2), data->getRank());
-    EXPECT_EQ(data->getAllocatedSize(), hist.getTotalNumberOfBins());
-    EXPECT_EQ(data->getAxis(0).getMin(), hist.getXmin());
-    EXPECT_EQ(data->getAxis(0).getMax(), hist.getXmax());
-    EXPECT_EQ(data->getAxis(1).getMin(), hist.getYmin());
-    EXPECT_EQ(data->getAxis(1).getMax(), hist.getYmax());
+    EXPECT_EQ(data->getAllocatedSize(), h2.getTotalNumberOfBins());
+    EXPECT_EQ(data->getAxis(0).getMin(), h2.getXmin());
+    EXPECT_EQ(data->getAxis(0).getMax(), h2.getXmax());
+    EXPECT_EQ(data->getAxis(1).getMin(), h2.getYmin());
+    EXPECT_EQ(data->getAxis(1).getMax(), h2.getYmax());
     for (size_t i = 0; i < data->getAllocatedSize(); ++i) {
         EXPECT_EQ(double(i), (*data)[i]);
     }
 
-    data.reset(hist.createOutputData(IHistogram::DataType::AVERAGE));
+    data.reset(h2.createOutputData(IHistogram::DataType::AVERAGE));
     for (size_t i = 0; i < data->getAllocatedSize(); ++i) {
         EXPECT_EQ(double(i), (*data)[i]);
     }
 
-    data.reset(hist.createOutputData(IHistogram::DataType::STANDARD_ERROR));
+    data.reset(h2.createOutputData(IHistogram::DataType::STANDARD_ERROR));
     for (size_t i = 0; i < data->getAllocatedSize(); ++i) {
         EXPECT_EQ(0.0, (*data)[i]);
     }
 
-    data.reset(hist.createOutputData(IHistogram::DataType::NENTRIES));
+    data.reset(h2.createOutputData(IHistogram::DataType::NENTRIES));
     for (size_t i = 0; i < data->getAllocatedSize(); ++i) {
         EXPECT_EQ(1.0, (*data)[i]);
     }
@@ -410,16 +402,16 @@ TEST_F(Histogram2DTest, CreateOutputData)
 
 TEST_F(Histogram2DTest, GetMaximumGetMinimum)
 {
-    Histogram2D hist(10, -5.0, 5.0, 5, -5.0, 0.0);
+    Histogram2D h2(10, -5.0, 5.0, 5, -5.0, 0.0);
 
-    for (size_t ix = 0; ix < hist.getNbinsX(); ++ix) {
-        for (size_t iy = 0; iy < hist.getNbinsY(); ++iy) {
-            hist.fill(-5.0 + ix + 0.5, -5.0 + iy + 0.5, 10.0 + ix + hist.getNbinsX() * iy);
+    for (size_t ix = 0; ix < h2.getNbinsX(); ++ix) {
+        for (size_t iy = 0; iy < h2.getNbinsY(); ++iy) {
+            h2.fill(-5.0 + ix + 0.5, -5.0 + iy + 0.5, 10.0 + ix + h2.getNbinsX() * iy);
         }
     }
 
-    EXPECT_EQ(10.0, hist.getMinimum());
-    EXPECT_EQ(size_t(0), hist.getMinimumBinIndex());
-    EXPECT_EQ(59.0, hist.getMaximum());
-    EXPECT_EQ(size_t(49), hist.getMaximumBinIndex());
+    EXPECT_EQ(10.0, h2.getMinimum());
+    EXPECT_EQ(size_t(0), h2.getMinimumBinIndex());
+    EXPECT_EQ(59.0, h2.getMaximum());
+    EXPECT_EQ(size_t(49), h2.getMaximumBinIndex());
 }

--- a/Tests/UnitTests/Core/Axes/KVectorTest.cpp
+++ b/Tests/UnitTests/Core/Axes/KVectorTest.cpp
@@ -4,11 +4,7 @@
 
 class KVectorTest : public ::testing::Test
 {
-protected:
-    ~KVectorTest();
 };
-
-KVectorTest::~KVectorTest() = default;
 
 TEST_F(KVectorTest, BasicMethods)
 {

--- a/Tests/UnitTests/Core/Axes/PointwiseAxisTest.cpp
+++ b/Tests/UnitTests/Core/Axes/PointwiseAxisTest.cpp
@@ -6,11 +6,7 @@
 
 class PointwiseAxisTest : public ::testing::Test
 {
-public:
-    ~PointwiseAxisTest();
 };
-
-PointwiseAxisTest::~PointwiseAxisTest() = default;
 
 TEST_F(PointwiseAxisTest, Construction)
 {

--- a/Tests/UnitTests/Core/Axes/UnitConverter1DTest.cpp
+++ b/Tests/UnitTests/Core/Axes/UnitConverter1DTest.cpp
@@ -13,7 +13,6 @@ class UnitConverter1DTest : public ::testing::Test
 {
 public:
     UnitConverter1DTest();
-    ~UnitConverter1DTest();
 
     double getQ(double angle) { return 4.0 * M_PI * std::sin(angle) / m_beam.getWavelength(); }
 
@@ -35,8 +34,6 @@ UnitConverter1DTest::UnitConverter1DTest()
 {
     m_beam.setCentralK(1.0, 0.0, 0.0); // wavelength = 1.0 nm
 }
-
-UnitConverter1DTest::~UnitConverter1DTest() = default;
 
 void UnitConverter1DTest::checkConventionalConverter(const UnitConverter1D& test_object)
 {

--- a/Tests/UnitTests/Core/Axes/VariableBinAxisTest.cpp
+++ b/Tests/UnitTests/Core/Axes/VariableBinAxisTest.cpp
@@ -5,11 +5,7 @@
 
 class VariableBinAxisTest : public ::testing::Test
 {
-protected:
-    ~VariableBinAxisTest();
 };
-
-VariableBinAxisTest::~VariableBinAxisTest() = default;
 
 TEST_F(VariableBinAxisTest, VectorOfUnitLength)
 {

--- a/Tests/UnitTests/Core/DataStructure/ArrayUtilsTest.cpp
+++ b/Tests/UnitTests/Core/DataStructure/ArrayUtilsTest.cpp
@@ -5,11 +5,7 @@
 
 class ArrayUtilsTest : public ::testing::Test
 {
-protected:
-    ~ArrayUtilsTest();
 };
-
-ArrayUtilsTest::~ArrayUtilsTest() = default;
 
 TEST_F(ArrayUtilsTest, OutputDataFromVector1D)
 {

--- a/Tests/UnitTests/Core/DataStructure/IOStrategyTest.cpp
+++ b/Tests/UnitTests/Core/DataStructure/IOStrategyTest.cpp
@@ -8,12 +8,9 @@ class IOStrategyTest : public ::testing::Test
 {
 protected:
     IOStrategyTest();
-    ~IOStrategyTest() override;
 
     OutputData<double> m_model_data;
 };
-
-IOStrategyTest::~IOStrategyTest() = default;
 
 IOStrategyTest::IOStrategyTest()
 {

--- a/Tests/UnitTests/Core/DataStructure/IntensityDataFunctionsTest.cpp
+++ b/Tests/UnitTests/Core/DataStructure/IntensityDataFunctionsTest.cpp
@@ -4,11 +4,7 @@
 
 class IntensityDataFunctionsTest : public ::testing::Test
 {
-protected:
-    ~IntensityDataFunctionsTest();
 };
-
-IntensityDataFunctionsTest::~IntensityDataFunctionsTest() = default;
 
 TEST_F(IntensityDataFunctionsTest, ClipDataSetFixed)
 {

--- a/Tests/UnitTests/Core/DataStructure/LLDataTest.cpp
+++ b/Tests/UnitTests/Core/DataStructure/LLDataTest.cpp
@@ -7,7 +7,6 @@ class LLDataTest : public ::testing::Test
 {
 protected:
     LLDataTest();
-    ~LLDataTest();
 
     LLData<int>* int_data_0d;
     LLData<float>* fl_data_1d;
@@ -38,8 +37,6 @@ LLDataTest::LLDataTest()
 
     matrix_data_2d = new LLData<Eigen::Matrix2d>(2u, dim2);
 }
-
-LLDataTest::~LLDataTest() = default;
 
 TEST_F(LLDataTest, TotalSize)
 {

--- a/Tests/UnitTests/Core/DataStructure/OutputDataIteratorTest.cpp
+++ b/Tests/UnitTests/Core/DataStructure/OutputDataIteratorTest.cpp
@@ -6,56 +6,49 @@ class OutputDataIteratorTest : public ::testing::Test
 {
 protected:
     OutputDataIteratorTest();
-    virtual ~OutputDataIteratorTest();
 
-    OutputData<double>* p_data;
+    OutputData<double> _data;
 };
 
 OutputDataIteratorTest::OutputDataIteratorTest()
 {
-    p_data = new OutputData<double>();
     int* dims = new int[2];
     dims[0] = 3;
     dims[1] = 5;
-    p_data->setAxisSizes(2, dims);
+    _data.setAxisSizes(2, dims);
     double value = 0.0;
-    OutputData<double>::iterator it = p_data->begin();
-    while (it != p_data->end()) {
+    OutputData<double>::iterator it = _data.begin();
+    while (it != _data.end()) {
         *it = value;
         value += 1.0;
         ++it;
     }
 }
 
-OutputDataIteratorTest::~OutputDataIteratorTest()
-{
-    delete p_data;
-}
-
 TEST_F(OutputDataIteratorTest, Iterate)
 {
-    OutputData<double>::iterator it = p_data->begin();
+    OutputData<double>::iterator it = _data.begin();
     EXPECT_EQ(0.0, *it);
     for (size_t i = 0; i < 14; ++i) {
         ++it;
     }
     EXPECT_DOUBLE_EQ(14.0, *it);
     ++it;
-    EXPECT_EQ(it, p_data->end());
+    EXPECT_EQ(it, _data.end());
     ++it;
-    EXPECT_EQ(it, p_data->end());
+    EXPECT_EQ(it, _data.end());
 }
 
 TEST_F(OutputDataIteratorTest, ConstIterate)
 {
-    OutputData<double>::const_iterator it = p_data->begin();
+    OutputData<double>::const_iterator it = _data.begin();
     EXPECT_EQ(0.0, *it);
     for (size_t i = 0; i < 14; ++i) {
         ++it;
     }
     EXPECT_DOUBLE_EQ(14.0, *it);
     ++it;
-    EXPECT_EQ(it, p_data->end());
+    EXPECT_EQ(it, _data.end());
     ++it;
-    EXPECT_EQ(it, p_data->end());
+    EXPECT_EQ(it, _data.end());
 }

--- a/Tests/UnitTests/Core/Detector/DetectorMaskTest.cpp
+++ b/Tests/UnitTests/Core/Detector/DetectorMaskTest.cpp
@@ -6,11 +6,7 @@
 
 class DetectorMaskTest : public ::testing::Test
 {
-public:
-    ~DetectorMaskTest();
 };
-
-DetectorMaskTest::~DetectorMaskTest() = default;
 
 TEST_F(DetectorMaskTest, InitialState)
 {

--- a/Tests/UnitTests/Core/Detector/OffSpecularConverterTest.cpp
+++ b/Tests/UnitTests/Core/Detector/OffSpecularConverterTest.cpp
@@ -9,7 +9,6 @@ class OffSpecularConverterTest : public ::testing::Test
 {
 public:
     OffSpecularConverterTest();
-    ~OffSpecularConverterTest();
 
 protected:
     SphericalDetector m_detector;
@@ -23,8 +22,6 @@ OffSpecularConverterTest::OffSpecularConverterTest()
 {
     m_beam.setCentralK(1.0, 1.0 * Units::deg, 0.0);
 }
-
-OffSpecularConverterTest::~OffSpecularConverterTest() = default;
 
 TEST_F(OffSpecularConverterTest, OffSpecularConverter)
 {

--- a/Tests/UnitTests/Core/Detector/PolygonTest.cpp
+++ b/Tests/UnitTests/Core/Detector/PolygonTest.cpp
@@ -5,11 +5,7 @@
 
 class PolygonTest : public ::testing::Test
 {
-public:
-    ~PolygonTest();
 };
-
-PolygonTest::~PolygonTest() = default;
 
 TEST_F(PolygonTest, SimpleRectangle)
 {

--- a/Tests/UnitTests/Core/Detector/PrecomputedTest.cpp
+++ b/Tests/UnitTests/Core/Detector/PrecomputedTest.cpp
@@ -9,11 +9,7 @@ constexpr auto ReciprocalFactorialArray = Precomputed::GenerateReciprocalFactori
 
 class PrecomputedTest : public ::testing::Test
 {
-public:
-    ~PrecomputedTest();
 };
-
-PrecomputedTest::~PrecomputedTest() = default;
 
 TEST_F(PrecomputedTest, ReciprocalFactorial)
 {

--- a/Tests/UnitTests/Core/Detector/RectangularConverterTest.cpp
+++ b/Tests/UnitTests/Core/Detector/RectangularConverterTest.cpp
@@ -19,7 +19,6 @@ class RectangularConverterTest : public ::testing::Test
 {
 public:
     RectangularConverterTest();
-    ~RectangularConverterTest();
 
 protected:
     RectangularDetector m_detector;
@@ -42,8 +41,6 @@ RectangularConverterTest::RectangularConverterTest()
     m_kfy = K * std::sin(m_phi);
     m_kfz = K * std::sin(m_alpha);
 }
-
-RectangularConverterTest::~RectangularConverterTest() = default;
 
 TEST_F(RectangularConverterTest, RectangularConverter)
 {

--- a/Tests/UnitTests/Core/Detector/RectangularDetectorTest.cpp
+++ b/Tests/UnitTests/Core/Detector/RectangularDetectorTest.cpp
@@ -9,8 +9,6 @@
 class RectangularDetectorTest : public ::testing::Test
 {
 protected:
-    ~RectangularDetectorTest();
-
     //    double phi(DetectorElement& element, double wavelength);
     //    double alpha(DetectorElement& element, double wavelength);
     double phi(kvector_t k) { return k.phi() / Units::degree; }
@@ -27,8 +25,6 @@ protected:
         return is_equal;
     }
 };
-
-RectangularDetectorTest::~RectangularDetectorTest() = default;
 
 TEST_F(RectangularDetectorTest, InitialState)
 {

--- a/Tests/UnitTests/Core/Detector/RegionOfInterestTest.cpp
+++ b/Tests/UnitTests/Core/Detector/RegionOfInterestTest.cpp
@@ -6,11 +6,7 @@
 
 class RegionOfInterestTest : public ::testing::Test
 {
-protected:
-    ~RegionOfInterestTest();
 };
-
-RegionOfInterestTest::~RegionOfInterestTest() = default;
 
 //! Testing region of interest with reasonable area within the detector.
 

--- a/Tests/UnitTests/Core/Detector/SimulationAreaTest.cpp
+++ b/Tests/UnitTests/Core/Detector/SimulationAreaTest.cpp
@@ -8,11 +8,7 @@
 
 class SimulationAreaTest : public ::testing::Test
 {
-protected:
-    ~SimulationAreaTest();
 };
-
-SimulationAreaTest::~SimulationAreaTest() = default;
 
 // Iterators test
 

--- a/Tests/UnitTests/Core/Detector/SpecialFunctionsTest.cpp
+++ b/Tests/UnitTests/Core/Detector/SpecialFunctionsTest.cpp
@@ -8,11 +8,7 @@
 
 class SpecialFunctionsTest : public ::testing::Test
 {
-protected:
-    ~SpecialFunctionsTest();
 };
-
-SpecialFunctionsTest::~SpecialFunctionsTest() = default;
 
 // Test complex Bessel function J1
 TEST_F(SpecialFunctionsTest, BesselJ1)

--- a/Tests/UnitTests/Core/Detector/SpecularDetector1DTest.cpp
+++ b/Tests/UnitTests/Core/Detector/SpecularDetector1DTest.cpp
@@ -10,11 +10,7 @@
 
 class SpecularDetectorTest : public ::testing::Test
 {
-protected:
-    ~SpecularDetectorTest();
 };
-
-SpecularDetectorTest::~SpecularDetectorTest() = default;
 
 // Default detector construction
 TEST_F(SpecularDetectorTest, basicBehaviour)

--- a/Tests/UnitTests/Core/Detector/SphericalConverterTest.cpp
+++ b/Tests/UnitTests/Core/Detector/SphericalConverterTest.cpp
@@ -9,7 +9,6 @@ class SphericalConverterTest : public ::testing::Test
 {
 public:
     SphericalConverterTest();
-    ~SphericalConverterTest();
 
 protected:
     SphericalDetector m_detector;
@@ -28,8 +27,6 @@ SphericalConverterTest::SphericalConverterTest()
     m_kfz1 = K * std::sin(-2.0 * Units::deg);
     m_kfz2 = K * std::sin(1.5);
 }
-
-SphericalConverterTest::~SphericalConverterTest() = default;
 
 TEST_F(SphericalConverterTest, SphericalConverter)
 {

--- a/Tests/UnitTests/Core/Detector/SphericalDetectorTest.cpp
+++ b/Tests/UnitTests/Core/Detector/SphericalDetectorTest.cpp
@@ -17,11 +17,7 @@
 
 class SphericalDetectorTest : public ::testing::Test
 {
-protected:
-    ~SphericalDetectorTest();
 };
-
-SphericalDetectorTest::~SphericalDetectorTest() = default;
 
 // Default detector construction
 TEST_F(SphericalDetectorTest, initialState)

--- a/Tests/UnitTests/Core/ExportToPython/PythonFormattingTest.cpp
+++ b/Tests/UnitTests/Core/ExportToPython/PythonFormattingTest.cpp
@@ -10,11 +10,7 @@
 
 class PythonFormattingTest : public ::testing::Test
 {
-public:
-    ~PythonFormattingTest();
 };
-
-PythonFormattingTest::~PythonFormattingTest() = default;
 
 TEST_F(PythonFormattingTest, ValueTimesUnits)
 {

--- a/Tests/UnitTests/Core/Fitting/FitObjectiveTest.cpp
+++ b/Tests/UnitTests/Core/Fitting/FitObjectiveTest.cpp
@@ -5,13 +5,7 @@
 
 class FitObjectiveTest : public ::testing::Test
 {
-public:
-    ~FitObjectiveTest();
-
-protected:
 };
-
-FitObjectiveTest::~FitObjectiveTest() = default;
 
 TEST_F(FitObjectiveTest, twoDatasets)
 {

--- a/Tests/UnitTests/Core/Fitting/FitObserverTest.cpp
+++ b/Tests/UnitTests/Core/Fitting/FitObserverTest.cpp
@@ -11,13 +11,7 @@ public:
         int m_ncalls;
         int m_data;
     };
-
-    ~FitObserverTest();
-
-protected:
 };
-
-FitObserverTest::~FitObserverTest() = default;
 
 //! Checks that single observer is called on every iteration.
 

--- a/Tests/UnitTests/Core/Fitting/ObjectiveMetricTest.cpp
+++ b/Tests/UnitTests/Core/Fitting/ObjectiveMetricTest.cpp
@@ -5,11 +5,7 @@
 
 class ObjectiveMetricTest : public ::testing::Test
 {
-public:
-    ~ObjectiveMetricTest() override;
 };
-
-ObjectiveMetricTest::~ObjectiveMetricTest() = default;
 
 TEST_F(ObjectiveMetricTest, Chi2WellFormed)
 {

--- a/Tests/UnitTests/Core/Fitting/SimDataPairTest.cpp
+++ b/Tests/UnitTests/Core/Fitting/SimDataPairTest.cpp
@@ -5,13 +5,7 @@
 
 class SimDataPairTest : public ::testing::Test
 {
-public:
-    ~SimDataPairTest();
-
-protected:
 };
-
-SimDataPairTest::~SimDataPairTest() = default;
 
 TEST_F(SimDataPairTest, standardPair)
 {

--- a/Tests/UnitTests/Core/Fresnel/DepthProbeSimulationTest.cpp
+++ b/Tests/UnitTests/Core/Fresnel/DepthProbeSimulationTest.cpp
@@ -16,7 +16,6 @@ class DepthProbeSimulationTest : public ::testing::Test
 {
 protected:
     DepthProbeSimulationTest();
-    ~DepthProbeSimulationTest();
 
     std::unique_ptr<DepthProbeSimulation> defaultSimulation();
     void checkBeamState(const DepthProbeSimulation& sim);
@@ -39,8 +38,6 @@ DepthProbeSimulationTest::DepthProbeSimulationTest()
     multilayer.addLayer(layer1);
     multilayer.addLayer(layer2);
 }
-
-DepthProbeSimulationTest::~DepthProbeSimulationTest() = default;
 
 std::unique_ptr<DepthProbeSimulation> DepthProbeSimulationTest::defaultSimulation()
 {

--- a/Tests/UnitTests/Core/Fresnel/KzComputationTest.cpp
+++ b/Tests/UnitTests/Core/Fresnel/KzComputationTest.cpp
@@ -10,8 +10,6 @@
 
 class KzComputationTest : public ::testing::Test
 {
-protected:
-    ~KzComputationTest() override = default;
 };
 
 TEST_F(KzComputationTest, initial)

--- a/Tests/UnitTests/Core/Fresnel/MatrixRTCoefficientsTest.cpp
+++ b/Tests/UnitTests/Core/Fresnel/MatrixRTCoefficientsTest.cpp
@@ -4,12 +4,8 @@
 class MatrixRTCoefficientsTest : public ::testing::Test
 {
 protected:
-    ~MatrixRTCoefficientsTest();
-
     MatrixRTCoefficients mrtcDefault;
 };
-
-MatrixRTCoefficientsTest::~MatrixRTCoefficientsTest() = default;
 
 TEST_F(MatrixRTCoefficientsTest, T1plus)
 {

--- a/Tests/UnitTests/Core/Fresnel/ScalarRTCoefficientsTest.cpp
+++ b/Tests/UnitTests/Core/Fresnel/ScalarRTCoefficientsTest.cpp
@@ -5,7 +5,6 @@ class ScalarRTCoefficientsTest : public ::testing::Test
 {
 protected:
     ScalarRTCoefficientsTest();
-    ~ScalarRTCoefficientsTest();
 
     ScalarRTCoefficients scrtDefault;
     ScalarRTCoefficients scrtCustom;
@@ -17,8 +16,6 @@ ScalarRTCoefficientsTest::ScalarRTCoefficientsTest()
     scrtCustom.t_r(0) = complex_t(0.0, 0.5);
     scrtCustom.t_r(1) = complex_t(1.0, 0.5);
 }
-
-ScalarRTCoefficientsTest::~ScalarRTCoefficientsTest() = default;
 
 TEST_F(ScalarRTCoefficientsTest, T1plus)
 {

--- a/Tests/UnitTests/Core/Fresnel/SpecularMagneticTest.cpp
+++ b/Tests/UnitTests/Core/Fresnel/SpecularMagneticTest.cpp
@@ -10,11 +10,7 @@
 
 class SpecularMagneticTest : public ::testing::Test
 {
-protected:
-    ~SpecularMagneticTest();
 };
-
-SpecularMagneticTest::~SpecularMagneticTest() = default;
 
 TEST_F(SpecularMagneticTest, initial)
 {

--- a/Tests/UnitTests/Core/Fresnel/SpecularMagneticTest_v2.cpp
+++ b/Tests/UnitTests/Core/Fresnel/SpecularMagneticTest_v2.cpp
@@ -13,16 +13,12 @@ constexpr double eps = 1e-10;
 class SpecularMagneticTest_v2 : public ::testing::Test
 {
 protected:
-    ~SpecularMagneticTest_v2();
-
     //! Compares results with scalar case
     void testZeroField(const kvector_t& k, const ProcessedSample& m_layer_scalar,
                        const ProcessedSample& m_layer_zerofield);
 
     void ifEqual(const Eigen::Vector2cd& lhs, const Eigen::Vector2cd& rhs);
 };
-
-SpecularMagneticTest_v2::~SpecularMagneticTest_v2() = default;
 
 void SpecularMagneticTest_v2::testZeroField(const kvector_t& k,
                                             const ProcessedSample& sample_scalar,

--- a/Tests/UnitTests/Core/Fresnel/SpecularScanTest.cpp
+++ b/Tests/UnitTests/Core/Fresnel/SpecularScanTest.cpp
@@ -10,11 +10,7 @@
 
 class SpecularScanTest : public ::testing::Test
 {
-protected:
-    ~SpecularScanTest();
 };
-
-SpecularScanTest::~SpecularScanTest() = default;
 
 TEST_F(SpecularScanTest, AngularScanInit)
 {

--- a/Tests/UnitTests/Core/Fresnel/SpecularSimulationTest.cpp
+++ b/Tests/UnitTests/Core/Fresnel/SpecularSimulationTest.cpp
@@ -21,7 +21,6 @@ class SpecularSimulationTest : public ::testing::Test
 {
 protected:
     SpecularSimulationTest();
-    ~SpecularSimulationTest();
 
     std::unique_ptr<SpecularSimulation> defaultSimulation();
     void checkBeamState(const SpecularSimulation& sim);
@@ -43,8 +42,6 @@ SpecularSimulationTest::SpecularSimulationTest()
     multilayer.addLayer(layer1);
     multilayer.addLayer(layer2);
 }
-
-SpecularSimulationTest::~SpecularSimulationTest() = default;
 
 TEST_F(SpecularSimulationTest, InitialState)
 {

--- a/Tests/UnitTests/Core/Other/BeamTest.cpp
+++ b/Tests/UnitTests/Core/Other/BeamTest.cpp
@@ -13,12 +13,8 @@
 class BeamTest : public ::testing::Test
 {
 protected:
-    ~BeamTest();
-
     Beam m_empty_beam;
 };
-
-BeamTest::~BeamTest() = default;
 
 TEST_F(BeamTest, BeamInitialState)
 {

--- a/Tests/UnitTests/Core/Other/ChiSquaredModuleTest.cpp
+++ b/Tests/UnitTests/Core/Other/ChiSquaredModuleTest.cpp
@@ -9,15 +9,11 @@
 class ChiSquaredModuleTest : public ::testing::Test
 {
 protected:
-    ~ChiSquaredModuleTest();
-
     ChiSquaredModule m_chi_empty;
     ChiSquaredModule m_chi_default;
     OutputData<double> m_real_data;
     OutputData<double> m_simul_data;
 };
-
-ChiSquaredModuleTest::~ChiSquaredModuleTest() = default;
 
 TEST_F(ChiSquaredModuleTest, InitialState)
 {

--- a/Tests/UnitTests/Core/Other/CumulativeValueTest.cpp
+++ b/Tests/UnitTests/Core/Other/CumulativeValueTest.cpp
@@ -3,11 +3,7 @@
 
 class CumulativeValueTest : public ::testing::Test
 {
-protected:
-    ~CumulativeValueTest();
 };
-
-CumulativeValueTest::~CumulativeValueTest() = default;
 
 TEST_F(CumulativeValueTest, InitialState)
 {

--- a/Tests/UnitTests/Core/Other/FileSystemUtilsTest.cpp
+++ b/Tests/UnitTests/Core/Other/FileSystemUtilsTest.cpp
@@ -3,11 +3,7 @@
 
 class FileSystemUtilsTest : public ::testing::Test
 {
-protected:
-    ~FileSystemUtilsTest();
 };
-
-FileSystemUtilsTest::~FileSystemUtilsTest() = default;
 
 TEST_F(FileSystemUtilsTest, extention)
 {

--- a/Tests/UnitTests/Core/Other/FourierTransformTest.cpp
+++ b/Tests/UnitTests/Core/Other/FourierTransformTest.cpp
@@ -9,11 +9,7 @@
 
 class FourierTransformTest : public ::testing::Test
 {
-protected:
-    ~FourierTransformTest();
 };
-
-FourierTransformTest::~FourierTransformTest() = default;
 
 // Testing implementation of 1D FT with with low freuency centering
 TEST_F(FourierTransformTest, fft1DTest)

--- a/Tests/UnitTests/Core/Other/GISASSimulationTest.cpp
+++ b/Tests/UnitTests/Core/Other/GISASSimulationTest.cpp
@@ -12,11 +12,8 @@
 class GISASSimulationTest : public ::testing::Test
 {
 protected:
-    ~GISASSimulationTest();
     GISASSimulation m_simulation;
 };
-
-GISASSimulationTest::~GISASSimulationTest() = default;
 
 TEST_F(GISASSimulationTest, SimulationInitialState)
 {

--- a/Tests/UnitTests/Core/Other/InstrumentTest.cpp
+++ b/Tests/UnitTests/Core/Other/InstrumentTest.cpp
@@ -8,7 +8,6 @@ class InstrumentTest : public ::testing::Test
 {
 protected:
     InstrumentTest();
-    ~InstrumentTest();
 
     Instrument m_instrument;
     OutputData<double> m_data;
@@ -19,8 +18,6 @@ InstrumentTest::InstrumentTest()
     m_data.addAxis(BornAgain::PHI_AXIS_NAME, 10, 0., 10.);
     m_data.addAxis("theta_f", 20, 0., 20.);
 }
-
-InstrumentTest::~InstrumentTest() = default;
 
 TEST_F(InstrumentTest, InstrumentInitialState)
 {

--- a/Tests/UnitTests/Core/Other/LayerFillLimitsTest.cpp
+++ b/Tests/UnitTests/Core/Other/LayerFillLimitsTest.cpp
@@ -6,7 +6,6 @@ class LayerFillLimitsTest : public ::testing::Test
 {
 protected:
     LayerFillLimitsTest();
-    ~LayerFillLimitsTest();
 
     LayerFillLimits m_fill_limits;
     std::vector<double> layers_bottomz;
@@ -17,8 +16,6 @@ LayerFillLimitsTest::LayerFillLimitsTest() : m_fill_limits({})
     std::vector<double> layers_bottomz = {0, -5, -20};
     m_fill_limits = LayerFillLimits(layers_bottomz);
 }
-
-LayerFillLimitsTest::~LayerFillLimitsTest() = default;
 
 TEST_F(LayerFillLimitsTest, LayerFillLimitsEmptyConstructor)
 {

--- a/Tests/UnitTests/Core/Other/MaterialTest.cpp
+++ b/Tests/UnitTests/Core/Other/MaterialTest.cpp
@@ -10,11 +10,7 @@
 
 class MaterialTest : public ::testing::Test
 {
-public:
-    ~MaterialTest();
 };
-
-MaterialTest::~MaterialTest() = default;
 
 TEST_F(MaterialTest, MaterialConstruction)
 {

--- a/Tests/UnitTests/Core/Other/OrderedMapTest.cpp
+++ b/Tests/UnitTests/Core/Other/OrderedMapTest.cpp
@@ -4,11 +4,7 @@
 
 class OrderedMapTest : public ::testing::Test
 {
-protected:
-    ~OrderedMapTest();
 };
-
-OrderedMapTest::~OrderedMapTest() = default;
 
 TEST_F(OrderedMapTest, OrderedMapInsert)
 {

--- a/Tests/UnitTests/Core/Other/RelDiffTest.cpp
+++ b/Tests/UnitTests/Core/Other/RelDiffTest.cpp
@@ -4,11 +4,7 @@
 
 class RelDiffTest : public ::testing::Test
 {
-protected:
-    ~RelDiffTest();
 };
-
-RelDiffTest::~RelDiffTest() = default;
 
 TEST_F(RelDiffTest, RelDiffAlmostEq)
 {

--- a/Tests/UnitTests/Core/Other/RotationTest.cpp
+++ b/Tests/UnitTests/Core/Other/RotationTest.cpp
@@ -5,14 +5,7 @@
 
 class RotationTest : public ::testing::Test
 {
-protected:
-    RotationTest();
-    virtual ~RotationTest();
 };
-
-RotationTest::RotationTest() {}
-
-RotationTest::~RotationTest() {}
 
 TEST_F(RotationTest, XRotations)
 {

--- a/Tests/UnitTests/Core/Other/SampleBuilderNoteTest.cpp
+++ b/Tests/UnitTests/Core/Other/SampleBuilderNoteTest.cpp
@@ -10,8 +10,6 @@
 class SampleBuilderNodeTest : public ::testing::Test
 {
 public:
-    ~SampleBuilderNodeTest();
-
     //! Returns test multilayer.
     static std::unique_ptr<MultiLayer> testMultiLayer(double length)
     {
@@ -34,8 +32,6 @@ public:
         double m_length;
     };
 };
-
-SampleBuilderNodeTest::~SampleBuilderNodeTest() = default;
 
 //! Checks children and pool parameters.
 

--- a/Tests/UnitTests/Core/Other/SampleProviderTest.cpp
+++ b/Tests/UnitTests/Core/Other/SampleProviderTest.cpp
@@ -9,8 +9,6 @@
 class SampleProviderTest : public ::testing::Test
 {
 public:
-    ~SampleProviderTest();
-
     //! Returns test multilayer.
     static std::unique_ptr<MultiLayer> testMultiLayer(double length)
     {
@@ -57,8 +55,6 @@ public:
         double m_length;
     };
 };
-
-SampleProviderTest::~SampleProviderTest() = default;
 
 //! Test initial state,  assignment operator.
 

--- a/Tests/UnitTests/Core/Other/Shape2DTest.cpp
+++ b/Tests/UnitTests/Core/Other/Shape2DTest.cpp
@@ -9,11 +9,7 @@
 
 class Shape2DTest : public ::testing::Test
 {
-public:
-    ~Shape2DTest();
 };
-
-Shape2DTest::~Shape2DTest() = default;
 
 TEST_F(Shape2DTest, Rectangle)
 {

--- a/Tests/UnitTests/Core/Other/SimulationResultTest.cpp
+++ b/Tests/UnitTests/Core/Other/SimulationResultTest.cpp
@@ -5,11 +5,7 @@
 
 class SimulationResultTest : public ::testing::Test
 {
-public:
-    ~SimulationResultTest();
 };
-
-SimulationResultTest::~SimulationResultTest() = default;
 
 TEST_F(SimulationResultTest, initialState)
 {

--- a/Tests/UnitTests/Core/Other/SpectrumTest.cpp
+++ b/Tests/UnitTests/Core/Other/SpectrumTest.cpp
@@ -6,11 +6,7 @@
 
 class SpectrumTest : public ::testing::Test
 {
-protected:
-    ~SpectrumTest();
 };
-
-SpectrumTest::~SpectrumTest() = default;
 
 TEST_F(SpectrumTest, arrayPeaks)
 {

--- a/Tests/UnitTests/Core/Other/ThreadInfoTest.cpp
+++ b/Tests/UnitTests/Core/Other/ThreadInfoTest.cpp
@@ -3,16 +3,11 @@
 
 class ThreadInfoTest : public ::testing::Test
 {
-protected:
-    ~ThreadInfoTest();
-
-    ThreadInfo thread_info;
 };
-
-ThreadInfoTest::~ThreadInfoTest() = default;
 
 TEST_F(ThreadInfoTest, DefaultValues)
 {
+    ThreadInfo thread_info;
     EXPECT_EQ(1u, thread_info.n_batches);
     EXPECT_EQ(0u, thread_info.current_batch);
     EXPECT_EQ(0u, thread_info.n_threads);

--- a/Tests/UnitTests/Core/Other/ZLimitsTest.cpp
+++ b/Tests/UnitTests/Core/Other/ZLimitsTest.cpp
@@ -4,11 +4,7 @@
 
 class ZLimitsTest : public ::testing::Test
 {
-protected:
-    ~ZLimitsTest();
 };
-
-ZLimitsTest::~ZLimitsTest() = default;
 
 TEST_F(ZLimitsTest, ZLimitsDefaultConstructor)
 {

--- a/Tests/UnitTests/Core/Parameters/DistributionHandlerTest.cpp
+++ b/Tests/UnitTests/Core/Parameters/DistributionHandlerTest.cpp
@@ -9,11 +9,8 @@ class DistributionHandlerTest : public ::testing::Test
 {
 protected:
     DistributionHandlerTest() : m_value(99.0) {}
-    ~DistributionHandlerTest();
     double m_value;
 };
-
-DistributionHandlerTest::~DistributionHandlerTest() = default;
 
 TEST_F(DistributionHandlerTest, DistributionHandlerConstructor)
 {

--- a/Tests/UnitTests/Core/Parameters/DistributionsTest.cpp
+++ b/Tests/UnitTests/Core/Parameters/DistributionsTest.cpp
@@ -10,13 +10,7 @@
 
 class DistributionsTest : public ::testing::Test
 {
-protected:
-    ~DistributionsTest();
 };
-
-DistributionsTest::~DistributionsTest() = default;
-
-// -------------------------------------------------------------------------- //
 
 TEST_F(DistributionsTest, DistributionGateDefaultConstructor)
 {

--- a/Tests/UnitTests/Core/Parameters/FTDistributionsTest.cpp
+++ b/Tests/UnitTests/Core/Parameters/FTDistributionsTest.cpp
@@ -8,11 +8,7 @@
 
 class FTDistributionsTest : public ::testing::Test
 {
-protected:
-    ~FTDistributionsTest();
 };
-
-FTDistributionsTest::~FTDistributionsTest() = default;
 
 // test 1D
 

--- a/Tests/UnitTests/Core/Parameters/IParameterizedTest.cpp
+++ b/Tests/UnitTests/Core/Parameters/IParameterizedTest.cpp
@@ -5,8 +5,6 @@
 class IParameterizedTest : public ::testing::Test
 {
 protected:
-    ~IParameterizedTest();
-
     IParameterized m_initial_object;
 
     class ParameterizedObject : public IParameterized
@@ -29,8 +27,6 @@ protected:
     };
     ParameterizedObject m_parameterized;
 };
-
-IParameterizedTest::~IParameterizedTest() = default;
 
 // TODO enable tests
 

--- a/Tests/UnitTests/Core/Parameters/ParameterDistributionTest.cpp
+++ b/Tests/UnitTests/Core/Parameters/ParameterDistributionTest.cpp
@@ -9,11 +9,7 @@
 
 class ParameterDistributionTest : public ::testing::Test
 {
-protected:
-    ~ParameterDistributionTest();
 };
-
-ParameterDistributionTest::~ParameterDistributionTest() = default;
 
 TEST_F(ParameterDistributionTest, ParameterDistributionConstructor)
 {

--- a/Tests/UnitTests/Core/Parameters/ParameterPatternTest.cpp
+++ b/Tests/UnitTests/Core/Parameters/ParameterPatternTest.cpp
@@ -4,11 +4,7 @@
 
 class ParameterPatternTest : public ::testing::Test
 {
-protected:
-    ~ParameterPatternTest();
 };
-
-ParameterPatternTest::~ParameterPatternTest() = default;
 
 TEST_F(ParameterPatternTest, declarationTest)
 {

--- a/Tests/UnitTests/Core/Parameters/ParameterPoolTest.cpp
+++ b/Tests/UnitTests/Core/Parameters/ParameterPoolTest.cpp
@@ -5,11 +5,7 @@
 
 class ParameterPoolTest : public ::testing::Test
 {
-protected:
-    ~ParameterPoolTest();
 };
-
-ParameterPoolTest::~ParameterPoolTest() = default;
 
 TEST_F(ParameterPoolTest, initialState)
 {

--- a/Tests/UnitTests/Core/Parameters/RangedDistributionTest.cpp
+++ b/Tests/UnitTests/Core/Parameters/RangedDistributionTest.cpp
@@ -6,8 +6,6 @@
 class RangedDistributionTest : public ::testing::Test
 {
 protected:
-    ~RangedDistributionTest();
-
     void checkDefaults(const RangedDistribution& distr);
 
     template <class T> void checkThrows();
@@ -18,8 +16,6 @@ protected:
 
     template <class T> void checkZeroWidth();
 };
-
-RangedDistributionTest::~RangedDistributionTest() = default;
 
 void RangedDistributionTest::checkDefaults(const RangedDistribution& distr)
 {

--- a/Tests/UnitTests/Core/Parameters/RealParameterTest.cpp
+++ b/Tests/UnitTests/Core/Parameters/RealParameterTest.cpp
@@ -6,11 +6,7 @@
 
 class RealParameterTest : public ::testing::Test
 {
-protected:
-    ~RealParameterTest();
 };
-
-RealParameterTest::~RealParameterTest() = default;
 
 TEST_F(RealParameterTest, simpleConstructor)
 {

--- a/Tests/UnitTests/Core/Parameters/ScanResolutionTest.cpp
+++ b/Tests/UnitTests/Core/Parameters/ScanResolutionTest.cpp
@@ -8,11 +8,8 @@ class ScanResolutionTest : public ::testing::Test
 {
 protected:
     using DistrOutput = std::vector<std::vector<ParameterSample>>;
-    ~ScanResolutionTest();
     void compareResults(const DistrOutput& lhs, const DistrOutput& rhs);
 };
-
-ScanResolutionTest::~ScanResolutionTest() = default;
 
 void ScanResolutionTest::compareResults(const DistrOutput& lhs, const DistrOutput& rhs)
 {

--- a/Tests/UnitTests/Core/Sample/CrystalTest.cpp
+++ b/Tests/UnitTests/Core/Sample/CrystalTest.cpp
@@ -6,11 +6,7 @@
 
 class CrystalTest : public ::testing::Test
 {
-protected:
-    ~CrystalTest();
 };
-
-CrystalTest::~CrystalTest() = default;
 
 TEST_F(CrystalTest, getChildren)
 {

--- a/Tests/UnitTests/Core/Sample/FormFactorBasicTest.cpp
+++ b/Tests/UnitTests/Core/Sample/FormFactorBasicTest.cpp
@@ -7,7 +7,6 @@
 class FormFactorBasicTest : public ::testing::Test
 {
 protected:
-    ~FormFactorBasicTest();
     void test_eps_q(const IFormFactorBorn* p, cvector_t qdir, double eps)
     {
         cvector_t q = eps * qdir;
@@ -64,8 +63,6 @@ protected:
     }
     double V, R;
 };
-
-FormFactorBasicTest::~FormFactorBasicTest() = default;
 
 TEST_F(FormFactorBasicTest, AnisoPyramid)
 {

--- a/Tests/UnitTests/Core/Sample/FormFactorCoherentSumTest.cpp
+++ b/Tests/UnitTests/Core/Sample/FormFactorCoherentSumTest.cpp
@@ -5,11 +5,7 @@
 
 class FormFactorCoherentSumTest : public ::testing::Test
 {
-protected:
-    ~FormFactorCoherentSumTest();
 };
-
-FormFactorCoherentSumTest::~FormFactorCoherentSumTest() = default;
 
 TEST_F(FormFactorCoherentSumTest, RelAbundance)
 {

--- a/Tests/UnitTests/Core/Sample/FormFactorSoftParticleTest.cpp
+++ b/Tests/UnitTests/Core/Sample/FormFactorSoftParticleTest.cpp
@@ -4,11 +4,7 @@
 
 class FormFactorSoftParticleTest : public ::testing::Test
 {
-protected:
-    ~FormFactorSoftParticleTest();
 };
-
-FormFactorSoftParticleTest::~FormFactorSoftParticleTest() = default;
 
 TEST_F(FormFactorSoftParticleTest, FormFactorOrnsteinZernike)
 {

--- a/Tests/UnitTests/Core/Sample/INodeTest.cpp
+++ b/Tests/UnitTests/Core/Sample/INodeTest.cpp
@@ -16,8 +16,6 @@ const double test_par1_value(1.0);
 class INodeTest : public ::testing::Test
 {
 public:
-    ~INodeTest();
-
     class TestClass : public INode
     {
     public:
@@ -50,8 +48,6 @@ public:
         double m_parameter1;
     };
 };
-
-INodeTest::~INodeTest() = default;
 
 TEST_F(INodeTest, initialState)
 {

--- a/Tests/UnitTests/Core/Sample/Lattice2DTest.cpp
+++ b/Tests/UnitTests/Core/Sample/Lattice2DTest.cpp
@@ -4,11 +4,7 @@
 
 class Lattice2DTest : public ::testing::Test
 {
-protected:
-    ~Lattice2DTest();
 };
-
-Lattice2DTest::~Lattice2DTest() = default;
 
 TEST_F(Lattice2DTest, basicLattice)
 {

--- a/Tests/UnitTests/Core/Sample/LatticeTest.cpp
+++ b/Tests/UnitTests/Core/Sample/LatticeTest.cpp
@@ -5,11 +5,7 @@
 
 class LatticeTest : public ::testing::Test
 {
-protected:
-    ~LatticeTest();
 };
-
-LatticeTest::~LatticeTest() = default;
 
 // tests the declaration of Lattice object, copy constructor and the getBasisVector_() functions
 TEST_F(LatticeTest, declarationTest)

--- a/Tests/UnitTests/Core/Sample/LatticeUtilsTest.cpp
+++ b/Tests/UnitTests/Core/Sample/LatticeUtilsTest.cpp
@@ -4,11 +4,7 @@
 
 class LatticeUtilsTest : public ::testing::Test
 {
-protected:
-    ~LatticeUtilsTest();
 };
-
-LatticeUtilsTest::~LatticeUtilsTest() = default;
 
 // tests the creation of an FCC lattice with the primitive cube aligned along the q-axes
 TEST_F(LatticeUtilsTest, cubeAlignedFCCTest)

--- a/Tests/UnitTests/Core/Sample/LayerInterfaceTest.cpp
+++ b/Tests/UnitTests/Core/Sample/LayerInterfaceTest.cpp
@@ -8,11 +8,7 @@
 
 class LayerInterfaceTest : public ::testing::Test
 {
-protected:
-    ~LayerInterfaceTest();
 };
-
-LayerInterfaceTest::~LayerInterfaceTest() = default;
 
 TEST_F(LayerInterfaceTest, createSmoothInterface)
 {

--- a/Tests/UnitTests/Core/Sample/LayerRoughnessTest.cpp
+++ b/Tests/UnitTests/Core/Sample/LayerRoughnessTest.cpp
@@ -5,11 +5,7 @@
 
 class LayerRoughnessTest : public ::testing::Test
 {
-protected:
-    ~LayerRoughnessTest();
 };
-
-LayerRoughnessTest::~LayerRoughnessTest() = default;
 
 TEST_F(LayerRoughnessTest, LayerRoughnessInitial)
 {

--- a/Tests/UnitTests/Core/Sample/LayerTest.cpp
+++ b/Tests/UnitTests/Core/Sample/LayerTest.cpp
@@ -6,11 +6,7 @@
 
 class LayerTest : public ::testing::Test
 {
-protected:
-    virtual ~LayerTest();
 };
-
-LayerTest::~LayerTest() = default;
 
 TEST_F(LayerTest, LayerGetAndSet)
 {

--- a/Tests/UnitTests/Core/Sample/MesoCrystalTest.cpp
+++ b/Tests/UnitTests/Core/Sample/MesoCrystalTest.cpp
@@ -8,11 +8,7 @@
 
 class MesoCrystalTest : public ::testing::Test
 {
-protected:
-    ~MesoCrystalTest();
 };
-
-MesoCrystalTest::~MesoCrystalTest() = default;
 
 TEST_F(MesoCrystalTest, getChildren)
 {

--- a/Tests/UnitTests/Core/Sample/MultiLayerTest.cpp
+++ b/Tests/UnitTests/Core/Sample/MultiLayerTest.cpp
@@ -35,14 +35,10 @@ protected:
         mLayer.addLayer(substrate);
     }
 
-    ~MultiLayerTest();
-
     MultiLayer mLayer;
     const Material air, iron, chromium, stone;
     Layer topLayer, layer1, layer2, substrate;
 };
-
-MultiLayerTest::~MultiLayerTest() = default;
 
 TEST_F(MultiLayerTest, BasicProperty)
 {

--- a/Tests/UnitTests/Core/Sample/MultilayerAveragingTest.cpp
+++ b/Tests/UnitTests/Core/Sample/MultilayerAveragingTest.cpp
@@ -20,12 +20,8 @@ protected:
     {
     }
 
-    ~MultilayerAveragingTest() override;
-
     const Material vacuum, stone;
 };
-
-MultilayerAveragingTest::~MultilayerAveragingTest() = default;
 
 TEST_F(MultilayerAveragingTest, AverageMultilayer)
 {

--- a/Tests/UnitTests/Core/Sample/ParticleCompositionTest.cpp
+++ b/Tests/UnitTests/Core/Sample/ParticleCompositionTest.cpp
@@ -8,11 +8,7 @@
 
 class ParticleCompositionTest : public ::testing::Test
 {
-protected:
-    ~ParticleCompositionTest();
 };
-
-ParticleCompositionTest::~ParticleCompositionTest() = default;
 
 TEST_F(ParticleCompositionTest, ParticleCompositionDefaultConstructor)
 {

--- a/Tests/UnitTests/Core/SimulationElement/DepthProbeElementTest.cpp
+++ b/Tests/UnitTests/Core/SimulationElement/DepthProbeElementTest.cpp
@@ -4,9 +4,6 @@
 
 class DepthProbeElementTest : public ::testing::Test
 {
-public:
-    ~DepthProbeElementTest();
-
 protected:
     DepthProbeElementTest();
     DepthProbeElement createDefaultElement();
@@ -15,8 +12,6 @@ protected:
 
     std::unique_ptr<FixedBinAxis> m_z_positions;
 };
-
-DepthProbeElementTest::~DepthProbeElementTest() = default;
 
 DepthProbeElementTest::DepthProbeElementTest() : m_z_positions(new FixedBinAxis("z", 10, 0.0, 10.0))
 {

--- a/Tests/UnitTests/Core/SimulationElement/PolarizationHandlerTest.cpp
+++ b/Tests/UnitTests/Core/SimulationElement/PolarizationHandlerTest.cpp
@@ -6,7 +6,6 @@ class PolarizationHandlerTest : public ::testing::Test
 {
 protected:
     PolarizationHandlerTest();
-    ~PolarizationHandlerTest();
 
     Eigen::Matrix2cd identity;
     Eigen::Matrix2cd test_matrix;
@@ -19,8 +18,6 @@ PolarizationHandlerTest::PolarizationHandlerTest()
     : identity(Eigen::Matrix2cd::Identity()), test_matrix(testMatrix())
 {
 }
-
-PolarizationHandlerTest::~PolarizationHandlerTest() = default;
 
 Eigen::Matrix2cd PolarizationHandlerTest::testMatrix()
 {

--- a/Tests/UnitTests/Core/SimulationElement/SimulationElementTest.cpp
+++ b/Tests/UnitTests/Core/SimulationElement/SimulationElementTest.cpp
@@ -17,8 +17,6 @@ const double phi_i = 0.0 * Units::deg;
 class SimulationElementTest : public ::testing::Test
 {
 public:
-    ~SimulationElementTest();
-
     std::unique_ptr<IPixel> createPixel() const
     {
         return std::make_unique<SphericalPixel>(alpha_bin, phi_bin);
@@ -29,8 +27,6 @@ public:
         return std::make_unique<SimulationElement>(wavelength, alpha_i, phi_i, createPixel());
     }
 };
-
-SimulationElementTest::~SimulationElementTest() = default;
 
 TEST_F(SimulationElementTest, basicConstructor)
 {

--- a/Tests/UnitTests/Fit/AttLimitsTest.cpp
+++ b/Tests/UnitTests/Fit/AttLimitsTest.cpp
@@ -3,11 +3,7 @@
 
 class AttLimitsTest : public ::testing::Test
 {
-protected:
-    ~AttLimitsTest();
 };
-
-AttLimitsTest::~AttLimitsTest() = default;
 
 TEST_F(AttLimitsTest, InitialState)
 {

--- a/Tests/UnitTests/Fit/MinimizerOptionsTest.cpp
+++ b/Tests/UnitTests/Fit/MinimizerOptionsTest.cpp
@@ -4,11 +4,7 @@
 
 class MinimizerOptionsTest : public ::testing::Test
 {
-protected:
-    ~MinimizerOptionsTest();
 };
-
-MinimizerOptionsTest::~MinimizerOptionsTest() = default;
 
 TEST_F(MinimizerOptionsTest, toOptionString)
 {

--- a/Tests/UnitTests/Fit/MultiOptionTest.cpp
+++ b/Tests/UnitTests/Fit/MultiOptionTest.cpp
@@ -4,11 +4,7 @@
 
 class MultiOptionTest : public ::testing::Test
 {
-protected:
-    ~MultiOptionTest();
 };
-
-MultiOptionTest::~MultiOptionTest() = default;
 
 TEST_F(MultiOptionTest, Variant)
 {

--- a/Tests/UnitTests/Fit/OptionContainerTest.cpp
+++ b/Tests/UnitTests/Fit/OptionContainerTest.cpp
@@ -4,11 +4,7 @@
 
 class OptionContainerTest : public ::testing::Test
 {
-protected:
-    ~OptionContainerTest();
 };
-
-OptionContainerTest::~OptionContainerTest() = default;
 
 TEST_F(OptionContainerTest, addOption)
 {

--- a/Tests/UnitTests/Fit/ParameterTest.cpp
+++ b/Tests/UnitTests/Fit/ParameterTest.cpp
@@ -4,11 +4,7 @@
 
 class ParameterTest : public ::testing::Test
 {
-protected:
-    ~ParameterTest();
 };
-
-ParameterTest::~ParameterTest() = default;
 
 TEST_F(ParameterTest, defaultConstructor)
 {

--- a/Tests/UnitTests/Fit/ParametersTest.cpp
+++ b/Tests/UnitTests/Fit/ParametersTest.cpp
@@ -4,11 +4,7 @@
 
 class ParametersTest : public ::testing::Test
 {
-protected:
-    ~ParametersTest();
 };
-
-ParametersTest::~ParametersTest() = default;
 
 TEST_F(ParametersTest, defaultConstructor)
 {

--- a/Tests/UnitTests/Fit/RealLimitsTest.cpp
+++ b/Tests/UnitTests/Fit/RealLimitsTest.cpp
@@ -4,11 +4,7 @@
 
 class RealLimitsTest : public ::testing::Test
 {
-protected:
-    ~RealLimitsTest();
 };
-
-RealLimitsTest::~RealLimitsTest() = default;
 
 TEST_F(RealLimitsTest, LimitsInitial)
 {

--- a/Tests/UnitTests/Fit/StringUtilsTest.cpp
+++ b/Tests/UnitTests/Fit/StringUtilsTest.cpp
@@ -3,11 +3,7 @@
 
 class StringUtilsTest : public ::testing::Test
 {
-protected:
-    ~StringUtilsTest();
 };
-
-StringUtilsTest::~StringUtilsTest() = default;
 
 TEST_F(StringUtilsTest, removeSubstring)
 {

--- a/Tests/UnitTests/GUI/TestAxesItems.cpp
+++ b/Tests/UnitTests/GUI/TestAxesItems.cpp
@@ -9,11 +9,7 @@
 
 class TestAxesItems : public ::testing::Test
 {
-public:
-    ~TestAxesItems();
 };
-
-TestAxesItems::~TestAxesItems() = default;
 
 TEST_F(TestAxesItems, transformFromDomain)
 {

--- a/Tests/UnitTests/GUI/TestComboProperty.cpp
+++ b/Tests/UnitTests/GUI/TestComboProperty.cpp
@@ -6,14 +6,11 @@
 class TestComboProperty : public ::testing::Test
 {
 public:
-    ~TestComboProperty();
     ComboProperty propertyFromXML(const QString& buffer)
     {
         return TestUtils::propertyFromXML<ComboProperty>(buffer);
     }
 };
-
-TestComboProperty::~TestComboProperty() = default;
 
 TEST_F(TestComboProperty, initialState)
 {

--- a/Tests/UnitTests/GUI/TestComponentProxyModel.cpp
+++ b/Tests/UnitTests/GUI/TestComponentProxyModel.cpp
@@ -16,11 +16,7 @@
 
 class TestComponentProxyModel : public ::testing::Test
 {
-public:
-    ~TestComponentProxyModel();
 };
-
-TestComponentProxyModel::~TestComponentProxyModel() = default;
 
 //! Empty proxy model.
 

--- a/Tests/UnitTests/GUI/TestComponentUtils.cpp
+++ b/Tests/UnitTests/GUI/TestComponentUtils.cpp
@@ -9,11 +9,7 @@
 
 class TestComponentUtils : public ::testing::Test
 {
-public:
-    ~TestComponentUtils();
 };
-
-TestComponentUtils::~TestComponentUtils() = default;
 
 //! Testing component items of particle item.
 

--- a/Tests/UnitTests/GUI/TestCsvImportAssistant.cpp
+++ b/Tests/UnitTests/GUI/TestCsvImportAssistant.cpp
@@ -11,8 +11,6 @@
 class TestCsvImportAssistant : public ::testing::Test
 {
 protected:
-    ~TestCsvImportAssistant();
-
     const std::string m_testFilename = "tmp_TestCsvImportAssistant.txt";
     const std::vector<std::vector<double>> m_testVector = {
         {0.0, 1.0, 2.0, 3.0},     {4.0, 5.0, 6.0, 7.0},     {8.0, 9.0, 10.0, 11.0},
@@ -49,8 +47,6 @@ protected:
         return data;
     }
 };
-
-TestCsvImportAssistant::~TestCsvImportAssistant() = default;
 
 //! Testing component items of particle item.
 TEST_F(TestCsvImportAssistant, test_readFile)

--- a/Tests/UnitTests/GUI/TestCsvImportData.cpp
+++ b/Tests/UnitTests/GUI/TestCsvImportData.cpp
@@ -3,11 +3,7 @@
 
 class TestCsvImportData : public ::testing::Test
 {
-public:
-    ~TestCsvImportData() override;
 };
-
-TestCsvImportData::~TestCsvImportData() = default;
 
 TEST_F(TestCsvImportData, test_setting_data)
 {

--- a/Tests/UnitTests/GUI/TestDataItemViews.cpp
+++ b/Tests/UnitTests/GUI/TestDataItemViews.cpp
@@ -14,12 +14,8 @@
 class TestDataItemViews : public ::testing::Test
 {
 public:
-    ~TestDataItemViews();
-
     DataItem* insertNewDataItem(SessionModel& model, double val);
 };
-
-TestDataItemViews::~TestDataItemViews() = default;
 
 DataItem* TestDataItemViews::insertNewDataItem(SessionModel& model, double val)
 {

--- a/Tests/UnitTests/GUI/TestDataItems.cpp
+++ b/Tests/UnitTests/GUI/TestDataItems.cpp
@@ -6,12 +6,8 @@
 class TestDataItems : public ::testing::Test
 {
 public:
-    ~TestDataItems();
-
     void testItemClock(QString type);
 };
-
-TestDataItems::~TestDataItems() = default;
 
 void TestDataItems::testItemClock(QString model_type)
 {

--- a/Tests/UnitTests/GUI/TestDetectorItems.cpp
+++ b/Tests/UnitTests/GUI/TestDetectorItems.cpp
@@ -11,11 +11,7 @@
 
 class TestDetectorItems : public ::testing::Test
 {
-public:
-    ~TestDetectorItems();
 };
-
-TestDetectorItems::~TestDetectorItems() = default;
 
 TEST_F(TestDetectorItems, test_detectorAlignment)
 {

--- a/Tests/UnitTests/GUI/TestExternalProperty.cpp
+++ b/Tests/UnitTests/GUI/TestExternalProperty.cpp
@@ -6,14 +6,11 @@
 class TestExternalProperty : public ::testing::Test
 {
 public:
-    ~TestExternalProperty();
     ExternalProperty propertyFromXML(const QString& buffer)
     {
         return TestUtils::propertyFromXML<ExternalProperty>(buffer);
     }
 };
-
-TestExternalProperty::~TestExternalProperty() = default;
 
 TEST_F(TestExternalProperty, test_initialState)
 {

--- a/Tests/UnitTests/GUI/TestFTDistributionItems.cpp
+++ b/Tests/UnitTests/GUI/TestFTDistributionItems.cpp
@@ -4,11 +4,7 @@
 
 class TestFTDistributionItems : public ::testing::Test
 {
-public:
-    ~TestFTDistributionItems();
 };
-
-TestFTDistributionItems::~TestFTDistributionItems() = default;
 
 TEST_F(TestFTDistributionItems, test_FTDistribution1DCauchy)
 {

--- a/Tests/UnitTests/GUI/TestFitParameterModel.cpp
+++ b/Tests/UnitTests/GUI/TestFitParameterModel.cpp
@@ -6,11 +6,7 @@
 
 class TestFitParameterModel : public ::testing::Test
 {
-public:
-    ~TestFitParameterModel();
 };
-
-TestFitParameterModel::~TestFitParameterModel() = default;
 
 TEST_F(TestFitParameterModel, test_InitialState)
 {

--- a/Tests/UnitTests/GUI/TestFormFactorItems.cpp
+++ b/Tests/UnitTests/GUI/TestFormFactorItems.cpp
@@ -6,11 +6,7 @@
 
 class TestFormFactorItems : public ::testing::Test
 {
-public:
-    ~TestFormFactorItems();
 };
-
-TestFormFactorItems::~TestFormFactorItems() = default;
 
 TEST_F(TestFormFactorItems, test_AnisoPyramidItem)
 {

--- a/Tests/UnitTests/GUI/TestGUICoreObjectCorrespondence.cpp
+++ b/Tests/UnitTests/GUI/TestGUICoreObjectCorrespondence.cpp
@@ -9,8 +9,6 @@
 class TestGUICoreObjectCorrespondence : public ::testing::Test
 {
 public:
-    ~TestGUICoreObjectCorrespondence();
-
     void GUICoreObjectCorrespondence(const SessionItem& gui_object,
                                      const IParameterized& core_object)
     {
@@ -24,8 +22,6 @@ public:
         }
     }
 };
-
-TestGUICoreObjectCorrespondence::~TestGUICoreObjectCorrespondence() = default;
 
 TEST_F(TestGUICoreObjectCorrespondence, test_AnisoPyramid)
 {

--- a/Tests/UnitTests/GUI/TestGUIHelpers.cpp
+++ b/Tests/UnitTests/GUI/TestGUIHelpers.cpp
@@ -3,11 +3,7 @@
 
 class TestGUIHelpers : public ::testing::Test
 {
-public:
-    ~TestGUIHelpers();
 };
-
-TestGUIHelpers::~TestGUIHelpers() = default;
 
 TEST_F(TestGUIHelpers, test_VersionString)
 {

--- a/Tests/UnitTests/GUI/TestGroupItem.cpp
+++ b/Tests/UnitTests/GUI/TestGroupItem.cpp
@@ -9,11 +9,7 @@
 
 class TestGroupItem : public ::testing::Test
 {
-public:
-    ~TestGroupItem();
 };
-
-TestGroupItem::~TestGroupItem() = default;
 
 TEST_F(TestGroupItem, test_groupInfo)
 {

--- a/Tests/UnitTests/GUI/TestLayerItems.cpp
+++ b/Tests/UnitTests/GUI/TestLayerItems.cpp
@@ -9,11 +9,7 @@
 
 class TestLayerItems : public ::testing::Test
 {
-public:
-    ~TestLayerItems();
 };
-
-TestLayerItems::~TestLayerItems() = default;
 
 //! Checking default material of the layer.
 

--- a/Tests/UnitTests/GUI/TestLayerRoughnessItems.cpp
+++ b/Tests/UnitTests/GUI/TestLayerRoughnessItems.cpp
@@ -6,11 +6,7 @@
 
 class TestLayerRoughnessItems : public ::testing::Test
 {
-public:
-    ~TestLayerRoughnessItems();
 };
-
-TestLayerRoughnessItems::~TestLayerRoughnessItems() = default;
 
 TEST_F(TestLayerRoughnessItems, test_LayerRoughnessToDomain)
 {

--- a/Tests/UnitTests/GUI/TestLinkInstrument.cpp
+++ b/Tests/UnitTests/GUI/TestLinkInstrument.cpp
@@ -14,11 +14,7 @@
 
 class TestLinkInstrument : public ::testing::Test
 {
-public:
-    ~TestLinkInstrument();
 };
-
-TestLinkInstrument::~TestLinkInstrument() = default;
 
 //! Checks that LinkInstrumentManager listens instrument model.
 

--- a/Tests/UnitTests/GUI/TestMapperCases.cpp
+++ b/Tests/UnitTests/GUI/TestMapperCases.cpp
@@ -12,11 +12,7 @@ using SessionItemUtils::ParentRow;
 
 class TestMapperCases : public ::testing::Test
 {
-public:
-    ~TestMapperCases();
 };
-
-TestMapperCases::~TestMapperCases() = default;
 
 TEST_F(TestMapperCases, test_ParticeleCompositionUpdate)
 {

--- a/Tests/UnitTests/GUI/TestMaterialModel.cpp
+++ b/Tests/UnitTests/GUI/TestMaterialModel.cpp
@@ -7,11 +7,7 @@
 
 class TestMaterialModel : public ::testing::Test
 {
-public:
-    ~TestMaterialModel();
 };
-
-TestMaterialModel::~TestMaterialModel() = default;
 
 TEST_F(TestMaterialModel, addRefractiveMaterial)
 {

--- a/Tests/UnitTests/GUI/TestMaterialPropertyController.cpp
+++ b/Tests/UnitTests/GUI/TestMaterialPropertyController.cpp
@@ -10,11 +10,7 @@
 
 class TestMaterialPropertyController : public ::testing::Test
 {
-public:
-    ~TestMaterialPropertyController();
 };
-
-TestMaterialPropertyController::~TestMaterialPropertyController() = default;
 
 // TEST_F(TestMaterialPropertyController, test_ControllerForLayer)
 //{

--- a/Tests/UnitTests/GUI/TestMessageService.cpp
+++ b/Tests/UnitTests/GUI/TestMessageService.cpp
@@ -24,18 +24,12 @@ const QString description3("description3");
 class TestMessageService : public ::testing::Test
 {
 public:
-    ~TestMessageService();
-
     class Sender : public QObject
     {
     public:
         Sender(const QString& name) { setObjectName(name); }
-        ~Sender();
     };
 };
-
-TestMessageService::~TestMessageService() = default;
-TestMessageService::Sender::~Sender() = default;
 
 TEST_F(TestMessageService, guiMessage)
 {

--- a/Tests/UnitTests/GUI/TestModelUtils.cpp
+++ b/Tests/UnitTests/GUI/TestModelUtils.cpp
@@ -9,8 +9,6 @@
 class TestModelUtils : public ::testing::Test
 {
 public:
-    ~TestModelUtils();
-
     //! Returns true if model contains given item using iterate_if procedure.
     bool modelContainsItem(SessionModel* model, SessionItem* selectedItem)
     {
@@ -24,8 +22,6 @@ public:
         return result;
     }
 };
-
-TestModelUtils::~TestModelUtils() = default;
 
 //! Testing top item names.
 

--- a/Tests/UnitTests/GUI/TestMultiLayerItem.cpp
+++ b/Tests/UnitTests/GUI/TestMultiLayerItem.cpp
@@ -6,11 +6,7 @@
 
 class TestMultiLayerItem : public ::testing::Test
 {
-public:
-    ~TestMultiLayerItem();
 };
-
-TestMultiLayerItem::~TestMultiLayerItem() = default;
 
 //! Testing layer appearance (enabled, disabled) in a MultiLayer made of two default layers.
 //!

--- a/Tests/UnitTests/GUI/TestOutputDataIOService.cpp
+++ b/Tests/UnitTests/GUI/TestOutputDataIOService.cpp
@@ -20,11 +20,8 @@
 
 class TestOutputDataIOService : public ::testing::Test
 {
-public:
-    TestOutputDataIOService();
-    ~TestOutputDataIOService();
-
 protected:
+    TestOutputDataIOService();
     OutputData<double> m_data;
 };
 
@@ -35,8 +32,6 @@ TestOutputDataIOService::TestOutputDataIOService()
     m_data.addAxis(axis0);
     m_data.addAxis(axis1);
 }
-
-TestOutputDataIOService::~TestOutputDataIOService() = default;
 
 //! Test methods for retrieving nonXML data.
 

--- a/Tests/UnitTests/GUI/TestParaCrystalItems.cpp
+++ b/Tests/UnitTests/GUI/TestParaCrystalItems.cpp
@@ -13,11 +13,7 @@
 
 class TestParaCrystalItems : public ::testing::Test
 {
-public:
-    ~TestParaCrystalItems();
 };
-
-TestParaCrystalItems::~TestParaCrystalItems() = default;
 
 TEST_F(TestParaCrystalItems, test_Para2D_fromToDomain)
 {

--- a/Tests/UnitTests/GUI/TestParameterTreeUtils.cpp
+++ b/Tests/UnitTests/GUI/TestParameterTreeUtils.cpp
@@ -21,11 +21,7 @@ const QStringList expectedParticleParameterTranslations = {
 
 class TestParameterTreeUtils : public ::testing::Test
 {
-public:
-    ~TestParameterTreeUtils();
 };
-
-TestParameterTreeUtils::~TestParameterTreeUtils() = default;
 
 //! Tests parameter names of given item.
 

--- a/Tests/UnitTests/GUI/TestParticleCoreShell.cpp
+++ b/Tests/UnitTests/GUI/TestParticleCoreShell.cpp
@@ -12,11 +12,7 @@ using namespace SessionItemUtils;
 
 class TestParticleCoreShell : public ::testing::Test
 {
-public:
-    ~TestParticleCoreShell();
 };
-
-TestParticleCoreShell::~TestParticleCoreShell() = default;
 
 TEST_F(TestParticleCoreShell, test_moveCoreAndShell)
 {

--- a/Tests/UnitTests/GUI/TestParticleDistributionItem.cpp
+++ b/Tests/UnitTests/GUI/TestParticleDistributionItem.cpp
@@ -35,11 +35,7 @@ const QStringList expectedBoxParams = {"None",
 
 class TestParticleDistributionItem : public ::testing::Test
 {
-public:
-    ~TestParticleDistributionItem();
 };
-
-TestParticleDistributionItem::~TestParticleDistributionItem() = default;
 
 TEST_F(TestParticleDistributionItem, test_InitialState)
 {

--- a/Tests/UnitTests/GUI/TestParticleItem.cpp
+++ b/Tests/UnitTests/GUI/TestParticleItem.cpp
@@ -11,11 +11,7 @@ using namespace SessionItemUtils;
 
 class TestParticleItem : public ::testing::Test
 {
-public:
-    ~TestParticleItem();
 };
-
-TestParticleItem::~TestParticleItem() = default;
 
 TEST_F(TestParticleItem, test_InitialState)
 {

--- a/Tests/UnitTests/GUI/TestParticleLayoutItem.h
+++ b/Tests/UnitTests/GUI/TestParticleLayoutItem.h
@@ -8,11 +8,7 @@
 
 class TestParticleLayoutItem : public ::testing::Test
 {
-public:
-    ~TestParticleLayoutItem();
 };
-
-TestParticleLayoutItem::~TestParticleLayoutItem() = default;
 
 using namespace SessionItemUtils;
 

--- a/Tests/UnitTests/GUI/TestProjectDocument.cpp
+++ b/Tests/UnitTests/GUI/TestProjectDocument.cpp
@@ -15,9 +15,7 @@
 
 class TestProjectDocument : public ::testing::Test
 {
-public:
-    ~TestProjectDocument();
-
+protected:
     //! helper method to modify something in a model
     void modify_models(ApplicationModels* models)
     {
@@ -25,8 +23,6 @@ public:
         instrument->setItemValue(InstrumentItem::P_IDENTIFIER, GUIHelpers::createUuid());
     }
 };
-
-TestProjectDocument::~TestProjectDocument() = default;
 
 TEST_F(TestProjectDocument, test_documentFlags)
 {

--- a/Tests/UnitTests/GUI/TestProjectUtils.cpp
+++ b/Tests/UnitTests/GUI/TestProjectUtils.cpp
@@ -12,9 +12,7 @@ const QString& projectDir = "test_ProjectUtils";
 
 class TestProjectUtils : public ::testing::Test
 {
-public:
-    ~TestProjectUtils();
-
+protected:
     //! Helper function to create test file in a given directory (directory should exist).
     void createTestFile(const QString& dirname, const QString& fileName)
     {
@@ -30,8 +28,6 @@ public:
         file.close();
     }
 };
-
-TestProjectUtils::~TestProjectUtils() = default;
 
 TEST_F(TestProjectUtils, test_basicFileOperations)
 {

--- a/Tests/UnitTests/GUI/TestPropertyRepeater.cpp
+++ b/Tests/UnitTests/GUI/TestPropertyRepeater.cpp
@@ -21,11 +21,7 @@ BasicAxisItem* createAxis(SessionModel& model)
 
 class TestPropertyRepeater : public ::testing::Test
 {
-public:
-    ~TestPropertyRepeater();
 };
-
-TestPropertyRepeater::~TestPropertyRepeater() = default;
 
 //! Repeater handles two items.
 

--- a/Tests/UnitTests/GUI/TestProxyModelStrategy.cpp
+++ b/Tests/UnitTests/GUI/TestProxyModelStrategy.cpp
@@ -11,11 +11,7 @@
 
 class TestProxyModelStrategy : public ::testing::Test
 {
-public:
-    ~TestProxyModelStrategy();
 };
-
-TestProxyModelStrategy::~TestProxyModelStrategy() = default;
 
 //! Checking the mapping in the case of PropertyItem inserted in the source.
 

--- a/Tests/UnitTests/GUI/TestRealSpaceBuilderUtils.cpp
+++ b/Tests/UnitTests/GUI/TestRealSpaceBuilderUtils.cpp
@@ -20,11 +20,7 @@
 
 class TestRealSpaceBuilderUtils : public ::testing::Test
 {
-public:
-    ~TestRealSpaceBuilderUtils();
 };
-
-TestRealSpaceBuilderUtils::~TestRealSpaceBuilderUtils() = default;
 
 TEST_F(TestRealSpaceBuilderUtils, test_RealSpaceModelandParticle)
 {

--- a/Tests/UnitTests/GUI/TestSaveService.cpp
+++ b/Tests/UnitTests/GUI/TestSaveService.cpp
@@ -17,8 +17,6 @@
 class TestSaveService : public ::testing::Test
 {
 protected:
-    ~TestSaveService();
-
     // helper method to modify something in a model
     void modify_models(ApplicationModels* models)
     {
@@ -27,8 +25,6 @@ protected:
     }
     const int m_save_wait = 10000;
 };
-
-TestSaveService::~TestSaveService() = default;
 
 //! Testing AutosaveController. It watches ProjectDocument and sends autosaveRequest() when
 //! number of document changes has been accumulated.

--- a/Tests/UnitTests/GUI/TestSavingSpecularData.cpp
+++ b/Tests/UnitTests/GUI/TestSavingSpecularData.cpp
@@ -23,7 +23,6 @@ class TestSavingSpecularData : public ::testing::Test
 {
 public:
     TestSavingSpecularData();
-    ~TestSavingSpecularData();
 
 protected:
     SpecularInstrumentItem* createSpecularInstrument(ApplicationModels& models);
@@ -38,8 +37,6 @@ TestSavingSpecularData::TestSavingSpecularData()
     : m_axis(new PointwiseAxis("x", std::vector<double>{0.1, 0.2, 1.0}))
 {
 }
-
-TestSavingSpecularData::~TestSavingSpecularData() = default;
 
 SpecularInstrumentItem* TestSavingSpecularData::createSpecularInstrument(ApplicationModels& models)
 {

--- a/Tests/UnitTests/GUI/TestScientificSpinBox.cpp
+++ b/Tests/UnitTests/GUI/TestScientificSpinBox.cpp
@@ -4,14 +4,7 @@
 
 class TestScientificSpinBox : public ::testing::Test
 {
-public:
-    TestScientificSpinBox();
-    ~TestScientificSpinBox() override;
 };
-
-TestScientificSpinBox::TestScientificSpinBox() {}
-
-TestScientificSpinBox::~TestScientificSpinBox() = default;
 
 TEST_F(TestScientificSpinBox, testValueFromText)
 {

--- a/Tests/UnitTests/GUI/TestSessionItem.cpp
+++ b/Tests/UnitTests/GUI/TestSessionItem.cpp
@@ -5,11 +5,7 @@
 
 class TestSessionItem : public ::testing::Test
 {
-public:
-    ~TestSessionItem();
 };
-
-TestSessionItem::~TestSessionItem() = default;
 
 TEST_F(TestSessionItem, initialState)
 {

--- a/Tests/UnitTests/GUI/TestSessionItemController.cpp
+++ b/Tests/UnitTests/GUI/TestSessionItemController.cpp
@@ -7,11 +7,7 @@
 
 class TestSessionItemController : public ::testing::Test
 {
-public:
-    ~TestSessionItemController();
 };
-
-TestSessionItemController::~TestSessionItemController() = default;
 
 //! Testing helper classes which will be used for controller testing.
 

--- a/Tests/UnitTests/GUI/TestSessionItemData.cpp
+++ b/Tests/UnitTests/GUI/TestSessionItemData.cpp
@@ -5,11 +5,7 @@
 
 class TestSessionItemData : public ::testing::Test
 {
-public:
-    ~TestSessionItemData();
 };
-
-TestSessionItemData::~TestSessionItemData() = default;
 
 TEST_F(TestSessionItemData, initialState)
 {

--- a/Tests/UnitTests/GUI/TestSessionItemTags.cpp
+++ b/Tests/UnitTests/GUI/TestSessionItemTags.cpp
@@ -5,11 +5,7 @@
 
 class TestSessionItemTags : public ::testing::Test
 {
-public:
-    ~TestSessionItemTags();
 };
-
-TestSessionItemTags::~TestSessionItemTags() = default;
 
 TEST_F(TestSessionItemTags, initialState)
 {

--- a/Tests/UnitTests/GUI/TestSessionItemUtils.cpp
+++ b/Tests/UnitTests/GUI/TestSessionItemUtils.cpp
@@ -9,11 +9,7 @@
 
 class TestSessionItemUtils : public ::testing::Test
 {
-public:
-    ~TestSessionItemUtils();
 };
-
-TestSessionItemUtils::~TestSessionItemUtils() = default;
 
 //! Test SessionItemUtils::ParentVisibleRow utility method.
 

--- a/Tests/UnitTests/GUI/TestSessionModel.cpp
+++ b/Tests/UnitTests/GUI/TestSessionModel.cpp
@@ -13,11 +13,7 @@
 
 class TestSessionModel : public ::testing::Test
 {
-public:
-    ~TestSessionModel();
 };
-
-TestSessionModel::~TestSessionModel() = default;
 
 //! Testing SessionModel::setData notifications.
 

--- a/Tests/UnitTests/GUI/TestSessionXML.cpp
+++ b/Tests/UnitTests/GUI/TestSessionXML.cpp
@@ -26,11 +26,7 @@ void itemFromXML(QString buffer, SessionItem* item)
 
 class TestSessionXML : public ::testing::Test
 {
-public:
-    ~TestSessionXML();
 };
-
-TestSessionXML::~TestSessionXML() = default;
 
 //! Testing to/from xml: simple property item.
 

--- a/Tests/UnitTests/GUI/TestTranslations.cpp
+++ b/Tests/UnitTests/GUI/TestTranslations.cpp
@@ -12,11 +12,7 @@
 
 class TestTranslations : public ::testing::Test
 {
-public:
-    ~TestTranslations();
 };
-
-TestTranslations::~TestTranslations() = default;
 
 TEST_F(TestTranslations, test_TranslatePosition)
 {

--- a/Tests/UnitTests/GUI/TestUpdateTimer.cpp
+++ b/Tests/UnitTests/GUI/TestUpdateTimer.cpp
@@ -4,11 +4,7 @@
 
 class TestUpdateTimer : public ::testing::Test
 {
-public:
-    ~TestUpdateTimer();
 };
-
-TestUpdateTimer::~TestUpdateTimer() = default;
 
 TEST_F(TestUpdateTimer, test_updateTimerShort)
 {


### PR DESCRIPTION
Remove explicit code for destructors, and some constructors, that are automatically defined by modern C++.
Also unpointerize a few objects.

This saves us 400 LOC.

