### PR TITLE
Python utils: replace obsolete histogram method getArray() by array()

### DIFF
--- a/Examples/python/utils/plot_intensity_data.py
+++ b/Examples/python/utils/plot_intensity_data.py
@@ -27,7 +27,7 @@ def plot_intensity_data(file_name, intensity_max=None):
 
 
 def plot_intensity_data_2d(histogram, intensity_max):
-    plot_raw_data_2d(histogram.getArray(),
+    plot_raw_data_2d(histogram.array(),
                      [histogram.getXmin() / ba.deg, histogram.getXmax() / ba.deg,
                       histogram.getYmin() / ba.deg, histogram.getYmax() / ba.deg],
                      intensity_max)
@@ -47,7 +47,7 @@ def plot_raw_data_2d(values, extent_array, intensity_max):
 
 def plot_intensity_data_1d(histogram, intensity_max):
     axis_values = np.asarray(histogram.getXaxis().getBinCenters()) / ba.deg
-    array_values = histogram.getArray() * intensity_max / histogram.getMaximum()
+    array_values = histogram.array() * intensity_max / histogram.getMaximum()
     plot_raw_data_1d(axis_values, array_values)
 
 

--- a/Examples/python/utils/plot_intensity_data_diff.py
+++ b/Examples/python/utils/plot_intensity_data_diff.py
@@ -13,8 +13,8 @@ import sys
 def plot_intensity_data_diff(filename1, filename2):
     intensity_ref = ba.IntensityDataIOFactory.readIntensityData(filename1)
     intensity_other = ba.IntensityDataIOFactory.readIntensityData(filename2)
-    data = 2 * np.abs(intensity_ref.getArray() - intensity_other.getArray()) \
-           / (np.abs(intensity_ref.getArray()) + np.abs(intensity_other.getArray()))
+    data = 2 * np.abs(intensity_ref.array() - intensity_other.array()) \
+           / (np.abs(intensity_ref.array()) + np.abs(intensity_other.array()))
     if data.max() == 0:
         exit("Both data sets are equal, there is nothing to plot.")
     rank = intensity_ref.getRank()


### PR DESCRIPTION
This eliminates warnings, and thereby resolves #987.

No review needed. Will merge when tests pass.