### PR TITLE
Stabilized existing implementation of magnetic Fresnel computation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ project(BornAgain
      # TODO modernize FindCerf to get rid of AssertLibraryFunction to restore restriction to CXX
 
 set(CMAKE_C_STANDARD 11)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 14)
 
 include(CTest) # equivalent to "enable_testing() ???
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -LE Fullcheck)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ project(BornAgain
      # TODO modernize FindCerf to get rid of AssertLibraryFunction to restore restriction to CXX
 
 set(CMAKE_C_STANDARD 11)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 include(CTest) # equivalent to "enable_testing() ???
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -LE Fullcheck)

--- a/Core/Basics/Complex.h
+++ b/Core/Basics/Complex.h
@@ -17,7 +17,8 @@
 
 #include <complex>
 
-typedef std::complex<double> complex_t;
+using complex_t = std::complex<double>;
+constexpr complex_t I = complex_t(0.0, 1.0);
 
 //! Returns product I*z, where I is the imaginary unit.
 inline complex_t mul_I(complex_t z)

--- a/Core/Computation/SpecularComputationTerm.cpp
+++ b/Core/Computation/SpecularComputationTerm.cpp
@@ -69,7 +69,7 @@ void SpecularMatrixTerm::eval(SpecularSimulationElement& elem,
 }
 
 double SpecularMatrixTerm::intensity(const SpecularSimulationElement& elem,
-                                     ISpecularStrategy::single_coeff_t& coeff) const
+                                     const ISpecularStrategy::coefficient_pointer_type& coeff) const
 {
     const auto& polarization = elem.polarizationHandler().getPolarization();
     const auto& analyzer = elem.polarizationHandler().getAnalyzerOperator();

--- a/Core/Computation/SpecularComputationTerm.cpp
+++ b/Core/Computation/SpecularComputationTerm.cpp
@@ -74,10 +74,7 @@ double SpecularMatrixTerm::intensity(const SpecularSimulationElement& elem,
     const auto& polarization = elem.polarizationHandler().getPolarization();
     const auto& analyzer = elem.polarizationHandler().getAnalyzerOperator();
 
-    // constructing reflection operator
-    Eigen::Matrix2cd R;
-    R.col(0) = coeff->R1plus() + coeff->R2plus();
-    R.col(1) = coeff->R1min() + coeff->R2min();
+    auto R = coeff->getReflectionMatrix();
 
     const complex_t result = (polarization * R.adjoint() * analyzer * R).trace();
 

--- a/Core/Computation/SpecularComputationTerm.h
+++ b/Core/Computation/SpecularComputationTerm.h
@@ -85,7 +85,7 @@ private:
 protected:
     void eval(SpecularSimulationElement& elem, const std::vector<Slice>& slices) const override;
     double intensity(const SpecularSimulationElement& elem,
-                     ISpecularStrategy::single_coeff_t& coeff) const;
+                     const ISpecularStrategy::coefficient_pointer_type& coeff) const;
 };
 
 #endif // BORNAGAIN_CORE_COMPUTATION_SPECULARCOMPUTATIONTERM_H

--- a/Core/HardParticle/FormFactorPolyhedron.cpp
+++ b/Core/HardParticle/FormFactorPolyhedron.cpp
@@ -26,7 +26,6 @@
 
 namespace
 {
-const complex_t I = {0., 1.};
 const double eps = 2e-16;
 constexpr auto ReciprocalFactorialArray = Precomputed::GenerateReciprocalFactorialArray<171>();
 } // namespace

--- a/Core/HardParticle/FormFactorTruncatedSpheroid.cpp
+++ b/Core/HardParticle/FormFactorTruncatedSpheroid.cpp
@@ -70,7 +70,7 @@ complex_t FormFactorTruncatedSpheroid::Integrand(double Z) const
     complex_t qrRz = std::sqrt(m_q.x() * m_q.x() + m_q.y() * m_q.y()) * Rz;
     complex_t J1_qrRz_div_qrRz = MathFunctions::Bessel_J1c(qrRz);
 
-    return Rz * Rz * J1_qrRz_div_qrRz * std::exp(complex_t(0.0, 1.0) * m_q.z() * Z);
+    return Rz * Rz * J1_qrRz_div_qrRz * std::exp(I * m_q.z() * Z);
 }
 
 complex_t FormFactorTruncatedSpheroid::evaluate_for_q(cvector_t q) const
@@ -82,7 +82,7 @@ complex_t FormFactorTruncatedSpheroid::evaluate_for_q(cvector_t q) const
 
     if (std::abs(m_q.mag()) <= std::numeric_limits<double>::epsilon())
         return M_PI / 3. / fp * (H * H * (3. * R - H / fp) - m_dh * m_dh * (3. * R - m_dh / fp));
-    complex_t z_part = std::exp(complex_t(0.0, 1.0) * m_q.z() * (H - fp * R));
+    complex_t z_part = std::exp(I * m_q.z() * (H - fp * R));
     return M_TWOPI * z_part
            * ComplexIntegrator().integrate([&](double Z) { return Integrand(Z); }, fp * R - H,
                                            fp * R - m_dh);

--- a/Core/HardParticle/FormFactorTruncatedSpheroid.cpp
+++ b/Core/HardParticle/FormFactorTruncatedSpheroid.cpp
@@ -70,7 +70,7 @@ complex_t FormFactorTruncatedSpheroid::Integrand(double Z) const
     complex_t qrRz = std::sqrt(m_q.x() * m_q.x() + m_q.y() * m_q.y()) * Rz;
     complex_t J1_qrRz_div_qrRz = MathFunctions::Bessel_J1c(qrRz);
 
-    return Rz * Rz * J1_qrRz_div_qrRz * std::exp(I * m_q.z() * Z);
+    return Rz * Rz * J1_qrRz_div_qrRz * exp_I(m_q.z() * Z);
 }
 
 complex_t FormFactorTruncatedSpheroid::evaluate_for_q(cvector_t q) const
@@ -82,7 +82,7 @@ complex_t FormFactorTruncatedSpheroid::evaluate_for_q(cvector_t q) const
 
     if (std::abs(m_q.mag()) <= std::numeric_limits<double>::epsilon())
         return M_PI / 3. / fp * (H * H * (3. * R - H / fp) - m_dh * m_dh * (3. * R - m_dh / fp));
-    complex_t z_part = std::exp(I * m_q.z() * (H - fp * R));
+    complex_t z_part = exp_I(m_q.z() * (H - fp * R));
     return M_TWOPI * z_part
            * ComplexIntegrator().integrate([&](double Z) { return Integrand(Z); }, fp * R - H,
                                            fp * R - m_dh);

--- a/Core/HardParticle/Ripples.cpp
+++ b/Core/HardParticle/Ripples.cpp
@@ -60,7 +60,7 @@ complex_t ripples::profile_yz_cosine(complex_t qy, complex_t qz, double width, d
 
     // numerical integration otherwise
     const complex_t ay = qy * width / M_TWOPI;
-    const complex_t az = complex_t(0, 1) * qz * (height / 2);
+    const complex_t az = I * qz * (height / 2);
 
     const auto integrand = [&](double u) -> complex_t {
         return sin(u) * exp(az * std::cos(u)) * (ay == 0. ? u : sin(ay * u) / ay);

--- a/Core/HardParticle/Ripples.cpp
+++ b/Core/HardParticle/Ripples.cpp
@@ -60,13 +60,13 @@ complex_t ripples::profile_yz_cosine(complex_t qy, complex_t qz, double width, d
 
     // numerical integration otherwise
     const complex_t ay = qy * width / M_TWOPI;
-    const complex_t az = I * qz * (height / 2);
+    const complex_t az = qz * (height / 2);
 
     const auto integrand = [&](double u) -> complex_t {
-        return sin(u) * exp(az * std::cos(u)) * (ay == 0. ? u : sin(ay * u) / ay);
+        return sin(u) * exp_I(az * std::cos(u)) * (ay == 0. ? u : sin(ay * u) / ay);
     };
     complex_t integral = ComplexIntegrator().integrate(integrand, 0, M_PI);
-    return factor * integral * exp(az) * (height / 2);
+    return factor * integral * exp_I(az) * (height / 2);
 }
 
 //! Complex form factor of triangular ripple.

--- a/Core/Material/MaterialUtils.cpp
+++ b/Core/Material/MaterialUtils.cpp
@@ -29,8 +29,6 @@ const Eigen::Matrix2cd Unit_Matrix(Eigen::Matrix2cd::Identity());
 // Imaginary unit
 namespace
 {
-const complex_t I(0, 1);
-
 // Pauli matrices
 const Eigen::Matrix2cd Pauli_X((Eigen::Matrix2cd() << 0, 1, 1, 0).finished());
 const Eigen::Matrix2cd Pauli_Y((Eigen::Matrix2cd() << 0, -I, I, 0).finished());

--- a/Core/Multilayer/ISpecularStrategy.h
+++ b/Core/Multilayer/ISpecularStrategy.h
@@ -29,8 +29,13 @@ class BA_CORE_API_ ISpecularStrategy
 {
 public:
     virtual ~ISpecularStrategy() = default;
-    using single_coeff_t = std::unique_ptr<const ILayerRTCoefficients>;
-    using coeffs_t = std::vector<single_coeff_t>;
+    ISpecularStrategy() = default;
+    ISpecularStrategy& operator=(const ISpecularStrategy& other) = delete;
+    ISpecularStrategy(const ISpecularStrategy& other) = delete;
+
+    using coefficient_type         = ILayerRTCoefficients;
+    using coefficient_pointer_type = std::unique_ptr<const coefficient_type>;
+    using coeffs_t = std::vector<coefficient_pointer_type>;
 
     virtual coeffs_t Execute(const std::vector<Slice>& slices, const kvector_t& k) const = 0;
 

--- a/Core/Multilayer/MatrixFresnelMap.cpp
+++ b/Core/Multilayer/MatrixFresnelMap.cpp
@@ -61,10 +61,10 @@ MatrixFresnelMap::getCoefficients(const kvector_t& kvec, size_t layer_index,
 {
     if (!m_use_cache) {
         auto coeffs = m_Strategy->Execute(slices, kvec);
-        return ISpecularStrategy::single_coeff_t(coeffs[layer_index]->clone());
+        return ISpecularStrategy::coefficient_pointer_type(coeffs[layer_index]->clone());
     }
     const auto& coef_vector = getCoefficientsFromCache(kvec, slices, hash_table);
-    return ISpecularStrategy::single_coeff_t(coef_vector[layer_index]->clone());
+    return ISpecularStrategy::coefficient_pointer_type(coef_vector[layer_index]->clone());
 }
 
 const ISpecularStrategy::coeffs_t&

--- a/Core/Multilayer/ScalarFresnelMap.cpp
+++ b/Core/Multilayer/ScalarFresnelMap.cpp
@@ -44,10 +44,10 @@ ScalarFresnelMap::getCoefficients(const kvector_t& kvec, size_t layer_index) con
 {
     if (!m_use_cache) {
         auto coeffs = m_Strategy->Execute(m_slices, kvec);
-        return ISpecularStrategy::single_coeff_t(coeffs[layer_index]->clone());
+        return ISpecularStrategy::coefficient_pointer_type(coeffs[layer_index]->clone());
     }
     const auto& coef_vector = getCoefficientsFromCache(kvec);
-    return ISpecularStrategy::single_coeff_t(coef_vector[layer_index]->clone());
+    return ISpecularStrategy::coefficient_pointer_type(coef_vector[layer_index]->clone());
 }
 
 const ISpecularStrategy::coeffs_t& ScalarFresnelMap::getCoefficientsFromCache(kvector_t kvec) const

--- a/Core/Multilayer/SpecularMagneticOldStrategy.cpp
+++ b/Core/Multilayer/SpecularMagneticOldStrategy.cpp
@@ -28,7 +28,6 @@ void CalculateTransferAndBoundary(const std::vector<Slice>& slices,
                                   std::vector<MatrixRTCoefficients>& coeff);
 void SetForNoTransmission(std::vector<MatrixRTCoefficients>& coeff);
 complex_t GetImExponential(complex_t exponent);
-const complex_t I(0, 1);
 } // namespace
 
 ISpecularStrategy::coeffs_t SpecularMagneticOldStrategy::Execute(const std::vector<Slice>& slices,

--- a/Core/Multilayer/SpecularMagneticStrategy.cpp
+++ b/Core/Multilayer/SpecularMagneticStrategy.cpp
@@ -27,7 +27,6 @@ complex_t GetImExponential(complex_t exponent);
 // The factor 1e-18 is here to have unit: 1/T*nm^-2
 constexpr double magnetic_prefactor = PhysConsts::m_n * PhysConsts::g_factor_n * PhysConsts::mu_N
                                       / PhysConsts::h_bar / PhysConsts::h_bar * 1e-18;
-constexpr complex_t I(0.0, 1.0);
 } // namespace
 
 ISpecularStrategy::coeffs_t SpecularMagneticStrategy::Execute(const std::vector<Slice>& slices,

--- a/Core/Multilayer/SpecularMagneticStrategy.cpp
+++ b/Core/Multilayer/SpecularMagneticStrategy.cpp
@@ -194,7 +194,9 @@ void SpecularMagneticStrategy::propagateBackwardsForwards(
         coeff[i].m_w_min = l * coeff[i + 1].m_w_min;
 
         // rotate and normalize polarization
-        const auto [S, norm] = findNormalizationCoefficients(coeff[i]);
+        const auto Snorm = findNormalizationCoefficients(coeff[i]);
+        auto S = Snorm.first;
+        auto norm = Snorm.second;
 
         SMatrices[i] = S;
         Normalization[i] = norm;

--- a/Core/Multilayer/SpecularMagneticStrategy.h
+++ b/Core/Multilayer/SpecularMagneticStrategy.h
@@ -33,9 +33,9 @@ class Slice;
 class BA_CORE_API_ SpecularMagneticStrategy : public ISpecularStrategy
 {
 public:
-    using coefficient_type         = MatrixRTCoefficients_v2;
+    using coefficient_type = MatrixRTCoefficients_v2;
     using coefficient_pointer_type = std::unique_ptr<const coefficient_type>;
-    using coeffs_t                 = std::vector<coefficient_pointer_type>;
+    using coeffs_t = std::vector<coefficient_pointer_type>;
 
     //! Computes refraction angle reflection/transmission coefficients
     //! for given sliced multilayer and wavevector k
@@ -61,18 +61,16 @@ private:
 
     //! Propagates boundary conditions from the bottom to the top of the layer stack.
     //! Used to compute boundary conditions from the bottom one (with nullified reflection)
-    static void propagateBackwards(std::vector<MatrixRTCoefficients_v2>& coeff,
-                                   const std::vector<Slice>& slices);
+    //! simultaneously propagates amplitudes forward again
+    //! Due to the use of temporary objects this is combined into one function now
+    static void propagateBackwardsForwards(std::vector<MatrixRTCoefficients_v2>& coeff,
+                                           const std::vector<Slice>& slices);
 
     //! finds linear coefficients for normalizing transmitted wave to unity.
     //! The left column of the returned matrix corresponds to the coefficients for pure spin-up
     //! wave, while the right column - to the coefficients for the spin-down one.
-    static Eigen::Matrix2cd findNormalizationCoefficients(const MatrixRTCoefficients_v2& coeff);
-
-    //! makes a linear combination of boundary conditions with using the given weights for each
-    //! coefficient in the vector.
-    static void propagateForwards(std::vector<MatrixRTCoefficients_v2>& coeff,
-                                  const Eigen::Matrix2cd& weights);
+    static std::pair<Eigen::Matrix2cd, complex_t>
+    findNormalizationCoefficients(const MatrixRTCoefficients_v2& coeff);
 };
 
 #endif // BORNAGAIN_CORE_MULTILAYER_SPECULARMAGNETICSTRATEGY_H

--- a/Core/Multilayer/SpecularMagneticStrategy.h
+++ b/Core/Multilayer/SpecularMagneticStrategy.h
@@ -33,6 +33,10 @@ class Slice;
 class BA_CORE_API_ SpecularMagneticStrategy : public ISpecularStrategy
 {
 public:
+    using coefficient_type         = MatrixRTCoefficients_v2;
+    using coefficient_pointer_type = std::unique_ptr<const coefficient_type>;
+    using coeffs_t                 = std::vector<coefficient_pointer_type>;
+
     //! Computes refraction angle reflection/transmission coefficients
     //! for given sliced multilayer and wavevector k
     ISpecularStrategy::coeffs_t Execute(const std::vector<Slice>& slices, const kvector_t& k) const;
@@ -42,6 +46,7 @@ public:
     ISpecularStrategy::coeffs_t Execute(const std::vector<Slice>& slices,
                                         const std::vector<complex_t>& kz) const;
 
+private:
     static std::vector<MatrixRTCoefficients_v2> computeTR(const std::vector<Slice>& slices,
                                                           const std::vector<complex_t>& kzs);
 

--- a/Core/Multilayer/SpecularScalarStrategy.h
+++ b/Core/Multilayer/SpecularScalarStrategy.h
@@ -34,6 +34,10 @@ class Slice;
 class BA_CORE_API_ SpecularScalarStrategy : public ISpecularStrategy
 {
 public:
+    using coefficient_type         = ScalarRTCoefficients;
+    using coefficient_pointer_type = std::unique_ptr<const coefficient_type>;
+    using coeffs_t = std::vector<coefficient_pointer_type>;
+
     //! Computes refraction angles and transmission/reflection coefficients
     //! for given coherent wave propagation in a multilayer.
     virtual ISpecularStrategy::coeffs_t Execute(const std::vector<Slice>& slices,

--- a/Core/RT/ILayerRTCoefficients.h
+++ b/Core/RT/ILayerRTCoefficients.h
@@ -60,6 +60,11 @@ public:
         throw Exceptions::NotImplementedException("ILayerRTCoefficients::"
                                                   "getScalarKz(): coefficients are not scalar.");
     }
+
+    virtual Eigen::Matrix2cd getReflectionMatrix() const
+    {
+        throw Exceptions::NotImplementedException("Only defined for Matrix coefficeints");
+    }
 };
 
 #endif // BORNAGAIN_CORE_RT_ILAYERRTCOEFFICIENTS_H

--- a/Core/RT/MatrixRTCoefficients_v2.cpp
+++ b/Core/RT/MatrixRTCoefficients_v2.cpp
@@ -102,6 +102,15 @@ Eigen::Vector2cd MatrixRTCoefficients_v2::getKz() const
     return -I * m_kz_sign * m_lambda;
 }
 
+Eigen::Matrix2cd MatrixRTCoefficients_v2::getReflectionMatrix() const
+{
+    Eigen::Matrix2cd R;
+    R.col(0) = R1plus() + R2plus();
+    R.col(1) = R1min() + R2min();
+
+    return R;
+}
+
 namespace
 {
 Eigen::Vector2cd waveVector(const Eigen::Matrix4cd& frob_matrix,

--- a/Core/RT/MatrixRTCoefficients_v2.cpp
+++ b/Core/RT/MatrixRTCoefficients_v2.cpp
@@ -18,8 +18,6 @@ namespace
 {
 Eigen::Vector2cd waveVector(const Eigen::Matrix4cd& frob_matrix,
                             const Eigen::Vector4cd& boundary_cond);
-
-constexpr complex_t I = complex_t(0.0, 1.0);
 } // namespace
 
 MatrixRTCoefficients_v2::MatrixRTCoefficients_v2(double kz_sign, Eigen::Vector2cd eigenvalues,

--- a/Core/RT/MatrixRTCoefficients_v2.h
+++ b/Core/RT/MatrixRTCoefficients_v2.h
@@ -27,7 +27,6 @@ class BA_CORE_API_ MatrixRTCoefficients_v2 : public ILayerRTCoefficients
 {
 public:
     friend class SpecularMagneticStrategy;
-    friend class SpecularMagnetic_v3ConsistencyTest_ScalarMagneticAmplitudes_Test;
 
     MatrixRTCoefficients_v2(double kz_sign, Eigen::Vector2cd eigenvalues, kvector_t b);
     MatrixRTCoefficients_v2(const MatrixRTCoefficients_v2& other);

--- a/Core/RT/MatrixRTCoefficients_v2.h
+++ b/Core/RT/MatrixRTCoefficients_v2.h
@@ -27,6 +27,7 @@ class BA_CORE_API_ MatrixRTCoefficients_v2 : public ILayerRTCoefficients
 {
 public:
     friend class SpecularMagneticStrategy;
+    friend class SpecularMagnetic_v3ConsistencyTest_ScalarMagneticAmplitudes_Test;
 
     MatrixRTCoefficients_v2(double kz_sign, Eigen::Vector2cd eigenvalues, kvector_t b);
     MatrixRTCoefficients_v2(const MatrixRTCoefficients_v2& other);
@@ -46,6 +47,8 @@ public:
     Eigen::Vector2cd R2min() const override;
     //! Returns z-part of the two wavevector eigenmodes
     Eigen::Vector2cd getKz() const override;
+
+    Eigen::Matrix2cd getReflectionMatrix() const override;
 
 private:
     double m_kz_sign; //! wave propagation direction (-1 for direct one, 1 for time reverse)

--- a/Tests/UnitTests/Core/Axes/CVectorTest.cpp
+++ b/Tests/UnitTests/Core/Axes/CVectorTest.cpp
@@ -37,6 +37,6 @@ TEST_F(CVectorTest, BasicArithmetics)
     // f = f_re + j*f_im
     cvector_t vec_e(1., 2., 3.);
     cvector_t vec_f(5., 6., 7.);
-    EXPECT_EQ(vec_e + complex_t(0, 1) * vec_f,
+    EXPECT_EQ(vec_e + I * vec_f,
               cvector_t(complex_t(1., 5.), complex_t(2., 6), complex_t(3, 7)));
 }


### PR DESCRIPTION
This PR provides an enhanced numerical stability of the existing implementation of the polarized Fresnel computation. This method is unchanged and as described in the document theory/polarizedSpecular. 
The modification applied in the last commit is described in Section 4 of that document. 
With these changes, the numerical precision is enhanced for samples with more than a few layers as long as all the the layers are not too thick. Due to the rotation of the polarization there is still a significant loss of precision if the layer thickness becomes too large.
The first three commits do minor changes, also in preparation of the new polarized computational kernel, that will supersede this implementation. Even though this implementation will likely not be used in the future it still makes sense to update it, in order to facilitate testing of the new implementation, and especially the Fresnel coefficients.

Additional external testing was performed to verify these changes.