### PR TITLE
Update FindBornAgain.cmake

### DIFF
--- a/Examples/cpp/modules/FindBornAgain.cmake
+++ b/Examples/cpp/modules/FindBornAgain.cmake
@@ -17,47 +17,20 @@
 
 
 set(BORNAGAINSYS $ENV{BORNAGAINSYS})
+set(CoreComponents "Base;Param;Sample;Device;Core")
 
 if(BORNAGAINSYS)
     set(BORNAGAIN_LIBRARY_DIR ${BORNAGAINSYS}/lib/BornAgain-1.18)
     set(BORNAGAIN_INCLUDE_DIR ${BORNAGAINSYS}/include/BornAgain-1.18)
 endif()
 
-find_library (BORNAGAIN_BASE _libBornAgainBase.so
+foreach(lib ${CoreComponents})
+    message(STATUS ${lib})
+    find_library (BORNAGAIN_${lib}  _libBornAgain${lib}.so 
     PATHS ${BORNAGAIN_LIBRARY_DIR}
-    HINTS ${BORNAGAIN_LIBRARY_DIR}
-)
-
-find_library (BORNAGAIN_CORE _libBornAgainCore.so
-    PATHS ${BORNAGAIN_LIBRARY_DIR}
-    HINTS ${BORNAGAIN_LIBRARY_DIR}
-)
-
-find_library (BORNAGAIN_DEVICE _libBornAgainDevice.so
-    PATHS ${BORNAGAIN_LIBRARY_DIR}
-    HINTS ${BORNAGAIN_LIBRARY_DIR}
-)
-
-find_library (BORNAGAIN_FIT _libBornAgainFit.so
-    PATHS ${BORNAGAIN_LIBRARY_DIR}
-    HINTS ${BORNAGAIN_LIBRARY_DIR}
-)
-
-find_library (BORNAGAIN_PARAM _libBornAgainParam.so
-    PATHS ${BORNAGAIN_LIBRARY_DIR}
-    HINTS ${BORNAGAIN_LIBRARY_DIR}
-)
-
-find_library (BORNAGAIN_SAMPLE _libBornAgainSample.so
-    PATHS ${BORNAGAIN_LIBRARY_DIR}
-    HINTS ${BORNAGAIN_LIBRARY_DIR}
-)
-set(BORNAGAIN_LIBRARIES ${BORNAGAIN_BASE} 
-                        ${BORNAGAIN_CORE} 
-                        ${BORNAGAIN_DEVICE} 
-                        ${BORNAGAIN_FIT}
-                        ${BORNAGAIN_PARAM}
-                        ${BORNAGAIN_SAMPLE})
+    HINTS ${BORNAGAIN_LIBRARY_DIR})
+    list(APPEND BORNAGAIN_LIBRARIES ${BORNAGAIN_${lib}})
+endforeach()
 
 find_path(BORNAGAIN_INCLUDE_DIR BAVersion.h
     PATHS /usr/include /usr/local/include /opt/local/include ${BORNAGAIN_INCLUDE_DIR}

--- a/Examples/cpp/modules/FindBornAgain.cmake
+++ b/Examples/cpp/modules/FindBornAgain.cmake
@@ -19,11 +19,21 @@
 set(BORNAGAINSYS $ENV{BORNAGAINSYS})
 
 if(BORNAGAINSYS)
-    set(BORNAGAIN_LIBRARY_DIR ${BORNAGAINSYS}/lib/BornAgain-1.6)
-    set(BORNAGAIN_INCLUDE_DIR ${BORNAGAINSYS}/include/BornAgain-1.6)
+    set(BORNAGAIN_LIBRARY_DIR ${BORNAGAINSYS}/lib/BornAgain-1.18)
+    set(BORNAGAIN_INCLUDE_DIR ${BORNAGAINSYS}/include/BornAgain-1.18)
 endif()
 
+find_library (BORNAGAIN_BASE _libBornAgainBase.so
+    PATHS ${BORNAGAIN_LIBRARY_DIR}
+    HINTS ${BORNAGAIN_LIBRARY_DIR}
+)
+
 find_library (BORNAGAIN_CORE _libBornAgainCore.so
+    PATHS ${BORNAGAIN_LIBRARY_DIR}
+    HINTS ${BORNAGAIN_LIBRARY_DIR}
+)
+
+find_library (BORNAGAIN_DEVICE _libBornAgainDevice.so
     PATHS ${BORNAGAIN_LIBRARY_DIR}
     HINTS ${BORNAGAIN_LIBRARY_DIR}
 )
@@ -32,7 +42,22 @@ find_library (BORNAGAIN_FIT _libBornAgainFit.so
     PATHS ${BORNAGAIN_LIBRARY_DIR}
     HINTS ${BORNAGAIN_LIBRARY_DIR}
 )
-set(BORNAGAIN_LIBRARIES ${BORNAGAIN_CORE} ${BORNAGAIN_FIT})
+
+find_library (BORNAGAIN_PARAM _libBornAgainParam.so
+    PATHS ${BORNAGAIN_LIBRARY_DIR}
+    HINTS ${BORNAGAIN_LIBRARY_DIR}
+)
+
+find_library (BORNAGAIN_SAMPLE _libBornAgainSample.so
+    PATHS ${BORNAGAIN_LIBRARY_DIR}
+    HINTS ${BORNAGAIN_LIBRARY_DIR}
+)
+set(BORNAGAIN_LIBRARIES ${BORNAGAIN_BASE} 
+                        ${BORNAGAIN_CORE} 
+                        ${BORNAGAIN_DEVICE} 
+                        ${BORNAGAIN_FIT}
+                        ${BORNAGAIN_PARAM}
+                        ${BORNAGAIN_SAMPLE})
 
 find_path(BORNAGAIN_INCLUDE_DIR BAVersion.h
     PATHS /usr/include /usr/local/include /opt/local/include ${BORNAGAIN_INCLUDE_DIR}


### PR DESCRIPTION
This updates the include FindBornAgain.cmake file to support the split of core into several shared objects.
Then the cpp example is usable again, and it works to use BornAgain as a library from external C++ programs.