### PR TITLE
Correctly handle kz = 0 and kz -> 0 for polarized computations

### DIFF
--- a/Core/Multilayer/SpecularMagneticNewStrategy.cpp
+++ b/Core/Multilayer/SpecularMagneticNewStrategy.cpp
@@ -82,7 +82,8 @@ SpecularMagneticNewStrategy::computeTR(const std::vector<Slice>& slices,
         result[0].m_T = Eigen::Matrix2cd::Identity();
         result[0].m_R = Eigen::Matrix2cd::Zero();
         return result;
-    }else if(kzs[0] == 0.0){
+
+    }else if( kzs[0] == 0. ){
         result[0].m_T =  Eigen::Matrix2cd::Identity();
         result[0].m_R = -Eigen::Matrix2cd::Identity();
         for (size_t i = 1; i < N; ++i) {

--- a/Core/Multilayer/SpecularMagneticNewStrategy.cpp
+++ b/Core/Multilayer/SpecularMagneticNewStrategy.cpp
@@ -78,13 +78,13 @@ SpecularMagneticNewStrategy::computeTR(const std::vector<Slice>& slices,
                             B.mag() > eps ? B / B.mag() : kvector_t{0.0, 0.0, 0.0}, magnetic_SLD);
     }
 
-    if(N == 1){
+    if (N == 1) {
         result[0].m_T = Eigen::Matrix2cd::Identity();
         result[0].m_R = Eigen::Matrix2cd::Zero();
         return result;
 
-    }else if( kzs[0] == 0. ){
-        result[0].m_T =  Eigen::Matrix2cd::Identity();
+    } else if (kzs[0] == 0.) {
+        result[0].m_T = Eigen::Matrix2cd::Identity();
         result[0].m_R = -Eigen::Matrix2cd::Identity();
         for (size_t i = 1; i < N; ++i) {
             result[i].m_T.setZero();

--- a/Core/Multilayer/SpecularMagneticStrategy.cpp
+++ b/Core/Multilayer/SpecularMagneticStrategy.cpp
@@ -53,7 +53,7 @@ std::vector<MatrixRTCoefficients_v2>
 SpecularMagneticStrategy::computeTR(const std::vector<Slice>& slices,
                                     const std::vector<complex_t>& kzs)
 {
-    if(kzs[0] == 0.)
+    if (kzs[0] == 0.)
         throw std::runtime_error("Edge case k_z = 0 not implemented");
 
     if (slices.size() != kzs.size())

--- a/Core/Multilayer/SpecularMagneticStrategy.cpp
+++ b/Core/Multilayer/SpecularMagneticStrategy.cpp
@@ -53,6 +53,9 @@ std::vector<MatrixRTCoefficients_v2>
 SpecularMagneticStrategy::computeTR(const std::vector<Slice>& slices,
                                     const std::vector<complex_t>& kzs)
 {
+    if(kzs[0] == 0.)
+        throw std::runtime_error("Edge case k_z = 0 not implemented");
+
     if (slices.size() != kzs.size())
         throw std::runtime_error(
             "Error in SpecularMagnetic_::execute: kz vector and slices size shall coinside.");

--- a/Core/RT/MatrixRTCoefficients_v3.cpp
+++ b/Core/RT/MatrixRTCoefficients_v3.cpp
@@ -41,8 +41,7 @@ MatrixRTCoefficients_v3* MatrixRTCoefficients_v3::clone() const
     return new MatrixRTCoefficients_v3(*this);
 }
 
-Eigen::Matrix2cd MatrixRTCoefficients_v3::TransformationMatrix(complex_t eigenvalue,
-                                                               Eigen::Vector2d selection) const
+Eigen::Matrix2cd MatrixRTCoefficients_v3::TransformationMatrix(Eigen::Vector2d selection) const
 {
     const Eigen::Matrix2cd exp2 = Eigen::DiagonalMatrix<complex_t, 2>(selection);
 
@@ -60,12 +59,12 @@ Eigen::Matrix2cd MatrixRTCoefficients_v3::TransformationMatrix(complex_t eigenva
 
 Eigen::Matrix2cd MatrixRTCoefficients_v3::T1Matrix() const
 {
-    return TransformationMatrix(m_lambda(1), {0., 1.});
+    return TransformationMatrix({0., 1.});
 }
 
 Eigen::Matrix2cd MatrixRTCoefficients_v3::T2Matrix() const
 {
-    return TransformationMatrix(m_lambda(0), {1., 0.});
+    return TransformationMatrix({1., 0.});
 }
 
 Eigen::Vector2cd MatrixRTCoefficients_v3::T1plus() const

--- a/Core/RT/MatrixRTCoefficients_v3.cpp
+++ b/Core/RT/MatrixRTCoefficients_v3.cpp
@@ -54,9 +54,9 @@ Eigen::Matrix2cd MatrixRTCoefficients_v3::TransformationMatrix(complex_t eigenva
 
     } else if (m_b.mag() < eps && eigenvalue != 0.)
         return exp2;
-    //        result = Eigen::Matrix2cd(Eigen::DiagonalMatrix<complex_t, 2>({0.5, 0.5}));
+
     else if (m_b.mag() < eps && eigenvalue == 0.)
-        return Eigen::Matrix2cd(Eigen::DiagonalMatrix<complex_t, 2>({0.5, 0.5}));
+        return exp2;
 
     throw std::runtime_error("Broken magnetic field vector");
 }
@@ -145,7 +145,8 @@ Eigen::Matrix2cd MatrixRTCoefficients_v3::computeInverseP() const
     const complex_t beta = m_lambda(1) - m_lambda(0);
 
     if (std::abs(alpha * alpha - beta * beta) < eps)
-        throw std::runtime_error("Singular p_m");
+//        throw std::runtime_error("Singular p_m");
+        return Eigen::Matrix2cd::Zero();
 
     Eigen::Matrix2cd result = pMatrixHelper(-1.);
     result *= 2. / (alpha * alpha - beta * beta);

--- a/Core/RT/MatrixRTCoefficients_v3.cpp
+++ b/Core/RT/MatrixRTCoefficients_v3.cpp
@@ -52,10 +52,7 @@ Eigen::Matrix2cd MatrixRTCoefficients_v3::TransformationMatrix(complex_t eigenva
         Q << (1. + m_b.z()), (I * m_b.y() - m_b.x()), (m_b.x() + I * m_b.y()), (m_b.z() + 1.);
         return Q * exp2 * Q.adjoint() / factor1;
 
-    } else if (m_b.mag() < eps && eigenvalue != 0.)
-        return exp2;
-
-    else if (m_b.mag() < eps && eigenvalue == 0.)
+    } else if (m_b.mag() < eps)
         return exp2;
 
     throw std::runtime_error("Broken magnetic field vector");

--- a/Core/RT/MatrixRTCoefficients_v3.cpp
+++ b/Core/RT/MatrixRTCoefficients_v3.cpp
@@ -144,8 +144,7 @@ Eigen::Matrix2cd MatrixRTCoefficients_v3::computeInverseP() const
     const complex_t alpha = m_lambda(1) + m_lambda(0);
     const complex_t beta = m_lambda(1) - m_lambda(0);
 
-    if (std::abs(alpha * alpha - beta * beta) < eps)
-//        throw std::runtime_error("Singular p_m");
+    if (std::abs(alpha * alpha - beta * beta) == 0.)
         return Eigen::Matrix2cd::Zero();
 
     Eigen::Matrix2cd result = pMatrixHelper(-1.);

--- a/Core/RT/MatrixRTCoefficients_v3.h
+++ b/Core/RT/MatrixRTCoefficients_v3.h
@@ -74,7 +74,7 @@ private:
     Eigen::Matrix2cd m_R;
 
     // helper functions to compute DWBA compatible amplitudes used in the T1plus() etc. functions
-    Eigen::Matrix2cd TransformationMatrix(complex_t eigenvalue, Eigen::Vector2d selection) const;
+    Eigen::Matrix2cd TransformationMatrix(Eigen::Vector2d selection) const;
     Eigen::Matrix2cd T1Matrix() const;
     Eigen::Matrix2cd T2Matrix() const;
 

--- a/Core/RT/MatrixRTCoefficients_v3.h
+++ b/Core/RT/MatrixRTCoefficients_v3.h
@@ -33,8 +33,7 @@ public:
     friend class SpecularMagnetic_v3ConsistencyTest;
     friend class SpecularMagnetic_v3ConsistencyTest_ScalarMagneticAmplitudes_Test;
     friend class SpecularMagnetic_v3ConsistencyTest_AmplitudesBackwardsBackwards_Test;
-    template<class sampleClass>
-    friend class TestSimulation;
+    template <class sampleClass> friend class TestSimulation;
 
     MatrixRTCoefficients_v3(double kz_sign, Eigen::Vector2cd eigenvalues, kvector_t b,
                             double magnetic_SLD);
@@ -55,14 +54,14 @@ public:
     Eigen::Vector2cd R2min() const override;
     //! Returns z-part of the two wavevector eigenmodes
     Eigen::Vector2cd getKz() const override;
-    double magneticSLD() const {return m_magnetic_SLD;}
+    double magneticSLD() const { return m_magnetic_SLD; }
 
     Eigen::Matrix2cd computeP() const;
     Eigen::Matrix2cd computeInverseP() const;
 
     Eigen::Matrix2cd computeDeltaMatrix(double thickness);
 
-    Eigen::Matrix2cd getReflectionMatrix() const override {return m_R;};
+    Eigen::Matrix2cd getReflectionMatrix() const override { return m_R; };
 
 private:
     double m_kz_sign; //! wave propagation direction (-1 for direct one, 1 for time reverse)

--- a/Tests/GTestWrapper/google_test.h
+++ b/Tests/GTestWrapper/google_test.h
@@ -16,4 +16,12 @@
 
 #include <memory>
 
+#define EXPECT_NEAR_COMPLEX(z1, z2, eps) \
+    EXPECT_NEAR(z1.real(), z2.real(), eps); \
+    EXPECT_NEAR(z1.imag(), z2.imag(), eps);
+
+#define EXPECT_NEAR_VECTOR2CD(v1, v2, eps) \
+    EXPECT_NEAR_COMPLEX(v1(0), v2(0), eps); \
+    EXPECT_NEAR_COMPLEX(v1(1), v2(1), eps);
+
 #endif // BORNAGAIN_TESTS_GTESTWRAPPER_GOOGLE_TEST_H

--- a/Tests/GTestWrapper/google_test.h
+++ b/Tests/GTestWrapper/google_test.h
@@ -16,12 +16,12 @@
 
 #include <memory>
 
-#define EXPECT_NEAR_COMPLEX(z1, z2, eps) \
-    EXPECT_NEAR(z1.real(), z2.real(), eps); \
+#define EXPECT_NEAR_COMPLEX(z1, z2, eps)                                                           \
+    EXPECT_NEAR(z1.real(), z2.real(), eps);                                                        \
     EXPECT_NEAR(z1.imag(), z2.imag(), eps);
 
-#define EXPECT_NEAR_VECTOR2CD(v1, v2, eps) \
-    EXPECT_NEAR_COMPLEX(v1(0), v2(0), eps); \
+#define EXPECT_NEAR_VECTOR2CD(v1, v2, eps)                                                         \
+    EXPECT_NEAR_COMPLEX(v1(0), v2(0), eps);                                                        \
     EXPECT_NEAR_COMPLEX(v1(1), v2(1), eps);
 
 #endif // BORNAGAIN_TESTS_GTESTWRAPPER_GOOGLE_TEST_H

--- a/Tests/UnitTests/Core/Fresnel/MatrixRTCoefficients_v3Test.cpp
+++ b/Tests/UnitTests/Core/Fresnel/MatrixRTCoefficients_v3Test.cpp
@@ -10,7 +10,7 @@ protected:
 TEST_F(MatrixRTCoefficients_v3Test, T1plus)
 {
     Eigen::Vector2cd vector = mrtcDefault.T1plus();
-    EXPECT_EQ(complex_t(0.5, 0.0), vector(0));
+    EXPECT_EQ(0.0, vector(0));
     EXPECT_EQ(0.0, vector(1));
 }
 
@@ -18,13 +18,13 @@ TEST_F(MatrixRTCoefficients_v3Test, T1min)
 {
     Eigen::Vector2cd vector = mrtcDefault.T1min();
     EXPECT_EQ(0.0, vector(0));
-    EXPECT_EQ(complex_t(0.5, 0.0), vector(1));
+    EXPECT_EQ(complex_t(1.0, 0.0), vector(1));
 }
 
 TEST_F(MatrixRTCoefficients_v3Test, T2plus)
 {
     Eigen::Vector2cd vector = mrtcDefault.T2plus();
-    EXPECT_EQ(complex_t(0.5, 0.0), vector(0));
+    EXPECT_EQ(complex_t(1.0, 0.0), vector(0));
     EXPECT_EQ(0.0, vector(1));
 }
 
@@ -32,13 +32,13 @@ TEST_F(MatrixRTCoefficients_v3Test, T2min)
 {
     Eigen::Vector2cd vector = mrtcDefault.T2min();
     EXPECT_EQ(0.0, vector(0));
-    EXPECT_EQ(complex_t(0.5, 0.0), vector(1));
+    EXPECT_EQ(0.0, vector(1));
 }
 
 TEST_F(MatrixRTCoefficients_v3Test, R1plus)
 {
     Eigen::Vector2cd vector = mrtcDefault.R1plus();
-    EXPECT_EQ(complex_t(-0.5, 0.0), vector(0));
+    EXPECT_EQ(0.0, vector(0));
     EXPECT_EQ(0.0, vector(1));
 }
 
@@ -46,13 +46,13 @@ TEST_F(MatrixRTCoefficients_v3Test, R1min)
 {
     Eigen::Vector2cd vector = mrtcDefault.R1min();
     EXPECT_EQ(0.0, vector(0));
-    EXPECT_EQ(complex_t(-0.5, 0.0), vector(1));
+    EXPECT_EQ(complex_t(-1.0, 0.0), vector(1));
 }
 
 TEST_F(MatrixRTCoefficients_v3Test, R2plus)
 {
     Eigen::Vector2cd vector = mrtcDefault.R2plus();
-    EXPECT_EQ(complex_t(-0.5, 0.0), vector(0));
+    EXPECT_EQ(complex_t(-1.0, 0.0), vector(0));
     EXPECT_EQ(0.0, vector(1));
 }
 
@@ -60,7 +60,7 @@ TEST_F(MatrixRTCoefficients_v3Test, R2min)
 {
     Eigen::Vector2cd vector = mrtcDefault.R2min();
     EXPECT_EQ(0.0, vector(0));
-    EXPECT_EQ(complex_t(-0.5, 0.0), vector(1));
+    EXPECT_EQ(0.0, vector(1));
 }
 
 TEST_F(MatrixRTCoefficients_v3Test, getKz)

--- a/Tests/UnitTests/Core/Fresnel/SpecularMagneticTest.cpp
+++ b/Tests/UnitTests/Core/Fresnel/SpecularMagneticTest.cpp
@@ -29,29 +29,6 @@ protected:
     template <typename Strategy> void test_degenerate();
 };
 
-template <typename Strategy> void SpecularMagneticTest::test_degenerate()
-{
-    kvector_t v;
-
-    Eigen::Vector2cd Tp_ref{0.5, 0.0};
-    Eigen::Vector2cd Rp_ref{-0.5, 0.0};
-    Eigen::Vector2cd Tm_ref{0.0, 0.5};
-    Eigen::Vector2cd Rm_ref{0.0, -0.5};
-
-    auto sample = sample_degenerate();
-    auto result = std::make_unique<Strategy>()->Execute(sample->slices(), v);
-    for (auto& coeff : result) {
-        EXPECT_NEAR_VECTOR2CD(coeff->T1plus(), Tp_ref, eps);
-        EXPECT_NEAR_VECTOR2CD(coeff->T2plus(), Tp_ref, eps);
-        EXPECT_NEAR_VECTOR2CD(coeff->T1min(), Tm_ref, eps);
-        EXPECT_NEAR_VECTOR2CD(coeff->T2min(), Tm_ref, eps);
-        EXPECT_NEAR_VECTOR2CD(coeff->R1plus(), Rp_ref, eps);
-        EXPECT_NEAR_VECTOR2CD(coeff->R2plus(), Rp_ref, eps);
-        EXPECT_NEAR_VECTOR2CD(coeff->R1min(), Rm_ref, eps);
-        EXPECT_NEAR_VECTOR2CD(coeff->R2min(), Rm_ref, eps);
-    }
-}
-
 template <> void SpecularMagneticTest::test_degenerate<SpecularMagneticNewTanhStrategy>()
 {
     kvector_t v;
@@ -118,11 +95,6 @@ std::unique_ptr<ProcessedSample> SpecularMagneticTest::sample_degenerate()
     Material air = HomogeneousMaterial("air", 0, 1.0);
     mLayer.addLayer(Layer(air, 0 * Units::nanometer));
     return std::make_unique<ProcessedSample>(mLayer, SimulationOptions());
-}
-
-TEST_F(SpecularMagneticTest, degenerate)
-{
-    test_degenerate<SpecularMagneticStrategy>();
 }
 
 TEST_F(SpecularMagneticTest, degenerate_new)

--- a/Tests/UnitTests/Core/Fresnel/SpecularMagneticTest.cpp
+++ b/Tests/UnitTests/Core/Fresnel/SpecularMagneticTest.cpp
@@ -23,7 +23,7 @@ protected:
     template<typename Strategy>
     void testZeroField(const kvector_t& k, const ProcessedSample& m_layer_scalar,
                        const ProcessedSample& m_layer_zerofield);
-    template<typename Strategy> void testcase_zerofield();
+    template<typename Strategy> void testcase_zerofield(std::vector<double> && angles);
 
     template<typename Strategy>
     void test_degenerate();
@@ -142,25 +142,22 @@ SpecularMagneticTest::sample_zerofield()
 }
 
 template<typename Strategy>
-void SpecularMagneticTest::testcase_zerofield()
+void SpecularMagneticTest::testcase_zerofield(std::vector<double> && angles)
 {
-    kvector_t k1 = vecOfLambdaAlphaPhi(1.0, -0.1 * Units::deg, 0.0);
-    kvector_t k2 = vecOfLambdaAlphaPhi(1.0, -2.0 * Units::deg, 0.0);
-    kvector_t k3 = vecOfLambdaAlphaPhi(1.0, -10.0 * Units::deg, 0.0);
-
-    auto samples = sample_zerofield();
-
-    testZeroField<Strategy>(k1, *std::get<0>(samples), *std::get<1>(samples));
-    testZeroField<Strategy>(k2, *std::get<0>(samples), *std::get<1>(samples));
-    testZeroField<Strategy>(k3, *std::get<0>(samples), *std::get<1>(samples));
+    for(auto & angle : angles)
+    {
+        auto samples = sample_zerofield();
+        kvector_t k = vecOfLambdaAlphaPhi(1.0, angle * Units::deg, 0.0);
+        testZeroField<Strategy>(k, *std::get<0>(samples), *std::get<1>(samples));
+    }
 }
 
 TEST_F(SpecularMagneticTest, zerofield)
 {
-    testcase_zerofield<SpecularMagneticStrategy>();
+    testcase_zerofield<SpecularMagneticStrategy>({-0.1, -2.0, -10.0});
 }
 
 TEST_F(SpecularMagneticTest, zerofield_new)
 {
-    testcase_zerofield<SpecularMagneticNewTanhStrategy>();
+    testcase_zerofield<SpecularMagneticNewTanhStrategy>({-0.0, -0.1, -2.0, -10.0});
 }

--- a/Tests/UnitTests/Core/Fresnel/SpecularMagneticTest.cpp
+++ b/Tests/UnitTests/Core/Fresnel/SpecularMagneticTest.cpp
@@ -3,8 +3,8 @@
 #include "Core/Material/MaterialFactoryFuncs.h"
 #include "Core/Multilayer/Layer.h"
 #include "Core/Multilayer/MultiLayer.h"
-#include "Core/Multilayer/SpecularMagneticStrategy.h"
 #include "Core/Multilayer/SpecularMagneticNewTanhStrategy.h"
+#include "Core/Multilayer/SpecularMagneticStrategy.h"
 #include "Core/Multilayer/SpecularScalarTanhStrategy.h"
 #include "Core/Parametrization/SimulationOptions.h"
 #include "Tests/GTestWrapper/google_test.h"
@@ -20,17 +20,15 @@ protected:
 
     std::unique_ptr<ProcessedSample> sample_degenerate();
     //! Compares results with scalar case
-    template<typename Strategy>
+    template <typename Strategy>
     void testZeroField(const kvector_t& k, const ProcessedSample& m_layer_scalar,
                        const ProcessedSample& m_layer_zerofield);
-    template<typename Strategy> void testcase_zerofield(std::vector<double> && angles);
+    template <typename Strategy> void testcase_zerofield(std::vector<double>&& angles);
 
-    template<typename Strategy>
-    void test_degenerate();
+    template <typename Strategy> void test_degenerate();
 };
 
-template<typename Strategy>
-void SpecularMagneticTest::test_degenerate()
+template <typename Strategy> void SpecularMagneticTest::test_degenerate()
 {
     kvector_t v;
 
@@ -53,15 +51,13 @@ void SpecularMagneticTest::test_degenerate()
     }
 }
 
-template<typename Strategy>
-void SpecularMagneticTest::testZeroField(const kvector_t& k,
-                                         const ProcessedSample& sample_scalar,
+template <typename Strategy>
+void SpecularMagneticTest::testZeroField(const kvector_t& k, const ProcessedSample& sample_scalar,
                                          const ProcessedSample& sample_zerofield)
 {
     auto coeffs_scalar =
         std::make_unique<SpecularScalarTanhStrategy>()->Execute(sample_scalar.slices(), k);
-    auto coeffs_zerofield =
-        std::make_unique<Strategy>()->Execute(sample_zerofield.slices(), k);
+    auto coeffs_zerofield = std::make_unique<Strategy>()->Execute(sample_zerofield.slices(), k);
 
     EXPECT_EQ(coeffs_scalar.size(), coeffs_zerofield.size());
 
@@ -133,11 +129,10 @@ SpecularMagneticTest::sample_zerofield()
     return std::make_pair(std::move(sample_scalar), std::move(sample_zerofield));
 }
 
-template<typename Strategy>
-void SpecularMagneticTest::testcase_zerofield(std::vector<double> && angles)
+template <typename Strategy>
+void SpecularMagneticTest::testcase_zerofield(std::vector<double>&& angles)
 {
-    for(auto & angle : angles)
-    {
+    for (auto& angle : angles) {
         auto samples = sample_zerofield();
         kvector_t k = vecOfLambdaAlphaPhi(1.0, angle * Units::deg, 0.0);
         testZeroField<Strategy>(k, *std::get<0>(samples), *std::get<1>(samples));

--- a/Tests/UnitTests/Core/Fresnel/SpecularMagneticTest.cpp
+++ b/Tests/UnitTests/Core/Fresnel/SpecularMagneticTest.cpp
@@ -27,15 +27,7 @@ protected:
 
     template<typename Strategy>
     void test_degenerate();
-
-    void ifEqual(const Eigen::Vector2cd& lhs, const Eigen::Vector2cd& rhs);
 };
-
-void SpecularMagneticTest::ifEqual(const Eigen::Vector2cd& lhs, const Eigen::Vector2cd& rhs)
-{
-    EXPECT_NEAR(0.0, std::abs(lhs(0) - rhs(0)), eps);
-    EXPECT_NEAR(0.0, std::abs(lhs(1) - rhs(1)), eps);
-}
 
 template<typename Strategy>
 void SpecularMagneticTest::test_degenerate()
@@ -50,14 +42,14 @@ void SpecularMagneticTest::test_degenerate()
     auto sample = sample_degenerate();
     auto result = std::make_unique<Strategy>()->Execute(sample->slices(), v);
     for (auto& coeff : result) {
-        ifEqual(coeff->T1plus(), Tp_ref);
-        ifEqual(coeff->T2plus(), Tp_ref);
-        ifEqual(coeff->T1min(), Tm_ref);
-        ifEqual(coeff->T2min(), Tm_ref);
-        ifEqual(coeff->R1plus(), Rp_ref);
-        ifEqual(coeff->R2plus(), Rp_ref);
-        ifEqual(coeff->R1min(), Rm_ref);
-        ifEqual(coeff->R2min(), Rm_ref);
+        EXPECT_NEAR_VECTOR2CD(coeff->T1plus(), Tp_ref, eps);
+        EXPECT_NEAR_VECTOR2CD(coeff->T2plus(), Tp_ref, eps);
+        EXPECT_NEAR_VECTOR2CD(coeff->T1min(), Tm_ref, eps);
+        EXPECT_NEAR_VECTOR2CD(coeff->T2min(), Tm_ref, eps);
+        EXPECT_NEAR_VECTOR2CD(coeff->R1plus(), Rp_ref, eps);
+        EXPECT_NEAR_VECTOR2CD(coeff->R2plus(), Rp_ref, eps);
+        EXPECT_NEAR_VECTOR2CD(coeff->R1min(), Rm_ref, eps);
+        EXPECT_NEAR_VECTOR2CD(coeff->R2min(), Rm_ref, eps);
     }
 }
 
@@ -88,12 +80,12 @@ void SpecularMagneticTest::testZeroField(const kvector_t& k,
         Eigen::Vector2cd TMM = RTMatrix.T1min() + RTMatrix.T2min();
         Eigen::Vector2cd RMM = RTMatrix.R1min() + RTMatrix.R2min();
 
-        ifEqual(TPS, TPM);
-        ifEqual(RPS, RPM);
-        ifEqual(TMS, TMM);
-        ifEqual(RMS, RMM);
+        EXPECT_NEAR_VECTOR2CD(TPS, TPM, eps);
+        EXPECT_NEAR_VECTOR2CD(RPS, RPM, eps);
+        EXPECT_NEAR_VECTOR2CD(TMS, TMM, eps);
+        EXPECT_NEAR_VECTOR2CD(RMS, RMM, eps);
 
-        ifEqual(RTScalar.getKz(), RTMatrix.getKz());
+        EXPECT_NEAR_VECTOR2CD(RTScalar.getKz(), RTMatrix.getKz(), eps);
     }
 }
 

--- a/Tests/UnitTests/Core/Fresnel/SpecularMagneticTest.cpp
+++ b/Tests/UnitTests/Core/Fresnel/SpecularMagneticTest.cpp
@@ -9,6 +9,7 @@
 #include "Core/Parametrization/SimulationOptions.h"
 #include "Tests/GTestWrapper/google_test.h"
 #include <utility>
+#include "Core/Multilayer/KzComputation.h"
 
 constexpr double eps = 1e-10;
 
@@ -56,8 +57,10 @@ void SpecularMagneticTest::testZeroField(const kvector_t& k, const ProcessedSamp
                                          const ProcessedSample& sample_zerofield)
 {
     auto coeffs_scalar =
-        std::make_unique<SpecularScalarTanhStrategy>()->Execute(sample_scalar.slices(), k);
-    auto coeffs_zerofield = std::make_unique<Strategy>()->Execute(sample_zerofield.slices(), k);
+        std::make_unique<SpecularScalarTanhStrategy>()->Execute(sample_scalar.slices(),
+                                            KzComputation::computeKzFromRefIndices(sample_scalar.slices(), k) );
+    auto coeffs_zerofield = std::make_unique<Strategy>()->Execute(sample_zerofield.slices(),
+                                            KzComputation::computeKzFromRefIndices(sample_zerofield.slices(), k) );
 
     EXPECT_EQ(coeffs_scalar.size(), coeffs_zerofield.size());
 
@@ -146,5 +149,5 @@ TEST_F(SpecularMagneticTest, zerofield)
 
 TEST_F(SpecularMagneticTest, zerofield_new)
 {
-    testcase_zerofield<SpecularMagneticNewTanhStrategy>({-0.0, -0.1, -2.0, -10.0});
+    testcase_zerofield<SpecularMagneticNewTanhStrategy>({-0.0, -1.e-9, -1.e-5, -0.1, -2.0, -10.0});
 }

--- a/Tests/UnitTests/Core/Fresnel/SpecularMagneticTest.cpp
+++ b/Tests/UnitTests/Core/Fresnel/SpecularMagneticTest.cpp
@@ -1,6 +1,7 @@
 #include "Core/Basics/Units.h"
 #include "Core/Computation/ProcessedSample.h"
 #include "Core/Material/MaterialFactoryFuncs.h"
+#include "Core/Multilayer/KzComputation.h"
 #include "Core/Multilayer/Layer.h"
 #include "Core/Multilayer/MultiLayer.h"
 #include "Core/Multilayer/SpecularMagneticNewTanhStrategy.h"
@@ -9,7 +10,6 @@
 #include "Core/Parametrization/SimulationOptions.h"
 #include "Tests/GTestWrapper/google_test.h"
 #include <utility>
-#include "Core/Multilayer/KzComputation.h"
 
 constexpr double eps = 1e-10;
 
@@ -57,11 +57,10 @@ template <> void SpecularMagneticTest::test_degenerate<SpecularMagneticNewTanhSt
 template <typename Strategy>
 void SpecularMagneticTest::testZeroField(const kvector_t& k, const ProcessedSample& sample)
 {
-    auto coeffs_scalar =
-        std::make_unique<SpecularScalarTanhStrategy>()->Execute(sample.slices(),
-                                            KzComputation::computeKzFromRefIndices(sample.slices(), k) );
-    auto coeffs_zerofield = std::make_unique<Strategy>()->Execute(sample.slices(),
-                                            KzComputation::computeKzFromRefIndices(sample.slices(), k) );
+    auto coeffs_scalar = std::make_unique<SpecularScalarTanhStrategy>()->Execute(
+        sample.slices(), KzComputation::computeKzFromRefIndices(sample.slices(), k));
+    auto coeffs_zerofield = std::make_unique<Strategy>()->Execute(
+        sample.slices(), KzComputation::computeKzFromRefIndices(sample.slices(), k));
 
     EXPECT_EQ(coeffs_scalar.size(), coeffs_zerofield.size());
 
@@ -99,8 +98,7 @@ TEST_F(SpecularMagneticTest, degenerate_new)
     test_degenerate<SpecularMagneticNewTanhStrategy>();
 }
 
-std::unique_ptr<ProcessedSample>
-SpecularMagneticTest::sample_zerofield()
+std::unique_ptr<ProcessedSample> SpecularMagneticTest::sample_zerofield()
 {
     MultiLayer multi_layer_scalar;
     Material substr_material_scalar = HomogeneousMaterial("Substrate", 7e-6, 2e-8);


### PR DESCRIPTION
This PR corrects the treatment of the case kz = 0 and its limit to be consistent with the scalar implementation.
The tests are corrected in accordance and a proper consistency check between the scalar and polarized computation is performed.
The case k = 0 is not handled correctly in the previous implementation, and is disabled now. 