### PR TITLE
CPack: remove STGZ

### DIFF
--- a/cmake/modules/BornAgainCPack.cmake
+++ b/cmake/modules/BornAgainCPack.cmake
@@ -25,7 +25,7 @@ elseif(APPLE)
 elseif(UNIX AND BUILD_DEBIAN) # one can build debian package only on UNIX system
     include(CPackDebian)
 else()
-  set(CPACK_GENERATOR "STGZ;TGZ")
+  set(CPACK_GENERATOR "TGZ")
 endif()
 
 


### PR DESCRIPTION
STGZ seems to be no longer supported by CMake.
We don't know what it is and why it was there in a first place.

This resolves http://apps.jcns.fz-juelich.de/redmine/issues/2216.