### PR TITLE
CI: Win: Download libcerf1.13.mingw64.zip, which includes mingw64

### DIFF
--- a/.github/workflows/ba-windows.yml
+++ b/.github/workflows/ba-windows.yml
@@ -60,7 +60,7 @@ jobs:
         mkdir deps
         Get-Date -Format G
         wget http://apps.jcns.fz-juelich.de/src/WinLibs/libboost1.65.win64.zip -O ${{runner.temp}}\libboost.zip
-        wget http://apps.jcns.fz-juelich.de/src/WinLibs/libcerf1.13.win64.zip -O ${{runner.temp}}\libcerf.zip
+        wget http://apps.jcns.fz-juelich.de/src/WinLibs/libcerf1.13.mingw64.zip -O ${{runner.temp}}\libcerf.zip
         wget http://apps.jcns.fz-juelich.de/src/WinLibs/libfftw3.win64.zip -O ${{runner.temp}}\libfftw.zip
         wget http://apps.jcns.fz-juelich.de/src/WinLibs/libgsl-static.win64.zip -O ${{runner.temp}}\libgsl.zip
         wget http://apps.jcns.fz-juelich.de/src/WinLibs/libtiff.win64.zip -O ${{runner.temp}}\libtiff.zip


### PR DESCRIPTION
runtime libraries