### PR TITLE
Small changes in scalar Fresnel computation + Bugfix

### DIFF
--- a/Core/Multilayer/SpecularScalarStrategy.h
+++ b/Core/Multilayer/SpecularScalarStrategy.h
@@ -51,9 +51,9 @@ private:
 
     static void setZeroBelow(std::vector<ScalarRTCoefficients>& coeff, size_t current_layer);
 
-    bool calculateUpFromLayer(std::vector<ScalarRTCoefficients>& coeff,
-                              const std::vector<Slice>& slices, const std::vector<complex_t>& kz,
-                              size_t slice_index) const;
+    void calculateUpFromLayer(std::vector<ScalarRTCoefficients>& coeff,
+                              const std::vector<Slice>& slices,
+                              const std::vector<complex_t>& kz) const;
 };
 
 #endif // BORNAGAIN_CORE_MULTILAYER_SPECULARSCALARSTRATEGY_H

--- a/Tests/UnitTests/Core/Sample/RTTest.cpp
+++ b/Tests/UnitTests/Core/Sample/RTTest.cpp
@@ -30,11 +30,11 @@ protected:
         EXPECT_NEAR(coeff1.t_r(1).real(), coeff2.t_r(1).real(), 1e-10);
         EXPECT_NEAR(coeff1.t_r(1).imag(), coeff2.t_r(1).imag(), 1e-10);
     }
-    std::vector<ScalarRTCoefficients> getCoeffs(SpecularScalarTanhStrategy::coeffs_t&& inputCoeffs)
+    std::vector<ScalarRTCoefficients> getCoeffs(ISpecularStrategy::coeffs_t&& inputCoeffs)
     {
         std::vector<ScalarRTCoefficients> result;
         for (auto& coeff : inputCoeffs)
-            result.push_back(*dynamic_cast<const ScalarRTCoefficients*>(coeff.get()));
+            result.push_back(*dynamic_cast<const ScalarRTCoefficients*>(coeff.release()));
 
         return result;
     }

--- a/Tests/UnitTests/Core/Sample/RTTest.cpp
+++ b/Tests/UnitTests/Core/Sample/RTTest.cpp
@@ -34,7 +34,7 @@ protected:
     {
         std::vector<ScalarRTCoefficients> result;
         for (auto& coeff : inputCoeffs)
-            result.push_back(*dynamic_cast<const ScalarRTCoefficients*>(coeff.release()));
+            result.push_back(*dynamic_cast<const ScalarRTCoefficients*>(coeff.get()));
 
         return result;
     }


### PR DESCRIPTION
This PR fixes an ugly use-after-free in RTTest.
Furthermore some cleanup of unused variables in the scalar Fresnel kernel is done and the use of indices is changed such that it is a bit easier readable and consistent with the upcoming polarized engine.