### PR TITLE
Decrease static string usage

### DIFF
--- a/GUI/coregui/Models/ApplicationModels.cpp
+++ b/GUI/coregui/Models/ApplicationModels.cpp
@@ -28,6 +28,7 @@
 #include "GUI/coregui/Models/RealDataItem.h"
 #include "GUI/coregui/Models/RealDataModel.h"
 #include "GUI/coregui/Models/SampleModel.h"
+#include "GUI/coregui/Models/SimulationOptionsItem.h"
 #include "GUI/coregui/Views/ImportDataWidgets/ImportDataUtils.h"
 #include "GUI/coregui/utils/MessageService.h"
 #include "Sample/Multilayer/MultiLayer.h"
@@ -85,7 +86,7 @@ JobModel* ApplicationModels::jobModel()
 void ApplicationModels::resetModels()
 {
     m_documentModel->clear();
-    m_documentModel->insertNewItem("SimulationOptions");
+    m_documentModel->insertItem<SimulationOptionsItem>();
 
     m_materialModel->clear();
     m_materialModel->addRefractiveMaterial("Default", 1e-3, 1e-5);
@@ -100,7 +101,7 @@ void ApplicationModels::resetModels()
     m_jobModel->clear();
 
     m_instrumentModel->clear();
-    SessionItem* instrument = m_instrumentModel->insertNewItem("GISASInstrument");
+    auto instrument = m_instrumentModel->insertItem<GISASInstrumentItem>();
     instrument->setItemName("GISAS");
 }
 
@@ -185,7 +186,7 @@ void ApplicationModels::createTestJob()
 
 void ApplicationModels::createTestRealData()
 {
-    auto realDataItem = dynamic_cast<RealDataItem*>(m_realDataModel->insertNewItem("RealData"));
+    auto realDataItem = m_realDataModel->insertItem<RealDataItem>();
     realDataItem->setItemName("realdata");
 
     std::unique_ptr<OutputData<double>> data(

--- a/GUI/coregui/Models/BeamItems.cpp
+++ b/GUI/coregui/Models/BeamItems.cpp
@@ -25,9 +25,9 @@
 #include "GUI/coregui/Models/SessionItemUtils.h"
 #include "GUI/coregui/Models/SpecularBeamInclinationItem.h"
 #include "GUI/coregui/utils/GUIHelpers.h"
+#include "GUI/coregui/Models/VectorItem.h"
 #include <cmath>
 
-using SessionItemUtils::GetVectorItem;
 
 namespace {
 const QString polarization_tooltip = "Polarization of the beam, given as the Bloch vector";
@@ -110,7 +110,7 @@ std::unique_ptr<Beam> BeamItem::createBeam() const
     auto result =
         std::make_unique<Beam>(intensity(), lambda, Direction(inclination_angle, azimuthal_angle));
 
-    result->setPolarization(GetVectorItem(*this, P_POLARIZATION));
+    result->setPolarization(item<VectorItem>(P_POLARIZATION).getVector());
 
     return result;
 }

--- a/GUI/coregui/Models/BeamItems.cpp
+++ b/GUI/coregui/Models/BeamItems.cpp
@@ -110,7 +110,7 @@ std::unique_ptr<Beam> BeamItem::createBeam() const
     auto result =
         std::make_unique<Beam>(intensity(), lambda, Direction(inclination_angle, azimuthal_angle));
 
-    result->setPolarization(item<VectorItem>(P_POLARIZATION).getVector());
+    result->setPolarization(item<VectorItem>(P_POLARIZATION)->getVector());
 
     return result;
 }
@@ -190,7 +190,7 @@ FootprintItem* SpecularBeamItem::currentFootprintItem() const
 
 void SpecularBeamItem::updateFileName(const QString& filename)
 {
-    item<SpecularBeamInclinationItem>(BeamItem::P_INCLINATION_ANGLE).updateFileName(filename);
+    item<SpecularBeamInclinationItem>(BeamItem::P_INCLINATION_ANGLE)->updateFileName(filename);
 }
 
 void SpecularBeamItem::updateToData(const IAxis& axis, QString units)

--- a/GUI/coregui/Models/DepthProbeInstrumentItem.cpp
+++ b/GUI/coregui/Models/DepthProbeInstrumentItem.cpp
@@ -48,7 +48,7 @@ DepthProbeInstrumentItem::DepthProbeInstrumentItem() : InstrumentItem("DepthProb
 
 SpecularBeamItem* DepthProbeInstrumentItem::beamItem() const
 {
-    return &item<SpecularBeamItem>(P_BEAM);
+    return item<SpecularBeamItem>(P_BEAM);
 }
 
 std::unique_ptr<Instrument> DepthProbeInstrumentItem::createInstrument() const
@@ -82,12 +82,12 @@ std::unique_ptr<DepthProbeSimulation> DepthProbeInstrumentItem::createSimulation
     simulation->setZSpan(depthAxis->size(), depthAxis->lowerBound(), depthAxis->upperBound());
 
     TransformToDomain::setBeamDistribution(
-        "Wavelength", beamItem()->item<BeamWavelengthItem>(SpecularBeamItem::P_WAVELENGTH),
+        "Wavelength", *beamItem()->item<BeamWavelengthItem>(SpecularBeamItem::P_WAVELENGTH),
         *simulation.get());
 
     TransformToDomain::setBeamDistribution(
         "InclinationAngle",
-        beamItem()->item<SpecularBeamInclinationItem>(SpecularBeamItem::P_INCLINATION_ANGLE),
+        *beamItem()->item<SpecularBeamInclinationItem>(SpecularBeamItem::P_INCLINATION_ANGLE),
         *simulation.get());
 
     return simulation;

--- a/GUI/coregui/Models/DetectorItems.cpp
+++ b/GUI/coregui/Models/DetectorItems.cpp
@@ -20,8 +20,7 @@
 #include "GUI/coregui/Models/ResolutionFunctionItems.h"
 #include "GUI/coregui/Models/SessionItemUtils.h"
 #include "GUI/coregui/Models/SessionModel.h"
-
-using SessionItemUtils::GetVectorItem;
+#include "GUI/coregui/Models/VectorItem.h"
 
 namespace {
 const QString res_func_group_label = "Type";
@@ -66,7 +65,7 @@ std::unique_ptr<IDetector2D> DetectorItem::createDetector() const
     if (auto resFunc = createResolutionFunction())
         result->setResolutionFunction(*resFunc);
 
-    kvector_t analyzer_dir = GetVectorItem(*this, P_ANALYZER_DIRECTION);
+    kvector_t analyzer_dir = item<VectorItem>(P_ANALYZER_DIRECTION).getVector();
     double analyzer_eff = getItemValue(P_ANALYZER_EFFICIENCY).toDouble();
     double analyzer_total_trans = getItemValue(P_ANALYZER_TOTAL_TRANSMISSION).toDouble();
     if (analyzer_dir.mag() > 0.0)

--- a/GUI/coregui/Models/DetectorItems.cpp
+++ b/GUI/coregui/Models/DetectorItems.cpp
@@ -65,7 +65,7 @@ std::unique_ptr<IDetector2D> DetectorItem::createDetector() const
     if (auto resFunc = createResolutionFunction())
         result->setResolutionFunction(*resFunc);
 
-    kvector_t analyzer_dir = item<VectorItem>(P_ANALYZER_DIRECTION).getVector();
+    kvector_t analyzer_dir = item<VectorItem>(P_ANALYZER_DIRECTION)->getVector();
     double analyzer_eff = getItemValue(P_ANALYZER_EFFICIENCY).toDouble();
     double analyzer_total_trans = getItemValue(P_ANALYZER_TOTAL_TRANSMISSION).toDouble();
     if (analyzer_dir.mag() > 0.0)

--- a/GUI/coregui/Models/DetectorItems.cpp
+++ b/GUI/coregui/Models/DetectorItems.cpp
@@ -88,7 +88,7 @@ MaskContainerItem* DetectorItem::maskContainerItem() const
 void DetectorItem::createMaskContainer()
 {
     if (!maskContainerItem())
-        model()->insertNewItem("MaskContainer", this->index());
+        model()->insertItem<MaskContainerItem>(this->index());
 }
 
 void DetectorItem::importMasks(const MaskContainerItem* maskContainer)

--- a/GUI/coregui/Models/FitParameterHelper.cpp
+++ b/GUI/coregui/Models/FitParameterHelper.cpp
@@ -30,11 +30,10 @@ void FitParameterHelper::createFitParameter(FitParameterContainerItem* container
 
     removeFromFitParameters(container, parameterItem);
 
-    FitParameterItem* fitPar = dynamic_cast<FitParameterItem*>(
-        container->model()->insertNewItem("FitParameter", container->index()));
-    ASSERT(fitPar);
+    auto model = container->model();
+    auto fitPar = model->insertItem<FitParameterItem>(container->index());
     fitPar->setDisplayName("par");
-    SessionItem* link = fitPar->model()->insertNewItem("FitParameterLink", fitPar->index());
+    auto link = model->insertItem<FitParameterLinkItem>(fitPar->index());
     fitPar->setItemValue(FitParameterItem::P_START_VALUE, parameterItem->value());
     link->setItemValue(FitParameterLinkItem::P_LINK, getParameterItemPath(parameterItem));
 

--- a/GUI/coregui/Models/GUIDomainSampleVisitor.cpp
+++ b/GUI/coregui/Models/GUIDomainSampleVisitor.cpp
@@ -25,9 +25,9 @@
 #include "GUI/coregui/Models/ParticleLayoutItem.h"
 #include "GUI/coregui/Models/RotationItems.h"
 #include "GUI/coregui/Models/SampleModel.h"
-#include "GUI/coregui/Models/SessionItemUtils.h"
 #include "GUI/coregui/Models/TransformFromDomain.h"
 #include "GUI/coregui/Models/TransformationItem.h"
+#include "GUI/coregui/Models/VectorItem.h"
 #include "GUI/coregui/Views/MaterialEditor/MaterialItemUtils.h"
 #include "GUI/coregui/utils/GUIHelpers.h"
 #include "Param/Node/NodeUtils.h"
@@ -43,8 +43,6 @@
 #include "Sample/Particle/ParticleCoreShell.h"
 #include "Sample/Particle/ParticleDistribution.h"
 #include "Sample/SoftParticle/SoftParticles.h"
-
-using SessionItemUtils::SetVectorItem;
 
 namespace {
 SessionItem* AddFormFactorItem(SessionItem* parent, const QString& model_type)
@@ -132,7 +130,8 @@ void GUIDomainSampleVisitor::visit(const MultiLayer* sample)
     SessionItem* multilayer_item = m_sampleModel->insertNewItem("MultiLayer");
     multilayer_item->setItemName(sample->getName().c_str());
     multilayer_item->setItemValue(MultiLayerItem::P_CROSS_CORR_LENGTH, sample->crossCorrLength());
-    SetVectorItem(*multilayer_item, MultiLayerItem::P_EXTERNAL_FIELD, sample->externalField());
+    multilayer_item->item<VectorItem>(MultiLayerItem::P_EXTERNAL_FIELD)
+        .setVector(sample->externalField());
     m_levelToParentItem[depth()] = multilayer_item;
     m_itemToSample[multilayer_item] = sample;
 }
@@ -186,9 +185,9 @@ void GUIDomainSampleVisitor::visit(const Crystal* sample)
     auto vector_b = lattice.getBasisVectorB();
     auto vector_c = lattice.getBasisVectorC();
 
-    SetVectorItem(*mesocrystal_item, MesoCrystalItem::P_VECTOR_A, vector_a);
-    SetVectorItem(*mesocrystal_item, MesoCrystalItem::P_VECTOR_B, vector_b);
-    SetVectorItem(*mesocrystal_item, MesoCrystalItem::P_VECTOR_C, vector_c);
+    mesocrystal_item->item<VectorItem>(MesoCrystalItem::P_VECTOR_A).setVector(vector_a);
+    mesocrystal_item->item<VectorItem>(MesoCrystalItem::P_VECTOR_B).setVector(vector_b);
+    mesocrystal_item->item<VectorItem>(MesoCrystalItem::P_VECTOR_C).setVector(vector_c);
 
     // Since there is no CrystalItem, set the parent map to the MesoCrystalItem
     m_levelToParentItem[depth()] = mesocrystal_item;
@@ -596,8 +595,7 @@ void GUIDomainSampleVisitor::visit(const RotationEuler* sample)
 
 void GUIDomainSampleVisitor::buildPositionInfo(SessionItem* particle_item, const IParticle* sample)
 {
-    kvector_t position = sample->position();
-    SetVectorItem(*particle_item, ParticleItem::P_POSITION, position);
+    particle_item->item<VectorItem>(ParticleItem::P_POSITION).setVector(sample->position());
 }
 
 ExternalProperty GUIDomainSampleVisitor::createMaterialFromDomain(const Material* material)
@@ -620,7 +618,8 @@ ExternalProperty GUIDomainSampleVisitor::createMaterialFromDomain(const Material
                                 "Unsupported material");
     }
 
-    SetVectorItem(*materialItem, MaterialItem::P_MAGNETIZATION, material->magnetization());
+    materialItem->item<VectorItem>(MaterialItem::P_MAGNETIZATION)
+        .setVector(material->magnetization());
     return MaterialItemUtils::materialProperty(*materialItem);
 }
 

--- a/GUI/coregui/Models/GUIDomainSampleVisitor.cpp
+++ b/GUI/coregui/Models/GUIDomainSampleVisitor.cpp
@@ -131,7 +131,7 @@ void GUIDomainSampleVisitor::visit(const MultiLayer* sample)
     multilayer_item->setItemName(sample->getName().c_str());
     multilayer_item->setItemValue(MultiLayerItem::P_CROSS_CORR_LENGTH, sample->crossCorrLength());
     multilayer_item->item<VectorItem>(MultiLayerItem::P_EXTERNAL_FIELD)
-        .setVector(sample->externalField());
+        ->setVector(sample->externalField());
     m_levelToParentItem[depth()] = multilayer_item;
     m_itemToSample[multilayer_item] = sample;
 }
@@ -185,9 +185,9 @@ void GUIDomainSampleVisitor::visit(const Crystal* sample)
     auto vector_b = lattice.getBasisVectorB();
     auto vector_c = lattice.getBasisVectorC();
 
-    mesocrystal_item->item<VectorItem>(MesoCrystalItem::P_VECTOR_A).setVector(vector_a);
-    mesocrystal_item->item<VectorItem>(MesoCrystalItem::P_VECTOR_B).setVector(vector_b);
-    mesocrystal_item->item<VectorItem>(MesoCrystalItem::P_VECTOR_C).setVector(vector_c);
+    mesocrystal_item->item<VectorItem>(MesoCrystalItem::P_VECTOR_A)->setVector(vector_a);
+    mesocrystal_item->item<VectorItem>(MesoCrystalItem::P_VECTOR_B)->setVector(vector_b);
+    mesocrystal_item->item<VectorItem>(MesoCrystalItem::P_VECTOR_C)->setVector(vector_c);
 
     // Since there is no CrystalItem, set the parent map to the MesoCrystalItem
     m_levelToParentItem[depth()] = mesocrystal_item;
@@ -595,7 +595,7 @@ void GUIDomainSampleVisitor::visit(const RotationEuler* sample)
 
 void GUIDomainSampleVisitor::buildPositionInfo(SessionItem* particle_item, const IParticle* sample)
 {
-    particle_item->item<VectorItem>(ParticleItem::P_POSITION).setVector(sample->position());
+    particle_item->item<VectorItem>(ParticleItem::P_POSITION)->setVector(sample->position());
 }
 
 ExternalProperty GUIDomainSampleVisitor::createMaterialFromDomain(const Material* material)
@@ -619,7 +619,7 @@ ExternalProperty GUIDomainSampleVisitor::createMaterialFromDomain(const Material
     }
 
     materialItem->item<VectorItem>(MaterialItem::P_MAGNETIZATION)
-        .setVector(material->magnetization());
+        ->setVector(material->magnetization());
     return MaterialItemUtils::materialProperty(*materialItem);
 }
 

--- a/GUI/coregui/Models/GUIDomainSampleVisitor.cpp
+++ b/GUI/coregui/Models/GUIDomainSampleVisitor.cpp
@@ -16,11 +16,13 @@
 #include "Base/Const/Units.h"
 #include "GUI/coregui/Models/ComboProperty.h"
 #include "GUI/coregui/Models/FormFactorItems.h"
+#include "GUI/coregui/Models/InterferenceFunctionItems.h"
 #include "GUI/coregui/Models/LayerItem.h"
 #include "GUI/coregui/Models/MaterialModel.h"
 #include "GUI/coregui/Models/MesoCrystalItem.h"
 #include "GUI/coregui/Models/MultiLayerItem.h"
 #include "GUI/coregui/Models/ParticleCoreShellItem.h"
+#include "GUI/coregui/Models/ParticleDistributionItem.h"
 #include "GUI/coregui/Models/ParticleItem.h"
 #include "GUI/coregui/Models/ParticleLayoutItem.h"
 #include "GUI/coregui/Models/RotationItems.h"
@@ -92,12 +94,8 @@ SessionItem* GUIDomainSampleVisitor::populateSampleModel(SampleModel* sampleMode
 void GUIDomainSampleVisitor::visit(const ParticleLayout* sample)
 {
     SessionItem* parent = m_levelToParentItem[depth() - 1];
-    SessionItem* layout_item(nullptr);
-    if (parent)
-        layout_item =
-            m_sampleModel->insertNewItem("ParticleLayout", m_sampleModel->indexOfItem(parent));
-    else
-        layout_item = m_sampleModel->insertNewItem("ParticleLayout");
+    auto layout_item = m_sampleModel->insertItem<ParticleLayoutItem>(
+        parent ? m_sampleModel->indexOfItem(parent) : QModelIndex());
     layout_item->setItemValue(ParticleLayoutItem::P_TOTAL_DENSITY,
                               sample->totalParticleSurfaceDensity());
     layout_item->setItemValue(ParticleLayoutItem::P_WEIGHT, sample->weight());
@@ -116,7 +114,7 @@ void GUIDomainSampleVisitor::visit(const Layer* sample)
         layer_index == 0 ? nullptr : multilayer->layerInterface(layer_index - 1);
 
     SessionItem* layer_item =
-        m_sampleModel->insertNewItem("Layer", m_sampleModel->indexOfItem(parent));
+        m_sampleModel->insertItem<LayerItem>(m_sampleModel->indexOfItem(parent));
     layer_item->setItemValue(LayerItem::P_MATERIAL,
                              createMaterialFromDomain(sample->material()).variant());
 
@@ -127,7 +125,7 @@ void GUIDomainSampleVisitor::visit(const Layer* sample)
 
 void GUIDomainSampleVisitor::visit(const MultiLayer* sample)
 {
-    SessionItem* multilayer_item = m_sampleModel->insertNewItem("MultiLayer");
+    auto multilayer_item = m_sampleModel->insertItem<MultiLayerItem>();
     multilayer_item->setItemName(sample->getName().c_str());
     multilayer_item->setItemValue(MultiLayerItem::P_CROSS_CORR_LENGTH, sample->crossCorrLength());
     multilayer_item->item<VectorItem>(MultiLayerItem::P_EXTERNAL_FIELD)
@@ -147,9 +145,8 @@ void GUIDomainSampleVisitor::visit(const ParticleDistribution* sample)
 {
     SessionItem* layout_item = m_levelToParentItem[depth() - 1];
     ASSERT(layout_item);
-    SessionItem* particle_distribution_item = m_sampleModel->insertNewItem(
-        "ParticleDistribution", m_sampleModel->indexOfItem(layout_item));
-    ASSERT(particle_distribution_item);
+    auto particle_distribution_item = m_sampleModel->insertItem<ParticleDistributionItem>(
+        m_sampleModel->indexOfItem(layout_item));
 
     TransformFromDomain::setParticleDistributionItem(particle_distribution_item, *sample);
 
@@ -470,10 +467,8 @@ void GUIDomainSampleVisitor::visit(const InterferenceFunction1DLattice* sample)
 {
     SessionItem* parent = m_levelToParentItem[depth() - 1];
     ASSERT(parent);
-    SessionItem* item =
-        m_sampleModel->insertNewItem("Interference1DLattice", m_sampleModel->indexOfItem(parent),
-                                     -1, ParticleLayoutItem::T_INTERFERENCE);
-    ASSERT(item);
+    auto item = m_sampleModel->insertItem<InterferenceFunction1DLatticeItem>(
+        m_sampleModel->indexOfItem(parent), -1, ParticleLayoutItem::T_INTERFERENCE);
     TransformFromDomain::set1DLatticeItem(item, *sample);
     m_levelToParentItem[depth()] = item;
 }
@@ -482,10 +477,8 @@ void GUIDomainSampleVisitor::visit(const InterferenceFunction2DLattice* sample)
 {
     SessionItem* parent = m_levelToParentItem[depth() - 1];
     ASSERT(parent);
-    SessionItem* item =
-        m_sampleModel->insertNewItem("Interference2DLattice", m_sampleModel->indexOfItem(parent),
-                                     -1, ParticleLayoutItem::T_INTERFERENCE);
-    ASSERT(item);
+    auto item = m_sampleModel->insertItem<InterferenceFunction2DLatticeItem>(
+        m_sampleModel->indexOfItem(parent), -1, ParticleLayoutItem::T_INTERFERENCE);
     TransformFromDomain::set2DLatticeItem(item, *sample);
     m_levelToParentItem[depth()] = item;
 }
@@ -494,10 +487,8 @@ void GUIDomainSampleVisitor::visit(const InterferenceFunction2DParaCrystal* samp
 {
     SessionItem* parent = m_levelToParentItem[depth() - 1];
     ASSERT(parent);
-    SessionItem* item = m_sampleModel->insertNewItem("Interference2DParaCrystal",
-                                                     m_sampleModel->indexOfItem(parent), -1,
-                                                     ParticleLayoutItem::T_INTERFERENCE);
-    ASSERT(item);
+    auto item = m_sampleModel->insertItem<InterferenceFunction2DParaCrystalItem>(
+        m_sampleModel->indexOfItem(parent), -1, ParticleLayoutItem::T_INTERFERENCE);
     TransformFromDomain::set2DParaCrystalItem(item, *sample);
     m_levelToParentItem[depth()] = item;
 }
@@ -506,10 +497,8 @@ void GUIDomainSampleVisitor::visit(const InterferenceFunctionFinite2DLattice* sa
 {
     SessionItem* parent = m_levelToParentItem[depth() - 1];
     ASSERT(parent);
-    SessionItem* item = m_sampleModel->insertNewItem("InterferenceFinite2DLattice",
-                                                     m_sampleModel->indexOfItem(parent), -1,
-                                                     ParticleLayoutItem::T_INTERFERENCE);
-    ASSERT(item);
+    auto item = m_sampleModel->insertItem<InterferenceFunctionFinite2DLatticeItem>(
+        m_sampleModel->indexOfItem(parent), -1, ParticleLayoutItem::T_INTERFERENCE);
     TransformFromDomain::setFinite2DLatticeItem(item, *sample);
     m_levelToParentItem[depth()] = item;
 }
@@ -518,10 +507,8 @@ void GUIDomainSampleVisitor::visit(const InterferenceFunctionHardDisk* sample)
 {
     SessionItem* parent = m_levelToParentItem[depth() - 1];
     ASSERT(parent);
-    SessionItem* item =
-        m_sampleModel->insertNewItem("InterferenceHardDisk", m_sampleModel->indexOfItem(parent), -1,
-                                     ParticleLayoutItem::T_INTERFERENCE);
-    ASSERT(item);
+    auto item = m_sampleModel->insertItem<InterferenceFunctionHardDiskItem>(
+        m_sampleModel->indexOfItem(parent), -1, ParticleLayoutItem::T_INTERFERENCE);
     TransformFromDomain::setHardDiskItem(item, *sample);
     m_levelToParentItem[depth()] = item;
 }
@@ -530,10 +517,8 @@ void GUIDomainSampleVisitor::visit(const InterferenceFunctionRadialParaCrystal* 
 {
     SessionItem* parent = m_levelToParentItem[depth() - 1];
     ASSERT(parent);
-    SessionItem* item = m_sampleModel->insertNewItem("InterferenceRadialParaCrystal",
-                                                     m_sampleModel->indexOfItem(parent), -1,
-                                                     ParticleLayoutItem::T_INTERFERENCE);
-    ASSERT(item);
+    auto item = m_sampleModel->insertItem<InterferenceFunctionRadialParaCrystalItem>(
+        m_sampleModel->indexOfItem(parent), -1, ParticleLayoutItem::T_INTERFERENCE);
     TransformFromDomain::setRadialParaCrystalItem(item, *sample);
     m_levelToParentItem[depth()] = item;
 }
@@ -543,8 +528,8 @@ void GUIDomainSampleVisitor::visit(const RotationX* sample)
     SessionItem* parent = m_levelToParentItem[depth() - 1];
     ASSERT(parent);
 
-    SessionItem* transformation_item = m_sampleModel->insertNewItem(
-        "Rotation", m_sampleModel->indexOfItem(parent), -1, ParticleItem::T_TRANSFORMATION);
+    auto transformation_item = m_sampleModel->insertItem<TransformationItem>(
+        m_sampleModel->indexOfItem(parent), -1, ParticleItem::T_TRANSFORMATION);
     SessionItem* rotationItem =
         transformation_item->setGroupProperty(TransformationItem::P_ROT, "XRotation");
     rotationItem->setItemValue(XRotationItem::P_ANGLE, Units::rad2deg(sample->getAngle()));
@@ -556,8 +541,8 @@ void GUIDomainSampleVisitor::visit(const RotationY* sample)
     SessionItem* parent = m_levelToParentItem[depth() - 1];
     ASSERT(parent);
 
-    SessionItem* transformation_item = m_sampleModel->insertNewItem(
-        "Rotation", m_sampleModel->indexOfItem(parent), -1, ParticleItem::T_TRANSFORMATION);
+    auto transformation_item = m_sampleModel->insertItem<TransformationItem>(
+        m_sampleModel->indexOfItem(parent), -1, ParticleItem::T_TRANSFORMATION);
     SessionItem* rotationItem =
         transformation_item->setGroupProperty(TransformationItem::P_ROT, "YRotation");
     rotationItem->setItemValue(YRotationItem::P_ANGLE, Units::rad2deg(sample->getAngle()));
@@ -569,8 +554,8 @@ void GUIDomainSampleVisitor::visit(const RotationZ* sample)
     SessionItem* parent = m_levelToParentItem[depth() - 1];
     ASSERT(parent);
 
-    SessionItem* transformation_item = m_sampleModel->insertNewItem(
-        "Rotation", m_sampleModel->indexOfItem(parent), -1, ParticleItem::T_TRANSFORMATION);
+    auto transformation_item = m_sampleModel->insertItem<TransformationItem>(
+        m_sampleModel->indexOfItem(parent), -1, ParticleItem::T_TRANSFORMATION);
     SessionItem* rotationItem =
         transformation_item->setGroupProperty(TransformationItem::P_ROT, "ZRotation");
     rotationItem->setItemValue(ZRotationItem::P_ANGLE, Units::rad2deg(sample->getAngle()));
@@ -582,9 +567,8 @@ void GUIDomainSampleVisitor::visit(const RotationEuler* sample)
     SessionItem* parent = m_levelToParentItem[depth() - 1];
     ASSERT(parent);
 
-    SessionItem* transformation_item = m_sampleModel->insertNewItem(
-        "Rotation", m_sampleModel->indexOfItem(parent), -1, ParticleItem::T_TRANSFORMATION);
-    ASSERT(transformation_item);
+    auto transformation_item = m_sampleModel->insertItem<TransformationItem>(
+        m_sampleModel->indexOfItem(parent), -1, ParticleItem::T_TRANSFORMATION);
     SessionItem* rotationItem =
         transformation_item->setGroupProperty(TransformationItem::P_ROT, "EulerRotation");
     rotationItem->setItemValue(EulerRotationItem::P_ALPHA, Units::rad2deg(sample->getAlpha()));

--- a/GUI/coregui/Models/GUIObjectBuilder.cpp
+++ b/GUI/coregui/Models/GUIObjectBuilder.cpp
@@ -85,9 +85,7 @@ SessionItem* GUIObjectBuilder::populateInstrumentModel(InstrumentModel* p_instru
 SessionItem* GUIObjectBuilder::populateDocumentModel(DocumentModel* p_document_model,
                                                      const ISimulation& simulation)
 {
-    SimulationOptionsItem* p_options_item =
-        dynamic_cast<SimulationOptionsItem*>(p_document_model->insertNewItem("SimulationOptions"));
-    ASSERT(p_options_item);
+    auto p_options_item = p_document_model->insertItem<SimulationOptionsItem>();
     if (simulation.getOptions().isIntegrate()) {
         p_options_item->setComputationMethod("Monte-Carlo Integration");
         p_options_item->setNumberOfMonteCarloPoints(
@@ -107,8 +105,7 @@ GISASInstrumentItem* createGISASInstrumentItem(InstrumentModel* model,
                                                const GISASSimulation& simulation,
                                                const QString& name)
 {
-    auto result = dynamic_cast<GISASInstrumentItem*>(model->insertNewItem("GISASInstrument"));
-
+    auto result = model->insertItem<GISASInstrumentItem>();
     result->setItemName(name);
     TransformFromDomain::setGISASBeamItem(result->beamItem(), simulation);
     TransformFromDomain::setDetector(result, simulation);
@@ -121,9 +118,7 @@ OffSpecularInstrumentItem* createOffSpecularInstrumentItem(InstrumentModel* mode
                                                            const OffSpecularSimulation& simulation,
                                                            const QString& name)
 {
-    auto result =
-        dynamic_cast<OffSpecularInstrumentItem*>(model->insertNewItem("OffSpecularInstrument"));
-
+    auto result = model->insertItem<OffSpecularInstrumentItem>();
     result->setItemName(name);
     TransformFromDomain::setOffSpecularBeamItem(result->beamItem(), simulation);
     TransformFromDomain::setDetector(result, simulation);
@@ -139,8 +134,7 @@ SpecularInstrumentItem* createSpecularInstrumentItem(InstrumentModel* model,
                                                      const SpecularSimulation& simulation,
                                                      const QString& name)
 {
-    auto result = dynamic_cast<SpecularInstrumentItem*>(model->insertNewItem("SpecularInstrument"));
-
+    auto result = model->insertItem<SpecularInstrumentItem>();
     result->setItemName(name);
     TransformFromDomain::setSpecularBeamItem(result->beamItem(), simulation);
     TransformFromDomain::setBackground(result, simulation);

--- a/GUI/coregui/Models/InstrumentItems.cpp
+++ b/GUI/coregui/Models/InstrumentItems.cpp
@@ -56,7 +56,7 @@ QStringList InstrumentItem::translateList(const QStringList& list) const
 
 BeamItem* InstrumentItem::beamItem() const
 {
-    return &item<BeamItem>(P_BEAM);
+    return item<BeamItem>(P_BEAM);
 }
 
 BackgroundItem* InstrumentItem::backgroundItem() const
@@ -66,7 +66,7 @@ BackgroundItem* InstrumentItem::backgroundItem() const
 
 GroupItem* InstrumentItem::backgroundGroup()
 {
-    return &item<GroupItem>(P_BACKGROUND);
+    return item<GroupItem>(P_BACKGROUND);
 }
 
 bool InstrumentItem::alignedWith(const RealDataItem* item) const
@@ -106,12 +106,13 @@ SpecularInstrumentItem::SpecularInstrumentItem() : InstrumentItem("SpecularInstr
 {
     initBeamGroup("SpecularBeam");
     initBackgroundGroup();
-    item<SpecularBeamItem>(P_BEAM).updateFileName(ItemFileNameUtils::instrumentDataFileName(*this));
+    item<SpecularBeamItem>(P_BEAM)->updateFileName(
+        ItemFileNameUtils::instrumentDataFileName(*this));
 }
 
 SpecularBeamItem* SpecularInstrumentItem::beamItem() const
 {
-    return &item<SpecularBeamItem>(P_BEAM);
+    return item<SpecularBeamItem>(P_BEAM);
 }
 
 SpecularInstrumentItem::~SpecularInstrumentItem() = default;
@@ -196,7 +197,7 @@ DetectorItem* Instrument2DItem::detectorItem() const
 
 GroupItem* Instrument2DItem::detectorGroup()
 {
-    return &item<GroupItem>(P_DETECTOR);
+    return item<GroupItem>(P_DETECTOR);
 }
 
 void Instrument2DItem::setDetectorGroup(const QString& modelType)

--- a/GUI/coregui/Models/JobItem.cpp
+++ b/GUI/coregui/Models/JobItem.cpp
@@ -297,5 +297,5 @@ SimulationOptionsItem* JobItem::simulationOptionsItem()
 
 const SimulationOptionsItem* JobItem::simulationOptionsItem() const
 {
-    return &item<const SimulationOptionsItem>(T_SIMULATION_OPTIONS);
+    return item<const SimulationOptionsItem>(T_SIMULATION_OPTIONS);
 }

--- a/GUI/coregui/Models/JobModel.cpp
+++ b/GUI/coregui/Models/JobModel.cpp
@@ -78,7 +78,7 @@ JobItem* JobModel::addJob(const MultiLayerItem* multiLayerItem,
     ASSERT(instrumentItem);
     ASSERT(optionItem);
 
-    JobItem* jobItem = dynamic_cast<JobItem*>(insertNewItem("JobItem"));
+    auto jobItem = insertItem<JobItem>();
     jobItem->setItemName(generateJobName());
     jobItem->setIdentifier(GUIHelpers::createUuid());
 

--- a/GUI/coregui/Models/JobModelFunctions.cpp
+++ b/GUI/coregui/Models/JobModelFunctions.cpp
@@ -19,6 +19,7 @@
 #include "GUI/coregui/Models/DataPropertyContainer.h"
 #include "GUI/coregui/Models/DetectorItems.h"
 #include "GUI/coregui/Models/DomainObjectBuilder.h"
+#include "GUI/coregui/Models/FitParameterItems.h"
 #include "GUI/coregui/Models/FitSuiteItem.h"
 #include "GUI/coregui/Models/GroupItem.h"
 #include "GUI/coregui/Models/InstrumentItems.h"
@@ -29,9 +30,11 @@
 #include "GUI/coregui/Models/JobModel.h"
 #include "GUI/coregui/Models/MaskItems.h"
 #include "GUI/coregui/Models/MaterialItemContainer.h"
+#include "GUI/coregui/Models/MinimizerItem.h"
 #include "GUI/coregui/Models/MultiLayerItem.h"
 #include "GUI/coregui/Models/PointwiseAxisItem.h"
 #include "GUI/coregui/Models/RealDataItem.h"
+#include "GUI/coregui/Models/SpecularDataItem.h"
 #include "GUI/coregui/Views/MaskWidgets/MaskUnitsConverter.h"
 #include "GUI/coregui/Views/MaterialEditor/MaterialItemUtils.h"
 #include "GUI/coregui/utils/GUIHelpers.h"
@@ -65,13 +68,10 @@ void JobModelFunctions::initDataView(JobItem* job_item)
     ASSERT(!job_item->getItem(JobItem::T_DATAVIEW));
 
     SessionModel* model = job_item->model();
-    auto view_item = dynamic_cast<Data1DViewItem*>(
-        model->insertNewItem("Data1DViewItem", job_item->index(), -1, JobItem::T_DATAVIEW));
-    ASSERT(view_item);
+    auto view_item = model->insertItem<Data1DViewItem>(job_item->index(), -1, JobItem::T_DATAVIEW);
 
-    auto property_container = dynamic_cast<DataPropertyContainer*>(model->insertNewItem(
-        "DataPropertyContainer", view_item->index(), -1, Data1DViewItem::T_DATA_PROPERTIES));
-    ASSERT(property_container);
+    auto property_container = model->insertItem<DataPropertyContainer>(
+        view_item->index(), -1, Data1DViewItem::T_DATA_PROPERTIES);
 
     property_container->addItem(job_item->realDataItem()->dataItem());
     property_container->addItem(job_item->dataItem());
@@ -91,8 +91,8 @@ void JobModelFunctions::setupJobItemSampleData(JobItem* jobItem, const MultiLaye
     multilayer->setItemName("MultiLayer");
 
     // copying materials
-    auto container = static_cast<MaterialItemContainer*>(jobItem->model()->insertNewItem(
-        "MaterialContainer", jobItem->index(), -1, JobItem::T_MATERIAL_CONTAINER));
+    auto container = jobItem->model()->insertItem<MaterialItemContainer>(
+        jobItem->index(), -1, JobItem::T_MATERIAL_CONTAINER);
 
     std::map<MaterialItem*, QString> materials;
     for (auto property_item : multilayer->materialPropertyItems()) {
@@ -144,11 +144,11 @@ void JobModelFunctions::setupJobItemOutput(JobItem* jobItem)
 
     auto instrumentType = jobItem->instrumentItem()->modelType();
     if (instrumentType == "SpecularInstrument") {
-        model->insertNewItem("SpecularData", model->indexOfItem(jobItem), -1, JobItem::T_OUTPUT);
+        model->insertItem<SpecularDataItem>(model->indexOfItem(jobItem), -1, JobItem::T_OUTPUT);
 
     } else if (instrumentType == "GISASInstrument" || instrumentType == "OffSpecularInstrument"
                || instrumentType == "DepthProbeInstrument") {
-        model->insertNewItem("IntensityData", model->indexOfItem(jobItem), -1, JobItem::T_OUTPUT);
+        model->insertItem<IntensityDataItem>(model->indexOfItem(jobItem), -1, JobItem::T_OUTPUT);
 
     } else {
         throw GUIHelpers::Error("JobModelFunctions::setupJobItemOutput() -> Error. "
@@ -269,7 +269,7 @@ void createFitContainers(JobItem* jobItem)
                                 "a second FitSuiteItem.");
     }
 
-    fitSuiteItem = model->insertNewItem("FitSuite", jobItem->index(), -1, JobItem::T_FIT_SUITE);
+    fitSuiteItem = model->insertItem<FitSuiteItem>(jobItem->index(), -1, JobItem::T_FIT_SUITE);
 
     SessionItem* parsContainerItem =
         fitSuiteItem->getItem(FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
@@ -278,8 +278,8 @@ void createFitContainers(JobItem* jobItem)
                                 "a second FitParameterContainer.");
     }
 
-    model->insertNewItem("FitParameterContainer", fitSuiteItem->index(), -1,
-                         FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
+    model->insertItem<FitParameterContainerItem>(fitSuiteItem->index(), -1,
+                                                 FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
 
     // Minimizer settings
     SessionItem* minimizerContainerItem = fitSuiteItem->getItem(FitSuiteItem::T_MINIMIZER);
@@ -288,8 +288,7 @@ void createFitContainers(JobItem* jobItem)
                                 "a second MinimizerContainer.");
     }
 
-    model->insertNewItem("MinimizerContainer", fitSuiteItem->index(), -1,
-                         FitSuiteItem::T_MINIMIZER);
+    model->insertItem<MinimizerContainerItem>(fitSuiteItem->index(), -1, FitSuiteItem::T_MINIMIZER);
 }
 
 PointwiseAxisItem* getPointwiseAxisItem(const SpecularInstrumentItem* instrument)

--- a/GUI/coregui/Models/MaterialItem.cpp
+++ b/GUI/coregui/Models/MaterialItem.cpp
@@ -73,7 +73,7 @@ QColor MaterialItem::color() const
 std::unique_ptr<Material> MaterialItem::createMaterial() const
 {
     auto dataItem = getGroupItem(P_MATERIAL_DATA);
-    auto magnetization = item<VectorItem>(P_MAGNETIZATION).getVector();
+    auto magnetization = item<VectorItem>(P_MAGNETIZATION)->getVector();
     auto name = itemName().toStdString();
 
     if (dataItem->modelType() == "MaterialRefractiveData") {

--- a/GUI/coregui/Models/MaterialItem.cpp
+++ b/GUI/coregui/Models/MaterialItem.cpp
@@ -17,8 +17,7 @@
 #include "GUI/coregui/Views/MaterialEditor/MaterialItemUtils.h"
 #include "GUI/coregui/utils/GUIHelpers.h"
 #include "Sample/Material/MaterialFactoryFuncs.h"
-
-using SessionItemUtils::GetVectorItem;
+#include "GUI/coregui/Models/VectorItem.h"
 
 namespace {
 const QString magnetization_tooltip = "Magnetization (A/m)";
@@ -74,7 +73,7 @@ QColor MaterialItem::color() const
 std::unique_ptr<Material> MaterialItem::createMaterial() const
 {
     auto dataItem = getGroupItem(P_MATERIAL_DATA);
-    auto magnetization = GetVectorItem(*this, P_MAGNETIZATION);
+    auto magnetization = item<VectorItem>(P_MAGNETIZATION).getVector();
     auto name = itemName().toStdString();
 
     if (dataItem->modelType() == "MaterialRefractiveData") {

--- a/GUI/coregui/Models/MaterialModel.cpp
+++ b/GUI/coregui/Models/MaterialModel.cpp
@@ -93,7 +93,7 @@ MaterialItem* MaterialModel::cloneMaterial(const QModelIndex& index)
 
 MaterialItem* MaterialModel::createMaterial(const QString& name)
 {
-    auto result = dynamic_cast<MaterialItem*>(insertNewItem("Material"));
+    auto result = insertItem<MaterialItem>();
     result->setItemName(name);
 
     QColor color = MaterialItemUtils::suggestMaterialColor(name);

--- a/GUI/coregui/Models/MesoCrystalItem.cpp
+++ b/GUI/coregui/Models/MesoCrystalItem.cpp
@@ -105,6 +105,11 @@ MesoCrystalItem::MesoCrystalItem() : SessionGraphicsItem("MesoCrystal")
     });
 }
 
+VectorItem* MesoCrystalItem::positionItem() const
+{
+    return item<VectorItem>(ParticleItem::P_POSITION);
+}
+
 std::unique_ptr<MesoCrystal> MesoCrystalItem::createMesoCrystal() const
 {
     const Lattice3D& lattice = getLattice();

--- a/GUI/coregui/Models/MesoCrystalItem.cpp
+++ b/GUI/coregui/Models/MesoCrystalItem.cpp
@@ -140,9 +140,9 @@ QStringList MesoCrystalItem::translateList(const QStringList& list) const
 
 Lattice3D MesoCrystalItem::getLattice() const
 {
-    const kvector_t a1 = item<VectorItem>(P_VECTOR_A).getVector();
-    const kvector_t a2 = item<VectorItem>(P_VECTOR_B).getVector();
-    const kvector_t a3 = item<VectorItem>(P_VECTOR_C).getVector();
+    const kvector_t a1 = item<VectorItem>(P_VECTOR_A)->getVector();
+    const kvector_t a2 = item<VectorItem>(P_VECTOR_B)->getVector();
+    const kvector_t a3 = item<VectorItem>(P_VECTOR_C)->getVector();
     return Lattice3D(a1, a2, a3);
 }
 

--- a/GUI/coregui/Models/MesoCrystalItem.cpp
+++ b/GUI/coregui/Models/MesoCrystalItem.cpp
@@ -29,8 +29,6 @@
 #include "Sample/Particle/ParticleCoreShell.h"
 #include "Sample/Scattering/IFormFactor.h"
 
-using SessionItemUtils::GetVectorItem;
-
 namespace {
 const QString abundance_tooltip = "Proportion of this type of mesocrystal normalized to the \n"
                                   "total number of particles in the layout";
@@ -142,9 +140,9 @@ QStringList MesoCrystalItem::translateList(const QStringList& list) const
 
 Lattice3D MesoCrystalItem::getLattice() const
 {
-    const kvector_t a1 = GetVectorItem(*this, P_VECTOR_A);
-    const kvector_t a2 = GetVectorItem(*this, P_VECTOR_B);
-    const kvector_t a3 = GetVectorItem(*this, P_VECTOR_C);
+    const kvector_t a1 = item<VectorItem>(P_VECTOR_A).getVector();
+    const kvector_t a2 = item<VectorItem>(P_VECTOR_B).getVector();
+    const kvector_t a3 = item<VectorItem>(P_VECTOR_C).getVector();
     return Lattice3D(a1, a2, a3);
 }
 

--- a/GUI/coregui/Models/MesoCrystalItem.h
+++ b/GUI/coregui/Models/MesoCrystalItem.h
@@ -21,6 +21,7 @@
 class IFormFactor;
 class IParticle;
 class MesoCrystal;
+class VectorItem;
 
 class BA_CORE_API_ MesoCrystalItem : public SessionGraphicsItem {
 public:
@@ -31,6 +32,8 @@ public:
     static const QString P_VECTOR_C;
 
     MesoCrystalItem();
+
+    VectorItem* positionItem() const;
 
     std::unique_ptr<MesoCrystal> createMesoCrystal() const;
 

--- a/GUI/coregui/Models/ParameterTreeUtils.cpp
+++ b/GUI/coregui/Models/ParameterTreeUtils.cpp
@@ -55,8 +55,8 @@ void handleItem(SessionItem* tree, const SessionItem* source);
 
 void ParameterTreeUtils::createParameterTree(JobItem* jobItem)
 {
-    SessionItem* container = jobItem->model()->insertNewItem(
-        "Parameter Container", jobItem->index(), -1, JobItem::T_PARAMETER_TREE);
+    auto container = jobItem->model()->insertItem<ParameterContainerItem>(
+        jobItem->index(), -1, JobItem::T_PARAMETER_TREE);
 
     populateParameterContainer(container, jobItem->getItem(JobItem::T_MATERIAL_CONTAINER));
 
@@ -82,9 +82,7 @@ void ParameterTreeUtils::populateParameterContainer(SessionItem* container,
         throw GUIHelpers::Error("ParameterTreeUtils::populateParameterContainer() -> Error. "
                                 "Not a ParameterContainerType.");
 
-    SessionItem* sourceLabel =
-        container->model()->insertNewItem("Parameter Label", container->index());
-
+    auto sourceLabel = container->model()->insertItem<ParameterLabelItem>(container->index());
     handleItem(sourceLabel, source);
 }
 
@@ -144,7 +142,7 @@ QVector<QPair<QString, QString>> ParameterTreeUtils::parameterDictionary(const S
 
     // Create container with ParameterItem's of given source item
     SampleModel model;
-    SessionItem* container = model.insertNewItem("Parameter Container");
+    auto container = model.insertItem<ParameterContainerItem>();
     populateParameterContainer(container, source);
 
     // Iterate through all ParameterItems and retrieve necessary data.
@@ -198,7 +196,7 @@ SessionItem* ParameterTreeUtils::parameterNameToLinkedItem(const QString& parNam
                                                            const SessionItem* source)
 {
     SampleModel model;
-    SessionItem* container = model.insertNewItem("Parameter Container");
+    auto container = model.insertItem<ParameterContainerItem>();
     populateParameterContainer(container, source);
 
     // Iterate through all ParameterItems and retrieve necessary data.
@@ -246,20 +244,18 @@ void handleItem(SessionItem* tree, const SessionItem* source)
         if (child->isVisible() && child->isEnabled()) {
             if (child->modelType() == "Property") {
                 if (child->value().type() == QVariant::Double) {
-                    SessionItem* branch = tree->model()->insertNewItem("Parameter", tree->index());
+                    auto branch = tree->model()->insertItem<ParameterItem>(tree->index());
                     handleItem(branch, child);
                 }
 
             } else if (child->modelType() == "GroupProperty") {
                 SessionItem* currentItem = dynamic_cast<GroupItem*>(child)->currentItem();
                 if (currentItem && currentItem->numberOfChildren() > 0) {
-                    SessionItem* branch =
-                        tree->model()->insertNewItem("Parameter Label", tree->index());
+                    auto branch = tree->model()->insertItem<ParameterLabelItem>(tree->index());
                     handleItem(branch, currentItem);
                 }
             } else {
-                SessionItem* branch =
-                    tree->model()->insertNewItem("Parameter Label", tree->index());
+                auto branch = tree->model()->insertItem<ParameterLabelItem>(tree->index());
                 handleItem(branch, child);
             }
         }

--- a/GUI/coregui/Models/ParticleCompositionItem.cpp
+++ b/GUI/coregui/Models/ParticleCompositionItem.cpp
@@ -19,6 +19,7 @@
 #include "GUI/coregui/Models/ParticleItem.h"
 #include "GUI/coregui/Models/SessionItemUtils.h"
 #include "GUI/coregui/Models/TransformToDomain.h"
+#include "GUI/coregui/Models/VectorItem.h"
 #include "Sample/Particle/MesoCrystal.h"
 #include "Sample/Particle/Particle.h"
 #include "Sample/Particle/ParticleCoreShell.h"
@@ -65,6 +66,11 @@ ParticleCompositionItem::ParticleCompositionItem() : SessionGraphicsItem("Partic
             getItem(ParticleItem::P_ABUNDANCE)->setEnabled(true);
         }
     });
+}
+
+VectorItem* ParticleCompositionItem::positionItem() const
+{
+    return item<VectorItem>(ParticleItem::P_POSITION);
 }
 
 std::unique_ptr<ParticleComposition> ParticleCompositionItem::createParticleComposition() const

--- a/GUI/coregui/Models/ParticleCompositionItem.h
+++ b/GUI/coregui/Models/ParticleCompositionItem.h
@@ -18,10 +18,15 @@
 #include "GUI/coregui/Models/SessionGraphicsItem.h"
 #include "Sample/Particle/ParticleComposition.h"
 
+class VectorItem;
+
 class BA_CORE_API_ ParticleCompositionItem : public SessionGraphicsItem {
 public:
     static const QString T_PARTICLES;
     ParticleCompositionItem();
+
+    VectorItem* positionItem() const;
+
     std::unique_ptr<ParticleComposition> createParticleComposition() const;
 };
 

--- a/GUI/coregui/Models/ParticleCoreShellItem.cpp
+++ b/GUI/coregui/Models/ParticleCoreShellItem.cpp
@@ -19,6 +19,7 @@
 #include "GUI/coregui/Models/TransformToDomain.h"
 #include "GUI/coregui/utils/GUIHelpers.h"
 #include "Sample/Particle/Particle.h"
+#include "GUI/coregui/Models/VectorItem.h"
 #include "Sample/Particle/ParticleCoreShell.h"
 
 namespace {
@@ -61,6 +62,11 @@ ParticleCoreShellItem::ParticleCoreShellItem() : SessionGraphicsItem("ParticleCo
             getItem(ParticleItem::P_ABUNDANCE)->setEnabled(true);
         }
     });
+}
+
+VectorItem* ParticleCoreShellItem::positionItem() const
+{
+    return item<VectorItem>(ParticleItem::P_POSITION);
 }
 
 std::unique_ptr<ParticleCoreShell> ParticleCoreShellItem::createParticleCoreShell() const

--- a/GUI/coregui/Models/ParticleCoreShellItem.h
+++ b/GUI/coregui/Models/ParticleCoreShellItem.h
@@ -18,12 +18,17 @@
 #include "GUI/coregui/Models/SessionGraphicsItem.h"
 
 class ParticleCoreShell;
+class VectorItem;
 
 class BA_CORE_API_ ParticleCoreShellItem : public SessionGraphicsItem {
 public:
     static const QString T_CORE;
     static const QString T_SHELL;
+
     ParticleCoreShellItem();
+
+    VectorItem* positionItem() const;
+
     std::unique_ptr<ParticleCoreShell> createParticleCoreShell() const;
     QVector<SessionItem*> materialPropertyItems();
 };

--- a/GUI/coregui/Models/ParticleItem.cpp
+++ b/GUI/coregui/Models/ParticleItem.cpp
@@ -24,8 +24,6 @@
 #include "Sample/Particle/Particle.h"
 #include "Sample/Scattering/IFormFactor.h"
 
-using SessionItemUtils::SetVectorItem;
-
 namespace {
 const QString abundance_tooltip = "Proportion of this type of particles normalized to the \n"
                                   "total number of particles in the layout";
@@ -94,10 +92,9 @@ void ParticleItem::updatePropertiesAppearance(SessionItem* newParent)
         setItemValue(ParticleItem::P_ABUNDANCE, 1.0);
         getItem(ParticleItem::P_ABUNDANCE)->setEnabled(false);
         if (isShellParticle()) {
-            kvector_t zero_vector;
-            SetVectorItem(*this, ParticleItem::P_POSITION, zero_vector);
-            SessionItem* positionItem = getItem(ParticleItem::P_POSITION);
-            positionItem->setEnabled(false);
+            auto& pos = item<VectorItem>(P_POSITION);
+            pos.setVector(kvector_t());
+            pos.setEnabled(false);
         }
     } else {
         getItem(ParticleItem::P_ABUNDANCE)->setEnabled(true);

--- a/GUI/coregui/Models/ParticleItem.cpp
+++ b/GUI/coregui/Models/ParticleItem.cpp
@@ -92,9 +92,9 @@ void ParticleItem::updatePropertiesAppearance(SessionItem* newParent)
         setItemValue(ParticleItem::P_ABUNDANCE, 1.0);
         getItem(ParticleItem::P_ABUNDANCE)->setEnabled(false);
         if (isShellParticle()) {
-            auto& pos = item<VectorItem>(P_POSITION);
-            pos.setVector(kvector_t());
-            pos.setEnabled(false);
+            auto pos = item<VectorItem>(P_POSITION);
+            pos->setVector(kvector_t());
+            pos->setEnabled(false);
         }
     } else {
         getItem(ParticleItem::P_ABUNDANCE)->setEnabled(true);

--- a/GUI/coregui/Models/ParticleItem.cpp
+++ b/GUI/coregui/Models/ParticleItem.cpp
@@ -62,6 +62,12 @@ ParticleItem::ParticleItem() : SessionGraphicsItem("Particle")
         [this](SessionItem* newParent) { updatePropertiesAppearance(newParent); });
 }
 
+
+VectorItem* ParticleItem::positionItem() const
+{
+    return item<VectorItem>(P_POSITION);
+}
+
 std::unique_ptr<Particle> ParticleItem::createParticle() const
 {
     auto& ffItem = groupItem<FormFactorItem>(ParticleItem::P_FORM_FACTOR);
@@ -92,7 +98,7 @@ void ParticleItem::updatePropertiesAppearance(SessionItem* newParent)
         setItemValue(ParticleItem::P_ABUNDANCE, 1.0);
         getItem(ParticleItem::P_ABUNDANCE)->setEnabled(false);
         if (isShellParticle()) {
-            auto pos = item<VectorItem>(P_POSITION);
+            auto pos = positionItem();
             pos->setVector(kvector_t());
             pos->setEnabled(false);
         }

--- a/GUI/coregui/Models/ParticleItem.h
+++ b/GUI/coregui/Models/ParticleItem.h
@@ -18,6 +18,7 @@
 #include "GUI/coregui/Models/SessionGraphicsItem.h"
 
 class Particle;
+class VectorItem;
 
 class BA_CORE_API_ ParticleItem : public SessionGraphicsItem {
 public:
@@ -28,6 +29,8 @@ public:
     static const QString T_TRANSFORMATION;
 
     ParticleItem();
+
+    VectorItem* positionItem() const;
 
     std::unique_ptr<Particle> createParticle() const;
     QVector<SessionItem*> materialPropertyItems();

--- a/GUI/coregui/Models/RealDataItem.cpp
+++ b/GUI/coregui/Models/RealDataItem.cpp
@@ -146,7 +146,7 @@ void RealDataItem::setImportData(ImportDataInfo data)
 
     dataItem()->reset(std::move(data));
     getItem(P_NATIVE_DATA_UNITS)->setValue(units_name);
-    item<DataItem>(T_NATIVE_DATA).setOutputData(output_data.release());
+    item<DataItem>(T_NATIVE_DATA)->setOutputData(output_data.release());
 }
 
 bool RealDataItem::holdsDimensionalData() const

--- a/GUI/coregui/Models/RealDataItem.cpp
+++ b/GUI/coregui/Models/RealDataItem.cpp
@@ -113,7 +113,7 @@ void RealDataItem::setOutputData(OutputData<double>* data)
         throw GUIHelpers::Error("Error in RealDataItem::setOutputData: trying to set data "
                                 "incompatible with underlying data item");
     if (!data_item) {
-        this->model()->insertNewItem(target_model_type, this->index(), 0, T_INTENSITY_DATA);
+        model()->insertNewItem(target_model_type, this->index(), 0, T_INTENSITY_DATA);
         ASSERT(getItem(T_INTENSITY_DATA)
                && "Assertion failed in RealDataItem::setOutputData: inserting data item failed.");
     }
@@ -129,7 +129,7 @@ void RealDataItem::initDataItem(size_t data_rank, const QString& tag)
         throw GUIHelpers::Error("Error in RealDataItem::initDataItem: trying to set data "
                                 "incompatible with underlying data item");
     if (!data_item)
-        this->model()->insertNewItem(target_model_type, this->index(), 0, tag);
+        model()->insertNewItem(target_model_type, this->index(), 0, tag);
 }
 
 void RealDataItem::setImportData(ImportDataInfo data)

--- a/GUI/coregui/Models/RectangularDetectorItem.cpp
+++ b/GUI/coregui/Models/RectangularDetectorItem.cpp
@@ -160,13 +160,13 @@ void RectangularDetectorItem::setYSize(int ny)
 std::unique_ptr<IDetector2D> RectangularDetectorItem::createDomainDetector() const
 {
     // basic axes parameters
-    auto& x_axis = item<BasicAxisItem>(RectangularDetectorItem::P_X_AXIS);
-    size_t n_x = x_axis.getItemValue(BasicAxisItem::P_NBINS).toUInt();
-    double width = x_axis.getItemValue(BasicAxisItem::P_MAX_DEG).toDouble();
+    auto x_axis = item<BasicAxisItem>(RectangularDetectorItem::P_X_AXIS);
+    size_t n_x = x_axis->getItemValue(BasicAxisItem::P_NBINS).toUInt();
+    double width = x_axis->getItemValue(BasicAxisItem::P_MAX_DEG).toDouble();
 
-    auto& y_axis = item<BasicAxisItem>(RectangularDetectorItem::P_Y_AXIS);
-    size_t n_y = y_axis.getItemValue(BasicAxisItem::P_NBINS).toUInt();
-    double height = y_axis.getItemValue(BasicAxisItem::P_MAX_DEG).toDouble();
+    auto y_axis = item<BasicAxisItem>(RectangularDetectorItem::P_Y_AXIS);
+    size_t n_y = y_axis->getItemValue(BasicAxisItem::P_NBINS).toUInt();
+    double height = y_axis->getItemValue(BasicAxisItem::P_MAX_DEG).toDouble();
 
     std::unique_ptr<RectangularDetector> result(new RectangularDetector(n_x, width, n_y, height));
 
@@ -237,10 +237,10 @@ void RectangularDetectorItem::update_properties_appearance()
 
 kvector_t RectangularDetectorItem::normalVector() const
 {
-    return item<VectorItem>(RectangularDetectorItem::P_NORMAL).getVector();
+    return item<VectorItem>(RectangularDetectorItem::P_NORMAL)->getVector();
 }
 
 kvector_t RectangularDetectorItem::directionVector() const
 {
-    return item<VectorItem>(RectangularDetectorItem::P_DIRECTION).getVector();
+    return item<VectorItem>(RectangularDetectorItem::P_DIRECTION)->getVector();
 }

--- a/GUI/coregui/Models/SessionItem.cpp
+++ b/GUI/coregui/Models/SessionItem.cpp
@@ -335,14 +335,14 @@ SessionItem* SessionItem::addGroupProperty(const QString& groupTag, const QStrin
 
 SessionItem* SessionItem::setGroupProperty(const QString& groupTag, const QString& modelType) const
 {
-    return item<GroupItem>(groupTag).setCurrentType(modelType);
+    return item<GroupItem>(groupTag)->setCurrentType(modelType);
 }
 
 //! Access subitem of group item.
 
 SessionItem* SessionItem::getGroupItem(const QString& groupName) const
 {
-    return item<GroupItem>(groupName).currentItem();
+    return item<GroupItem>(groupName)->currentItem();
 }
 
 //! Returns corresponding variant under given role, invalid variant when role is not present.

--- a/GUI/coregui/Models/SessionItem.h
+++ b/GUI/coregui/Models/SessionItem.h
@@ -60,7 +60,7 @@ public:
 
     // access tagged items
     SessionItem* getItem(const QString& tag = "", int row = 0) const;
-    template <typename T> T& item(const QString& tag) const;
+    template <typename T> T* item(const QString& tag) const;
     QVector<SessionItem*> getItems(const QString& tag = "") const;
     bool insertItem(int row, SessionItem* item, const QString& tag = "");
     SessionItem* takeItem(int row, const QString& tag);
@@ -138,11 +138,11 @@ private:
     QVector<IPathTranslator*> m_translators;
 };
 
-template <typename T> T& SessionItem::item(const QString& tag) const
+template <typename T> T* SessionItem::item(const QString& tag) const
 {
     T* t = dynamic_cast<T*>(getItem(tag));
     ASSERT(t);
-    return *t;
+    return t;
 }
 
 template <typename T> T& SessionItem::groupItem(const QString& groupName) const

--- a/GUI/coregui/Models/SessionItemUtils.cpp
+++ b/GUI/coregui/Models/SessionItemUtils.cpp
@@ -47,12 +47,6 @@ int SessionItemUtils::ParentRow(const SessionItem& item)
     return -1;
 }
 
-kvector_t SessionItemUtils::GetVectorItem(const SessionItem& item, const QString& name)
-{
-    auto& vectorItem = item.item<VectorItem>(name);
-    return {vectorItem.x(), vectorItem.y(), vectorItem.z()};
-}
-
 void SessionItemUtils::SetVectorItem(const SessionItem& item, const QString& name, kvector_t value)
 {
     auto& vectorItem = item.item<VectorItem>(name);

--- a/GUI/coregui/Models/SessionItemUtils.cpp
+++ b/GUI/coregui/Models/SessionItemUtils.cpp
@@ -49,20 +49,16 @@ int SessionItemUtils::ParentRow(const SessionItem& item)
 
 kvector_t SessionItemUtils::GetVectorItem(const SessionItem& item, const QString& name)
 {
-    SessionItem* vectorItem = item.getItem(name);
-    ASSERT(vectorItem);
-    double x = vectorItem->getItemValue(VectorItem::P_X).toDouble();
-    double y = vectorItem->getItemValue(VectorItem::P_Y).toDouble();
-    double z = vectorItem->getItemValue(VectorItem::P_Z).toDouble();
-    return {x, y, z};
+    auto& vectorItem = item.item<VectorItem>(name);
+    return {vectorItem.x(), vectorItem.y(), vectorItem.z()};
 }
 
 void SessionItemUtils::SetVectorItem(const SessionItem& item, const QString& name, kvector_t value)
 {
-    auto p_vector_item = item.getItem(name);
-    p_vector_item->setItemValue(VectorItem::P_X, value.x());
-    p_vector_item->setItemValue(VectorItem::P_Y, value.y());
-    p_vector_item->setItemValue(VectorItem::P_Z, value.z());
+    auto& vectorItem = item.item<VectorItem>(name);
+    vectorItem.setX(value.x());
+    vectorItem.setY(value.y());
+    vectorItem.setZ(value.z());
 }
 
 int SessionItemUtils::ParentVisibleRow(const SessionItem& item)

--- a/GUI/coregui/Models/SessionItemUtils.cpp
+++ b/GUI/coregui/Models/SessionItemUtils.cpp
@@ -47,14 +47,6 @@ int SessionItemUtils::ParentRow(const SessionItem& item)
     return -1;
 }
 
-void SessionItemUtils::SetVectorItem(const SessionItem& item, const QString& name, kvector_t value)
-{
-    auto& vectorItem = item.item<VectorItem>(name);
-    vectorItem.setX(value.x());
-    vectorItem.setY(value.y());
-    vectorItem.setZ(value.z());
-}
-
 int SessionItemUtils::ParentVisibleRow(const SessionItem& item)
 {
     int result(-1);

--- a/GUI/coregui/Models/SessionItemUtils.h
+++ b/GUI/coregui/Models/SessionItemUtils.h
@@ -26,9 +26,6 @@ namespace SessionItemUtils {
 //! Returns the index of the given item within its parent. Returns -1 when no parent is set.
 int ParentRow(const SessionItem& item);
 
-//! Returns a VectorType group property's value as a kvector_t.
-void SetVectorItem(const SessionItem& item, const QString& name, kvector_t value);
-
 //! Returns the row of the given item within its parent not accounting for all hidden items
 //! above. Returns -1 when no parent set or item is hidden.
 int ParentVisibleRow(const SessionItem& item);

--- a/GUI/coregui/Models/SessionItemUtils.h
+++ b/GUI/coregui/Models/SessionItemUtils.h
@@ -27,9 +27,6 @@ namespace SessionItemUtils {
 int ParentRow(const SessionItem& item);
 
 //! Returns a VectorType group property's value as a kvector_t.
-kvector_t GetVectorItem(const SessionItem& item, const QString& name);
-
-//! Returns a VectorType group property's value as a kvector_t.
 void SetVectorItem(const SessionItem& item, const QString& name, kvector_t value);
 
 //! Returns the row of the given item within its parent not accounting for all hidden items

--- a/GUI/coregui/Models/SessionModel.h
+++ b/GUI/coregui/Models/SessionModel.h
@@ -55,6 +55,8 @@ public:
     QModelIndex indexOfItem(SessionItem* item) const;
     SessionItem* insertNewItem(QString model_type, const QModelIndex& parent = {}, int row = -1,
                                QString tag = "");
+    template <typename T>
+    T* insertItem(const QModelIndex& parent = {}, int row = -1, QString tag = "");
 
     QString getModelTag() const;
     QString getModelName() const;
@@ -102,6 +104,11 @@ private:
     QString m_name;      //!< model name
     QString m_model_tag; //!< model tag (SampleModel, InstrumentModel)
 };
+
+template <typename T> T* SessionModel::insertItem(const QModelIndex& parent, int row, QString tag)
+{
+    return static_cast<T*>(insertNewItem(T().modelType(), parent, row, tag));
+}
 
 template <typename T> T* SessionModel::topItem() const
 {

--- a/GUI/coregui/Models/SpecularBeamInclinationItem.cpp
+++ b/GUI/coregui/Models/SpecularBeamInclinationItem.cpp
@@ -43,8 +43,8 @@ double SpecularBeamInclinationItem::scaleFactor() const
 
 void SpecularBeamInclinationItem::updateFileName(const QString& filename)
 {
-    auto& group_item = item<GroupItem>(P_ALPHA_AXIS);
-    auto axis_item = group_item.getChildOfType("PointwiseAxis");
+    auto group_item = item<GroupItem>(P_ALPHA_AXIS);
+    auto axis_item = group_item->getChildOfType("PointwiseAxis");
     axis_item->setItemValue(PointwiseAxisItem::P_FILE_NAME, filename);
 }
 

--- a/GUI/coregui/Models/TransformFromDomain.cpp
+++ b/GUI/coregui/Models/TransformFromDomain.cpp
@@ -258,7 +258,7 @@ void TransformFromDomain::setGISASBeamItem(BeamItem* beam_item, const GISASSimul
     }
 
     // polarization parameters
-    beam_item->item<VectorItem>(BeamItem::P_POLARIZATION).setVector(beam.getBlochVector());
+    beam_item->item<VectorItem>(BeamItem::P_POLARIZATION)->setVector(beam.getBlochVector());
 }
 
 void TransformFromDomain::setOffSpecularBeamItem(BeamItem* beam_item,
@@ -377,7 +377,7 @@ void TransformFromDomain::setDetectorProperties(DetectorItem* detector_item,
 
     kvector_t analyzer_dir = detector.detectionProperties().analyzerDirection();
     double efficiency = detector.detectionProperties().analyzerEfficiency();
-    detector_item->item<VectorItem>(DetectorItem::P_ANALYZER_DIRECTION).setVector(analyzer_dir);
+    detector_item->item<VectorItem>(DetectorItem::P_ANALYZER_DIRECTION)->setVector(analyzer_dir);
     detector_item->setItemValue(DetectorItem::P_ANALYZER_EFFICIENCY, efficiency);
     detector_item->setItemValue(DetectorItem::P_ANALYZER_TOTAL_TRANSMISSION, total_transmission);
 }
@@ -424,10 +424,10 @@ void TransformFromDomain::setRectangularDetector(RectangularDetectorItem* detect
         detector_item->setDetectorAlignment("Generic");
 
         kvector_t normal = detector.getNormalVector();
-        detector_item->item<VectorItem>(RectangularDetectorItem::P_NORMAL).setVector(normal);
+        detector_item->item<VectorItem>(RectangularDetectorItem::P_NORMAL)->setVector(normal);
 
         kvector_t direction = detector.getDirectionVector();
-        detector_item->item<VectorItem>(RectangularDetectorItem::P_DIRECTION).setVector(direction);
+        detector_item->item<VectorItem>(RectangularDetectorItem::P_DIRECTION)->setVector(direction);
 
         detector_item->setItemValue(RectangularDetectorItem::P_U0, detector.getU0());
         detector_item->setItemValue(RectangularDetectorItem::P_V0, detector.getV0());

--- a/GUI/coregui/Models/TransformFromDomain.cpp
+++ b/GUI/coregui/Models/TransformFromDomain.cpp
@@ -50,9 +50,9 @@
 #include "GUI/coregui/Models/ParticleItem.h"
 #include "GUI/coregui/Models/RectangularDetectorItem.h"
 #include "GUI/coregui/Models/ResolutionFunctionItems.h"
-#include "GUI/coregui/Models/SessionItemUtils.h"
 #include "GUI/coregui/Models/SpecularBeamInclinationItem.h"
 #include "GUI/coregui/Models/SphericalDetectorItem.h"
+#include "GUI/coregui/Models/VectorItem.h"
 #include "GUI/coregui/utils/GUIHelpers.h"
 #include "Param/Distrib/Distributions.h"
 #include "Param/Distrib/RangedDistributions.h"
@@ -64,7 +64,6 @@
 #include "Sample/Slice/LayerRoughness.h"
 
 using namespace node_progeny;
-using SessionItemUtils::SetVectorItem;
 
 namespace {
 void SetPDF1D(SessionItem* item, const IFTDistribution1D* pdf, QString group_name);
@@ -259,7 +258,7 @@ void TransformFromDomain::setGISASBeamItem(BeamItem* beam_item, const GISASSimul
     }
 
     // polarization parameters
-    SetVectorItem(*beam_item, BeamItem::P_POLARIZATION, beam.getBlochVector());
+    beam_item->item<VectorItem>(BeamItem::P_POLARIZATION).setVector(beam.getBlochVector());
 }
 
 void TransformFromDomain::setOffSpecularBeamItem(BeamItem* beam_item,
@@ -378,7 +377,7 @@ void TransformFromDomain::setDetectorProperties(DetectorItem* detector_item,
 
     kvector_t analyzer_dir = detector.detectionProperties().analyzerDirection();
     double efficiency = detector.detectionProperties().analyzerEfficiency();
-    SetVectorItem(*detector_item, DetectorItem::P_ANALYZER_DIRECTION, analyzer_dir);
+    detector_item->item<VectorItem>(DetectorItem::P_ANALYZER_DIRECTION).setVector(analyzer_dir);
     detector_item->setItemValue(DetectorItem::P_ANALYZER_EFFICIENCY, efficiency);
     detector_item->setItemValue(DetectorItem::P_ANALYZER_TOTAL_TRANSMISSION, total_transmission);
 }
@@ -425,10 +424,10 @@ void TransformFromDomain::setRectangularDetector(RectangularDetectorItem* detect
         detector_item->setDetectorAlignment("Generic");
 
         kvector_t normal = detector.getNormalVector();
-        SetVectorItem(*detector_item, RectangularDetectorItem::P_NORMAL, normal);
+        detector_item->item<VectorItem>(RectangularDetectorItem::P_NORMAL).setVector(normal);
 
         kvector_t direction = detector.getDirectionVector();
-        SetVectorItem(*detector_item, RectangularDetectorItem::P_DIRECTION, direction);
+        detector_item->item<VectorItem>(RectangularDetectorItem::P_DIRECTION).setVector(direction);
 
         detector_item->setItemValue(RectangularDetectorItem::P_U0, detector.getU0());
         detector_item->setItemValue(RectangularDetectorItem::P_V0, detector.getV0());

--- a/GUI/coregui/Models/TransformToDomain.cpp
+++ b/GUI/coregui/Models/TransformToDomain.cpp
@@ -78,7 +78,7 @@ std::unique_ptr<MultiLayer> TransformToDomain::createMultiLayer(const SessionIte
     auto cross_corr_length = item.getItemValue(MultiLayerItem::P_CROSS_CORR_LENGTH).toDouble();
     if (cross_corr_length > 0)
         P_multilayer->setCrossCorrLength(cross_corr_length);
-    auto external_field = item.item<VectorItem>(MultiLayerItem::P_EXTERNAL_FIELD).getVector();
+    auto external_field = item.item<VectorItem>(MultiLayerItem::P_EXTERNAL_FIELD)->getVector();
     P_multilayer->setExternalField(external_field);
     return P_multilayer;
 }
@@ -213,7 +213,7 @@ void TransformToDomain::setTransformationInfo(IParticle* result, const SessionIt
 
 void TransformToDomain::setPositionInfo(IParticle* result, const SessionItem& item)
 {
-    kvector_t pos = item.item<VectorItem>(ParticleItem::P_POSITION).getVector();
+    kvector_t pos = item.item<VectorItem>(ParticleItem::P_POSITION)->getVector();
     result->setPosition(pos.x(), pos.y(), pos.z());
 }
 

--- a/GUI/coregui/Models/TransformToDomain.cpp
+++ b/GUI/coregui/Models/TransformToDomain.cpp
@@ -53,8 +53,6 @@
 #include "Sample/Particle/Particle.h"
 #include "Sample/Particle/ParticleCoreShell.h"
 
-using SessionItemUtils::GetVectorItem;
-
 namespace {
 template <class T>
 void setParameterDistributionToSimulation(const std::string& parameter_name,
@@ -80,7 +78,7 @@ std::unique_ptr<MultiLayer> TransformToDomain::createMultiLayer(const SessionIte
     auto cross_corr_length = item.getItemValue(MultiLayerItem::P_CROSS_CORR_LENGTH).toDouble();
     if (cross_corr_length > 0)
         P_multilayer->setCrossCorrLength(cross_corr_length);
-    auto external_field = GetVectorItem(item, MultiLayerItem::P_EXTERNAL_FIELD);
+    auto external_field = item.item<VectorItem>(MultiLayerItem::P_EXTERNAL_FIELD).getVector();
     P_multilayer->setExternalField(external_field);
     return P_multilayer;
 }
@@ -215,7 +213,7 @@ void TransformToDomain::setTransformationInfo(IParticle* result, const SessionIt
 
 void TransformToDomain::setPositionInfo(IParticle* result, const SessionItem& item)
 {
-    kvector_t pos = GetVectorItem(item, ParticleItem::P_POSITION);
+    kvector_t pos = item.item<VectorItem>(ParticleItem::P_POSITION).getVector();
     result->setPosition(pos.x(), pos.y(), pos.z());
 }
 

--- a/GUI/coregui/Models/VectorItem.cpp
+++ b/GUI/coregui/Models/VectorItem.cpp
@@ -60,18 +60,26 @@ void VectorItem::setZ(double value)
     setItemValue(P_Z, value);
 }
 
+void VectorItem::setXYZ(double x_value, double y_value, double z_value)
+{
+    setX(x_value);
+    setY(y_value);
+    setZ(z_value);
+}
+
 kvector_t VectorItem::getVector() const
 {
-    return kvector_t(getItemValue(P_X).toDouble(), getItemValue(P_Y).toDouble(),
-                     getItemValue(P_Z).toDouble());
+    return kvector_t(x(), y(), z());
+}
+
+void VectorItem::setVector(const kvector_t& vec)
+{
+    setXYZ(vec.x(), vec.y(), vec.z());
 }
 
 void VectorItem::updateLabel()
 {
-    QString label = QString("(%1, %2, %3)")
-                        .arg(getItemValue(P_X).toDouble())
-                        .arg(getItemValue(P_Y).toDouble())
-                        .arg(getItemValue(P_Z).toDouble());
+    QString label = QString("(%1, %2, %3)").arg(x()).arg(y()).arg(z());
 
     setValue(label);
 }

--- a/GUI/coregui/Models/VectorItem.cpp
+++ b/GUI/coregui/Models/VectorItem.cpp
@@ -30,6 +30,36 @@ VectorItem::VectorItem() : SessionItem("Vector")
     setEditable(false);
 }
 
+double VectorItem::x() const
+{
+    return getItemValue(P_X).toDouble();
+}
+
+void VectorItem::setX(double value)
+{
+    setItemValue(P_X, value);
+}
+
+double VectorItem::y() const
+{
+    return getItemValue(P_Y).toDouble();
+}
+
+void VectorItem::setY(double value)
+{
+    setItemValue(P_Y, value);
+}
+
+double VectorItem::z() const
+{
+    return getItemValue(P_Z).toDouble();
+}
+
+void VectorItem::setZ(double value)
+{
+    setItemValue(P_Z, value);
+}
+
 kvector_t VectorItem::getVector() const
 {
     return kvector_t(getItemValue(P_X).toDouble(), getItemValue(P_Y).toDouble(),

--- a/GUI/coregui/Models/VectorItem.h
+++ b/GUI/coregui/Models/VectorItem.h
@@ -26,6 +26,15 @@ public:
     static const QString P_Z;
     VectorItem();
 
+    double x() const;
+    void setX(double value);
+
+    double y() const;
+    void setY(double value);
+
+    double z() const;
+    void setZ(double value);
+
     kvector_t getVector() const;
 
 private:

--- a/GUI/coregui/Models/VectorItem.h
+++ b/GUI/coregui/Models/VectorItem.h
@@ -35,7 +35,10 @@ public:
     double z() const;
     void setZ(double value);
 
+    void setXYZ(double x_value, double y_value, double z_value);
+
     kvector_t getVector() const;
+    void setVector(const kvector_t& vec);
 
 private:
     void updateLabel();

--- a/GUI/coregui/Views/FitWidgets/FitComparisonViewController.cpp
+++ b/GUI/coregui/Views/FitWidgets/FitComparisonViewController.cpp
@@ -89,11 +89,10 @@ void FitComparison1DViewController::clear()
 
 void FitComparison1DViewController::createDiffViewItem(JobItem* job_item)
 {
-    m_diff_view_item = dynamic_cast<Data1DViewItem*>(
-        m_diff_item_controller->model()->insertNewItem("Data1DViewItem"));
-    auto container = m_diff_view_item->model()->insertNewItem(
-        "DataPropertyContainer", m_diff_view_item->index(), -1, Data1DViewItem::T_DATA_PROPERTIES);
-    dynamic_cast<DataPropertyContainer*>(container)->addItem(m_diff_item_controller->diffItem());
+    m_diff_view_item = m_diff_item_controller->model()->insertItem<Data1DViewItem>();
+    auto container = m_diff_view_item->model()->insertItem<DataPropertyContainer>(
+        m_diff_view_item->index(), -1, Data1DViewItem::T_DATA_PROPERTIES);
+    container->addItem(m_diff_item_controller->diffItem());
 
     m_diff_view_item->setJobItem(job_item);
     auto job_data_view = job_item->dataItemView();

--- a/GUI/coregui/Views/ImportDataWidgets/RealDataSelectorActions.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/RealDataSelectorActions.cpp
@@ -151,8 +151,7 @@ void RealDataSelectorActions::importDataLoop(int ndim)
         if (ndim == 2) {
             std::unique_ptr<OutputData<double>> data = ImportDataUtils::Import2dData(fileName);
             if (data) {
-                RealDataItem* realDataItem =
-                    dynamic_cast<RealDataItem*>(m_realDataModel->insertNewItem("RealData"));
+                auto realDataItem = m_realDataModel->insertItem<RealDataItem>();
                 realDataItem->setItemName(baseNameOfLoadedFile);
                 realDataItem->setOutputData(data.release());
                 m_selectionModel->clearSelection();
@@ -161,8 +160,7 @@ void RealDataSelectorActions::importDataLoop(int ndim)
         } else if (ndim == 1) {
             auto data = ImportDataUtils::Import1dData(fileName);
             if (data) {
-                RealDataItem* realDataItem =
-                    dynamic_cast<RealDataItem*>(m_realDataModel->insertNewItem("RealData"));
+                auto realDataItem = m_realDataModel->insertItem<RealDataItem>();
                 realDataItem->setItemName(baseNameOfLoadedFile);
                 realDataItem->setImportData(std::move(data));
                 m_selectionModel->clearSelection();

--- a/GUI/coregui/Views/InstrumentWidgets/DetectorMaskDelegate.cpp
+++ b/GUI/coregui/Views/InstrumentWidgets/DetectorMaskDelegate.cpp
@@ -56,11 +56,7 @@ void DetectorMaskDelegate::initMaskEditorContext(MaskEditor* maskEditor,
 void DetectorMaskDelegate::createIntensityDataItem()
 {
     m_tempIntensityDataModel->clear();
-
-    m_intensityItem =
-        dynamic_cast<IntensityDataItem*>(m_tempIntensityDataModel->insertNewItem("IntensityData"));
-    ASSERT(m_intensityItem);
-
+    m_intensityItem = m_tempIntensityDataModel->insertItem<IntensityDataItem>();
     m_intensityItem->getItem(IntensityDataItem::P_PROJECTIONS_FLAG)->setEnabled(false);
     m_intensityItem->setItemValue(IntensityDataItem::P_IS_INTERPOLATED, false);
 

--- a/GUI/coregui/Views/InstrumentWidgets/DetectorMaskDelegate.cpp
+++ b/GUI/coregui/Views/InstrumentWidgets/DetectorMaskDelegate.cpp
@@ -64,12 +64,12 @@ void DetectorMaskDelegate::createIntensityDataItem()
     m_intensityItem->getItem(IntensityDataItem::P_PROJECTIONS_FLAG)->setEnabled(false);
     m_intensityItem->setItemValue(IntensityDataItem::P_IS_INTERPOLATED, false);
 
-    auto& zAxisItem = m_intensityItem->item<AmplitudeAxisItem>(IntensityDataItem::P_ZAXIS);
-    zAxisItem.setItemValue(BasicAxisItem::P_IS_VISIBLE, false);
-    zAxisItem.setItemValue(BasicAxisItem::P_MIN_DEG, 0.0);
-    zAxisItem.setItemValue(BasicAxisItem::P_MAX_DEG, 2.0);
-    zAxisItem.setItemValue(AmplitudeAxisItem::P_IS_LOGSCALE, false);
-    zAxisItem.setItemValue(AmplitudeAxisItem::P_LOCK_MIN_MAX, true);
+    auto zAxisItem = m_intensityItem->item<AmplitudeAxisItem>(IntensityDataItem::P_ZAXIS);
+    zAxisItem->setItemValue(BasicAxisItem::P_IS_VISIBLE, false);
+    zAxisItem->setItemValue(BasicAxisItem::P_MIN_DEG, 0.0);
+    zAxisItem->setItemValue(BasicAxisItem::P_MAX_DEG, 2.0);
+    zAxisItem->setItemValue(AmplitudeAxisItem::P_IS_LOGSCALE, false);
+    zAxisItem->setItemValue(AmplitudeAxisItem::P_LOCK_MIN_MAX, true);
 
     // creating output data corresponding to the detector
     auto instrument = dynamic_cast<const GISASInstrumentItem*>(

--- a/GUI/coregui/Views/IntensityDataWidgets/IntensityDataFFTPresenter.cpp
+++ b/GUI/coregui/Views/IntensityDataWidgets/IntensityDataFFTPresenter.cpp
@@ -28,8 +28,7 @@ IntensityDataFFTPresenter::IntensityDataFFTPresenter(QWidget* parent)
     , m_fftItem(nullptr)
     , m_in_fft_mode(false)
 {
-    m_fftItem = dynamic_cast<IntensityDataItem*>(m_fftModel->insertNewItem("IntensityData"));
-
+    m_fftItem = m_fftModel->insertItem<IntensityDataItem>();
     m_fftAction = new QAction(this);
     m_fftAction->setText("Fourier");
     m_fftAction->setIcon(QIcon(":/images/alpha-f-box.svg"));

--- a/GUI/coregui/Views/JobWidgets/ProjectionsEditorCanvas.cpp
+++ b/GUI/coregui/Views/JobWidgets/ProjectionsEditorCanvas.cpp
@@ -90,9 +90,9 @@ void ProjectionsEditorCanvas::onEnteringColorMap()
     m_block_update = true;
 
     if (m_currentActivity == MaskEditorFlags::HORIZONTAL_LINE_MODE)
-        m_liveProjection = m_model->insertNewItem("HorizontalLineMask", m_containerIndex);
+        m_liveProjection = m_model->insertItem<HorizontalLineItem>(m_containerIndex);
     else if (m_currentActivity == MaskEditorFlags::VERTICAL_LINE_MODE)
-        m_liveProjection = m_model->insertNewItem("VerticalLineMask", m_containerIndex);
+        m_liveProjection = m_model->insertItem<VerticalLineItem>(m_containerIndex);
 
     if (m_liveProjection)
         m_liveProjection->setItemValue(MaskItem::P_IS_VISIBLE, false);

--- a/GUI/coregui/Views/MaskWidgets/MaskGraphicsScene.cpp
+++ b/GUI/coregui/Views/MaskWidgets/MaskGraphicsScene.cpp
@@ -639,7 +639,7 @@ void MaskGraphicsScene::processPolygonItem(QGraphicsSceneMouseEvent* event)
 
     if (!m_currentItem) {
         setDrawingInProgress(true);
-        m_currentItem = m_maskModel->insertNewItem("PolygonMask", m_maskContainerIndex, 0);
+        m_currentItem = m_maskModel->insertItem<PolygonItem>(m_maskContainerIndex, 0);
         m_currentItem->setItemValue(MaskItem::P_MASK_VALUE, m_context.getMaskValue());
         m_selectionModel->clearSelection();
         m_selectionModel->select(m_maskModel->indexOfItem(m_currentItem),
@@ -655,8 +655,7 @@ void MaskGraphicsScene::processPolygonItem(QGraphicsSceneMouseEvent* event)
             return;
         }
     }
-    SessionItem* point =
-        m_maskModel->insertNewItem("PolygonPoint", m_maskModel->indexOfItem(m_currentItem));
+    auto point = m_maskModel->insertItem<PolygonPointItem>(m_maskModel->indexOfItem(m_currentItem));
     QPointF click_pos = event->buttonDownScenePos(Qt::LeftButton);
 
     point->setItemValue(PolygonPointItem::P_POSX, m_adaptor->fromSceneX(click_pos.x()));
@@ -684,13 +683,13 @@ void MaskGraphicsScene::processLineItem(QGraphicsSceneMouseEvent* event)
 
 void MaskGraphicsScene::processVerticalLineItem(const QPointF& pos)
 {
-    m_currentItem = m_maskModel->insertNewItem("VerticalLineMask", m_maskContainerIndex, 0);
+    m_currentItem = m_maskModel->insertItem<VerticalLineItem>(m_maskContainerIndex, 0);
     m_currentItem->setItemValue(VerticalLineItem::P_POSX, m_adaptor->fromSceneX(pos.x()));
 }
 
 void MaskGraphicsScene::processHorizontalLineItem(const QPointF& pos)
 {
-    m_currentItem = m_maskModel->insertNewItem("HorizontalLineMask", m_maskContainerIndex, 0);
+    m_currentItem = m_maskModel->insertItem<HorizontalLineItem>(m_maskContainerIndex, 0);
     m_currentItem->setItemValue(HorizontalLineItem::P_POSY, m_adaptor->fromSceneY(pos.y()));
 }
 
@@ -698,7 +697,7 @@ void MaskGraphicsScene::processMaskAllItem(QGraphicsSceneMouseEvent* event)
 {
     Q_UNUSED(event);
     setDrawingInProgress(true);
-    m_currentItem = m_maskModel->insertNewItem("MaskAllMask", m_maskContainerIndex);
+    m_currentItem = m_maskModel->insertItem<MaskAllItem>(m_maskContainerIndex);
     m_selectionModel->clearSelection();
     setDrawingInProgress(false);
 }

--- a/GUI/coregui/Views/PropertyEditor/TestComponentView.cpp
+++ b/GUI/coregui/Views/PropertyEditor/TestComponentView.cpp
@@ -21,6 +21,7 @@
 #include "GUI/coregui/Models/ParticleItem.h"
 #include "GUI/coregui/Models/SampleModel.h"
 #include "GUI/coregui/Models/SessionModelDelegate.h"
+#include "GUI/coregui/Models/VectorItem.h"
 #include "GUI/coregui/Views/MaterialEditor/MaterialItemUtils.h"
 #include "GUI/coregui/Views/PropertyEditor/ComponentEditor.h"
 #include "GUI/coregui/Views/PropertyEditor/ComponentFlatView.h"

--- a/GUI/coregui/Views/PropertyEditor/TestComponentView.cpp
+++ b/GUI/coregui/Views/PropertyEditor/TestComponentView.cpp
@@ -13,9 +13,12 @@
 //  ************************************************************************************************
 
 #include "GUI/coregui/Views/PropertyEditor/TestComponentView.h"
+#include "GUI/coregui/Models/BeamItems.h"
 #include "GUI/coregui/Models/GUIObjectBuilder.h"
+#include "GUI/coregui/Models/IntensityDataItem.h"
 #include "GUI/coregui/Models/MaterialDataItems.h"
 #include "GUI/coregui/Models/MaterialModel.h"
+#include "GUI/coregui/Models/ParticleItem.h"
 #include "GUI/coregui/Models/SampleModel.h"
 #include "GUI/coregui/Models/SessionModelDelegate.h"
 #include "GUI/coregui/Views/MaterialEditor/MaterialItemUtils.h"
@@ -88,7 +91,7 @@ void TestComponentView::onUpdateRequest()
 
 void TestComponentView::onAddItemRequest()
 {
-    m_sampleModel->insertNewItem("Particle");
+    m_sampleModel->insertItem<ParticleItem>();
 }
 
 void TestComponentView::onExpandRequest()
@@ -121,11 +124,9 @@ void TestComponentView::init_source()
     const std::unique_ptr<MultiLayer> sample(
         factory.createSampleByName("CylindersWithSizeDistributionBuilder"));
     GUIObjectBuilder::populateSampleModel(m_sampleModel, m_materialModel, *sample);
-    m_sampleModel->insertNewItem("Vector");
-    m_sampleModel->insertNewItem("GISASBeam");
-
-    // adding intensity data item
-    m_sampleModel->insertNewItem("IntensityData");
+    m_sampleModel->insertItem<VectorItem>();
+    m_sampleModel->insertItem<GISASBeamItem>();
+    m_sampleModel->insertItem<IntensityDataItem>();
 }
 
 void TestComponentView::onSelectionChanged(const QItemSelection& selected, const QItemSelection&)

--- a/GUI/coregui/Views/SampleDesigner/DesignerScene.cpp
+++ b/GUI/coregui/Views/SampleDesigner/DesignerScene.cpp
@@ -413,7 +413,7 @@ void DesignerScene::dropEvent(QGraphicsSceneDragDropEvent* event)
 
                 SessionItem* new_item(0);
                 if (mimeData->getClassName().startsWith("FormFactor")) {
-                    new_item = m_sampleModel->insertNewItem("Particle");
+                    new_item = m_sampleModel->insertItem<ParticleItem>();
                     QString ffName = mimeData->getClassName();
                     ffName.remove("FormFactor");
                     new_item->setGroupProperty(ParticleItem::P_FORM_FACTOR, ffName);

--- a/GUI/coregui/Views/SampleDesigner/ParticleView.cpp
+++ b/GUI/coregui/Views/SampleDesigner/ParticleView.cpp
@@ -97,7 +97,7 @@ void ParticleView::updatePixmap()
     if (!getItem())
         return;
 
-    QString ff_type = getItem()->item<GroupItem>(ParticleItem::P_FORM_FACTOR).currentType();
+    QString ff_type = getItem()->item<GroupItem>(ParticleItem::P_FORM_FACTOR)->currentType();
     QString filename = QString(":/widgetbox/images/ff_%1_64x64.png").arg(ff_type);
     m_pixmap = QPixmap(filename);
 }
@@ -107,6 +107,6 @@ void ParticleView::updateToolTip()
     if (!getItem())
         return;
 
-    auto ffItem = getItem()->item<GroupItem>(ParticleItem::P_FORM_FACTOR).currentItem();
+    auto ffItem = getItem()->item<GroupItem>(ParticleItem::P_FORM_FACTOR)->currentItem();
     setToolTip(ffItem->toolTip());
 }

--- a/GUI/coregui/Views/TestView.cpp
+++ b/GUI/coregui/Views/TestView.cpp
@@ -85,8 +85,7 @@ void TestView::test_MinimizerSettings()
     setLayout(layout);
 
     SessionModel* model = new SessionModel("TempModel", this);
-    MinimizerContainerItem* minimizerItem =
-        dynamic_cast<MinimizerContainerItem*>(model->insertNewItem("MinimizerContainer"));
+    auto minimizerItem = model->insertItem<MinimizerContainerItem>();
     widget->setItem(minimizerItem);
 }
 
@@ -181,7 +180,7 @@ void TestView::test_specular_data_widget()
     SessionModel* tempModel = new SessionModel("Test", this);
 
     // creating job item
-    auto job_item = dynamic_cast<JobItem*>(tempModel->insertNewItem("JobItem"));
+    auto job_item = tempModel->insertItem<JobItem>();
 
     // creating "simulation" data
     auto data_item = new SpecularDataItem();

--- a/GUI/coregui/Views/TestView.cpp
+++ b/GUI/coregui/Views/TestView.cpp
@@ -199,9 +199,9 @@ void TestView::test_specular_data_widget()
     auto data_view = new Data1DViewItem();
     job_item->insertItem(-1, data_view, JobItem::T_DATAVIEW);
     data_view->insertItem(-1, new DataPropertyContainer, Data1DViewItem::T_DATA_PROPERTIES);
-    auto& container = data_view->item<DataPropertyContainer>(Data1DViewItem::T_DATA_PROPERTIES);
-    container.addItem(job_item->realDataItem()->dataItem());
-    container.addItem(job_item->dataItem());
+    auto container = data_view->item<DataPropertyContainer>(Data1DViewItem::T_DATA_PROPERTIES);
+    container->addItem(job_item->realDataItem()->dataItem());
+    container->addItem(job_item->dataItem());
 
     QVBoxLayout* layout = new QVBoxLayout;
     layout->setMargin(0);

--- a/Tests/UnitTests/GUI/TestComponentProxyModel.cpp
+++ b/Tests/UnitTests/GUI/TestComponentProxyModel.cpp
@@ -64,10 +64,10 @@ TEST_F(TestComponentProxyModel, test_setModelWithVector)
     const int ncols = static_cast<int>(SessionFlags::MAX_COLUMNS);
 
     SessionModel model("TestModel");
-    SessionItem* item = model.insertNewItem("Vector");
-    item->setItemValue(VectorItem::P_X, 1.0);
-    item->setItemValue(VectorItem::P_Y, 2.0);
-    item->setItemValue(VectorItem::P_Z, 3.0);
+    auto item = model.insertItem<VectorItem>();
+    item->setX(1.0);
+    item->setY(2.0);
+    item->setZ(3.0);
 
     ComponentProxyModel proxy;
     proxy.setSessionModel(&model);

--- a/Tests/UnitTests/GUI/TestComponentProxyModel.cpp
+++ b/Tests/UnitTests/GUI/TestComponentProxyModel.cpp
@@ -3,8 +3,11 @@
 #include "GUI/coregui/Models/ComponentProxyStrategy.h"
 #include "GUI/coregui/Models/FormFactorItems.h"
 #include "GUI/coregui/Models/GroupItem.h"
+#include "GUI/coregui/Models/LayerItem.h"
 #include "GUI/coregui/Models/ModelUtils.h"
+#include "GUI/coregui/Models/MultiLayerItem.h"
 #include "GUI/coregui/Models/ParticleItem.h"
+#include "GUI/coregui/Models/ParticleLayoutItem.h"
 #include "GUI/coregui/Models/SessionModel.h"
 #include "GUI/coregui/Models/VectorItem.h"
 #include "Tests/GTestWrapper/google_test.h"
@@ -46,7 +49,7 @@ TEST_F(TestComponentProxyModel, test_setModel)
 TEST_F(TestComponentProxyModel, test_setModelWithItem)
 {
     SessionModel model("TestModel");
-    model.insertNewItem("Property");
+    model.insertItem<PropertyItem>();
 
     ComponentProxyModel proxy;
     proxy.setSessionModel(&model);
@@ -155,9 +158,9 @@ TEST_F(TestComponentProxyModel, test_setModelWithVector)
 TEST_F(TestComponentProxyModel, test_displayRole)
 {
     SessionModel model("TestModel");
-    SessionItem* item1 = model.insertNewItem("Property");
+    auto item1 = model.insertItem<PropertyItem>();
     item1->setValue(1.0);
-    SessionItem* item2 = model.insertNewItem("Property");
+    auto item2 = model.insertItem<PropertyItem>();
     item2->setValue(2.0);
 
     EXPECT_EQ(model.data(model.index(0, 1, QModelIndex()), Qt::DisplayRole).toDouble(), 1.0);
@@ -175,7 +178,7 @@ TEST_F(TestComponentProxyModel, test_displayRole)
 TEST_F(TestComponentProxyModel, test_setData)
 {
     SessionModel model("TestModel");
-    SessionItem* item = model.insertNewItem("Property");
+    auto item = model.insertItem<PropertyItem>();
     item->setValue(1.0);
 
     ComponentProxyModel proxy;
@@ -226,7 +229,7 @@ TEST_F(TestComponentProxyModel, test_insertRows)
     QSignalSpy spyProxy(&proxy, &ComponentProxyModel::layoutChanged);
 
     // inserting item in the source
-    model.insertNewItem("Property");
+    model.insertItem<PropertyItem>();
     EXPECT_EQ(spyProxy.count(), 1);
     EXPECT_EQ(proxy.rowCount(QModelIndex()), 1);
 }
@@ -243,7 +246,7 @@ TEST_F(TestComponentProxyModel, test_componentStrategy)
     proxy.setSessionModel(&model);
 
     // inserting particle
-    SessionItem* item = model.insertNewItem("Particle");
+    auto item = model.insertItem<ParticleItem>();
     auto group = dynamic_cast<GroupItem*>(item->getItem(ParticleItem::P_FORM_FACTOR));
     SessionItem* ffItem = item->getGroupItem(ParticleItem::P_FORM_FACTOR);
     EXPECT_TRUE(ffItem->parent() == group);
@@ -288,7 +291,7 @@ TEST_F(TestComponentProxyModel, test_componentStrategyFormFactorChanges)
     proxy.setSessionModel(&model);
 
     // inserting particle
-    SessionItem* item = model.insertNewItem("Particle");
+    auto item = model.insertItem<ParticleItem>();
     auto group = dynamic_cast<GroupItem*>(item->getItem(ParticleItem::P_FORM_FACTOR));
     SessionItem* ffItem = item->getGroupItem(ParticleItem::P_FORM_FACTOR);
     EXPECT_TRUE(ffItem->parent() == group);
@@ -321,7 +324,7 @@ TEST_F(TestComponentProxyModel, test_setRootPropertyItem)
     proxy.setSessionModel(&model);
 
     // inserting simple property item
-    SessionItem* item = model.insertNewItem("Property");
+    auto item = model.insertItem<PropertyItem>();
     item->setValue(42.0);
     proxy.setRootIndex(model.indexOfItem(item));
 
@@ -358,10 +361,10 @@ TEST_F(TestComponentProxyModel, test_setRootIndexLayer)
     proxy.setSessionModel(&model);
 
     // inserting multilayer with two layers
-    auto multilayer = model.insertNewItem("MultiLayer");
-    auto layer1 = model.insertNewItem("Layer", model.indexOfItem(multilayer));
-    auto layout = model.insertNewItem("ParticleLayout", model.indexOfItem(layer1));
-    model.insertNewItem("Layer", model.indexOfItem(multilayer));
+    auto multilayer = model.insertItem<MultiLayerItem>();
+    auto layer1 = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
+    auto layout = model.insertItem<ParticleLayoutItem>(model.indexOfItem(layer1));
+    model.insertItem<LayerItem>(model.indexOfItem(multilayer));
 
     proxy.setRootIndex(model.indexOfItem(layer1));
     EXPECT_EQ(proxy.rowCount(QModelIndex()), 1);

--- a/Tests/UnitTests/GUI/TestComponentUtils.cpp
+++ b/Tests/UnitTests/GUI/TestComponentUtils.cpp
@@ -14,7 +14,7 @@ TEST_F(TestComponentUtils, test_componentItems)
 {
     SessionModel model("TestModel");
 
-    SessionItem* particle = model.insertNewItem("Particle");
+    auto particle = model.insertItem<ParticleItem>();
     SessionItem* group = particle->getItem(ParticleItem::P_FORM_FACTOR);
     SessionItem* ffItem = particle->getGroupItem(ParticleItem::P_FORM_FACTOR);
 
@@ -34,7 +34,7 @@ TEST_F(TestComponentUtils, test_componentItemsFFChange)
 {
     SessionModel model("TestModel");
 
-    SessionItem* particle = model.insertNewItem("Particle");
+    auto particle = model.insertItem<ParticleItem>();
     SessionItem* group = particle->getItem(ParticleItem::P_FORM_FACTOR);
 
     particle->setGroupProperty(ParticleItem::P_FORM_FACTOR, "FullSphere");

--- a/Tests/UnitTests/GUI/TestDataItemViews.cpp
+++ b/Tests/UnitTests/GUI/TestDataItemViews.cpp
@@ -1,6 +1,7 @@
 #include "GUI/coregui/Models/ApplicationModels.h"
 #include "GUI/coregui/Models/ComboProperty.h"
 #include "GUI/coregui/Models/DataItem.h"
+#include "GUI/coregui/Models/SpecularDataItem.h"
 #include "GUI/coregui/Models/DataProperties.h"
 #include "GUI/coregui/Models/DataPropertyContainer.h"
 #include "GUI/coregui/Models/RealDataModel.h"
@@ -17,7 +18,7 @@ public:
 
 DataItem* TestDataItemViews::insertNewDataItem(SessionModel& model, double val)
 {
-    auto item = model.insertItem<DataItem>();
+    auto item = model.insertItem<SpecularDataItem>();
     auto data = GuiUnittestUtils::createData(val, GuiUnittestUtils::DIM::D1);
     item->setOutputData(data.release());
     return item;

--- a/Tests/UnitTests/GUI/TestDataItemViews.cpp
+++ b/Tests/UnitTests/GUI/TestDataItemViews.cpp
@@ -17,7 +17,7 @@ public:
 
 DataItem* TestDataItemViews::insertNewDataItem(SessionModel& model, double val)
 {
-    DataItem* item = dynamic_cast<DataItem*>(model.insertNewItem("SpecularData"));
+    auto item = model.insertItem<DataItem>();
     auto data = GuiUnittestUtils::createData(val, GuiUnittestUtils::DIM::D1);
     item->setOutputData(data.release());
     return item;
@@ -26,8 +26,7 @@ DataItem* TestDataItemViews::insertNewDataItem(SessionModel& model, double val)
 TEST_F(TestDataItemViews, testDataLinking)
 {
     SessionModel model("TempModel");
-    auto view_item =
-        dynamic_cast<DataPropertyContainer*>(model.insertNewItem("DataPropertyContainer"));
+    auto view_item = model.insertItem<DataPropertyContainer>();
     DataItem* item = insertNewDataItem(model, 0.0);
     view_item->addItem(item);
 
@@ -39,8 +38,7 @@ TEST_F(TestDataItemViews, testDataLinking)
 TEST_F(TestDataItemViews, testLinkingSeveralItems)
 {
     SessionModel model("TempModel");
-    auto view_item =
-        dynamic_cast<DataPropertyContainer*>(model.insertNewItem("DataPropertyContainer"));
+    auto view_item = model.insertItem<DataPropertyContainer>();
     DataItem* item = insertNewDataItem(model, 0.0);
     DataItem* item2 = insertNewDataItem(model, 1.0);
     DataItem* item3 = insertNewDataItem(model, 2.0);
@@ -58,8 +56,7 @@ TEST_F(TestDataItemViews, testLinkingSeveralItems)
 TEST_F(TestDataItemViews, testColors)
 {
     SessionModel model("TempModel");
-    auto view_item =
-        dynamic_cast<DataPropertyContainer*>(model.insertNewItem("DataPropertyContainer"));
+    auto view_item = model.insertItem<DataPropertyContainer>();
     DataItem* item = insertNewDataItem(model, 0.0);
     DataItem* item2 = insertNewDataItem(model, 1.0);
     DataItem* item3 = insertNewDataItem(model, 2.0);
@@ -95,8 +92,7 @@ TEST_F(TestDataItemViews, testColors)
 TEST_F(TestDataItemViews, testBrokenLink)
 {
     SessionModel model("TempModel");
-    auto view_item =
-        dynamic_cast<DataPropertyContainer*>(model.insertNewItem("DataPropertyContainer"));
+    auto view_item = model.insertItem<DataPropertyContainer>();
     DataItem* item = insertNewDataItem(model, 0.0);
     view_item->addItem(item);
 
@@ -113,8 +109,7 @@ TEST_F(TestDataItemViews, testWrongHostingModel)
 {
     SessionModel model("TempModel");
     DataItem* item = insertNewDataItem(model, 0.0);
-    auto view_item =
-        dynamic_cast<DataPropertyContainer*>(model.insertNewItem("DataPropertyContainer"));
+    auto view_item = model.insertItem<DataPropertyContainer>();
     view_item->addItem(item);
 
     SessionModel model2("TempModel2");
@@ -138,8 +133,7 @@ TEST_F(TestDataItemViews, testSavingLinkedData)
         SessionModel* real_data_model = models.realDataModel();
         DataItem* item = insertNewDataItem(*real_data_model, 0.0);
         DataItem* item2 = insertNewDataItem(*real_data_model, 1.0);
-        auto view_item = dynamic_cast<DataPropertyContainer*>(
-            real_data_model->insertNewItem("DataPropertyContainer"));
+        auto view_item = real_data_model->insertItem<DataPropertyContainer>();
         view_item->addItem(item);
         view_item->addItem(item2);
 

--- a/Tests/UnitTests/GUI/TestDataItems.cpp
+++ b/Tests/UnitTests/GUI/TestDataItems.cpp
@@ -1,44 +1,43 @@
-#include "GUI/coregui/Models/DataItem.h"
+#include "GUI/coregui/Models/IntensityDataItem.h"
 #include "GUI/coregui/Models/SessionModel.h"
+#include "GUI/coregui/Models/SpecularDataItem.h"
 #include "Tests/GTestWrapper/google_test.h"
 #include <QTest>
 
 class TestDataItems : public ::testing::Test {
 public:
-    void testItemClock(QString type);
+    template <typename T> void testItemClock()
+    {
+        SessionModel model("TempModel");
+        auto item = model.insertItem<T>();
+
+        QDateTime time = QDateTime::currentDateTime();
+        item->setLastModified(time);
+        EXPECT_EQ(time, item->lastModified());
+
+        const int nap_time(20);
+        QTest::qSleep(nap_time);
+
+        // changing item (file name)
+        item->setItemValue(DataItem::P_FILE_NAME, "name.txt");
+        QDateTime time2 = item->lastModified();
+        EXPECT_TRUE(time.msecsTo(time2) > nap_time / 2);
+
+        QTest::qSleep(nap_time);
+
+        // changing item (OutputData)
+        item->emitDataChanged();
+        QDateTime time3 = item->lastModified();
+        EXPECT_TRUE(time2.msecsTo(time3) > nap_time / 2);
+    }
 };
-
-void TestDataItems::testItemClock(QString model_type)
-{
-    SessionModel model("TempModel");
-    DataItem* item = dynamic_cast<DataItem*>(model.insertNewItem(model_type));
-
-    QDateTime time = QDateTime::currentDateTime();
-    item->setLastModified(time);
-    EXPECT_EQ(time, item->lastModified());
-
-    const int nap_time(20);
-    QTest::qSleep(nap_time);
-
-    // changing item (file name)
-    item->setItemValue(DataItem::P_FILE_NAME, "name.txt");
-    QDateTime time2 = item->lastModified();
-    EXPECT_TRUE(time.msecsTo(time2) > nap_time / 2);
-
-    QTest::qSleep(nap_time);
-
-    // changing item (OutputData)
-    item->emitDataChanged();
-    QDateTime time3 = item->lastModified();
-    EXPECT_TRUE(time2.msecsTo(time3) > nap_time / 2);
-}
 
 TEST_F(TestDataItems, testSpecularItemClock)
 {
-    testItemClock("SpecularData");
+    testItemClock<SpecularDataItem>();
 }
 
 TEST_F(TestDataItems, testIntensityItemClock)
 {
-    testItemClock("IntensityData");
+    testItemClock<IntensityDataItem>();
 }

--- a/Tests/UnitTests/GUI/TestDetectorItems.cpp
+++ b/Tests/UnitTests/GUI/TestDetectorItems.cpp
@@ -14,7 +14,7 @@ class TestDetectorItems : public ::testing::Test {
 TEST_F(TestDetectorItems, test_detectorAlignment)
 {
     InstrumentModel model;
-    SessionItem* detector = model.insertNewItem("RectangularDetector");
+    auto detector = model.insertItem<RectangularDetectorItem>();
 
     ComboProperty alignment =
         detector->getItemValue(RectangularDetectorItem::P_ALIGNMENT).value<ComboProperty>();
@@ -34,8 +34,7 @@ TEST_F(TestDetectorItems, test_detectorAlignment)
 TEST_F(TestDetectorItems, test_resolutionFunction)
 {
     InstrumentModel model;
-    GISASInstrumentItem* instrument =
-        dynamic_cast<GISASInstrumentItem*>(model.insertNewItem("GISASInstrument"));
+    auto instrument = model.insertItem<GISASInstrumentItem>();
 
     DetectorItem* detectorItem = instrument->detectorItem();
 

--- a/Tests/UnitTests/GUI/TestFitParameterModel.cpp
+++ b/Tests/UnitTests/GUI/TestFitParameterModel.cpp
@@ -10,9 +10,9 @@ class TestFitParameterModel : public ::testing::Test {
 TEST_F(TestFitParameterModel, test_InitialState)
 {
     JobModel source;
-    SessionItem* fitSuiteItem = source.insertNewItem("FitSuite");
-    SessionItem* container = source.insertNewItem("FitParameterContainer", fitSuiteItem->index(),
-                                                  -1, FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
+    auto fitSuiteItem = source.insertItem<FitSuiteItem>();
+    auto container = source.insertItem<FitParameterContainerItem>(
+        fitSuiteItem->index(), -1, FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
     FitParameterProxyModel proxy(dynamic_cast<FitParameterContainerItem*>(container));
 
     EXPECT_EQ(0, proxy.rowCount(QModelIndex()));
@@ -24,13 +24,13 @@ TEST_F(TestFitParameterModel, test_InitialState)
 TEST_F(TestFitParameterModel, test_addFitParameter)
 {
     JobModel source;
-    SessionItem* fitSuiteItem = source.insertNewItem("FitSuite");
-    SessionItem* container = source.insertNewItem("FitParameterContainer", fitSuiteItem->index(),
-                                                  -1, FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
+    auto fitSuiteItem = source.insertItem<FitSuiteItem>();
+    auto container = source.insertItem<FitParameterContainerItem>(
+        fitSuiteItem->index(), -1, FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
     FitParameterProxyModel proxy(dynamic_cast<FitParameterContainerItem*>(container));
 
     // adding fit parameter
-    SessionItem* fitPar0 = source.insertNewItem("FitParameter", container->index());
+    auto fitPar0 = source.insertItem<FitParameterItem>(container->index());
     fitPar0->setDisplayName("par");
     fitPar0->setItemValue(FitParameterItem::P_MIN, 1.0);
     fitPar0->setItemValue(FitParameterItem::P_MAX, 2.0);
@@ -90,7 +90,7 @@ TEST_F(TestFitParameterModel, test_addFitParameter)
     // ----------------------------------------------------
     // adding second fit parameter
     // ----------------------------------------------------
-    SessionItem* fitPar1 = source.insertNewItem("FitParameter", container->index());
+    auto fitPar1 = source.insertItem<FitParameterItem>(container->index());
     fitPar0->setDisplayName("par");
     fitPar0->setItemValue(FitParameterItem::P_MIN, 10.0);
     fitPar0->setItemValue(FitParameterItem::P_MAX, 20.0);
@@ -128,20 +128,20 @@ TEST_F(TestFitParameterModel, test_addFitParameter)
 TEST_F(TestFitParameterModel, test_addFitParameterAndLink)
 {
     JobModel source;
-    SessionItem* fitSuiteItem = source.insertNewItem("FitSuite");
-    SessionItem* container = source.insertNewItem("FitParameterContainer", fitSuiteItem->index(),
-                                                  -1, FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
+    auto fitSuiteItem = source.insertItem<FitSuiteItem>();
+    auto container = source.insertItem<FitParameterContainerItem>(
+        fitSuiteItem->index(), -1, FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
     FitParameterProxyModel proxy(dynamic_cast<FitParameterContainerItem*>(container));
 
     // adding fit parameter
-    SessionItem* fitPar0 = source.insertNewItem("FitParameter", container->index());
+    auto fitPar0 = source.insertItem<FitParameterItem>(container->index());
     fitPar0->setDisplayName("par");
     fitPar0->setItemValue(FitParameterItem::P_MIN, 1.0);
     fitPar0->setItemValue(FitParameterItem::P_MAX, 2.0);
     fitPar0->setItemValue(FitParameterItem::P_START_VALUE, 3.0);
 
     // adding link
-    SessionItem* link0 = source.insertNewItem("FitParameterLink", fitPar0->index());
+    auto link0 = source.insertItem<FitParameterLinkItem>(fitPar0->index());
     link0->setItemValue(FitParameterLinkItem::P_LINK, "link0");
 
     // checking index of root
@@ -171,7 +171,7 @@ TEST_F(TestFitParameterModel, test_addFitParameterAndLink)
     EXPECT_EQ(linkIndex, proxy.indexOfItem(link0->getItem(FitParameterLinkItem::P_LINK)));
 
     // adding second link
-    SessionItem* link1 = source.insertNewItem("FitParameterLink", fitPar0->index());
+    auto link1 = source.insertItem<FitParameterLinkItem>(fitPar0->index());
     link1->setItemValue(FitParameterLinkItem::P_LINK, "link1");
     EXPECT_EQ(proxy.rowCount(index), 2);
     EXPECT_EQ(proxy.columnCount(index), 1); // linkItem
@@ -191,18 +191,18 @@ TEST_F(TestFitParameterModel, test_addFitParameterAndLink)
 TEST_F(TestFitParameterModel, test_addTwoFitParameterAndLinks)
 {
     JobModel source;
-    SessionItem* fitSuiteItem = source.insertNewItem("FitSuite");
-    SessionItem* container = source.insertNewItem("FitParameterContainer", fitSuiteItem->index(),
-                                                  -1, FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
+    auto fitSuiteItem = source.insertItem<FitSuiteItem>();
+    auto container = source.insertItem<FitParameterContainerItem>(
+        fitSuiteItem->index(), -1, FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
     FitParameterProxyModel proxy(dynamic_cast<FitParameterContainerItem*>(container));
 
     // adding fit parameters
-    SessionItem* fitPar0 = source.insertNewItem("FitParameter", container->index());
-    SessionItem* link0 = source.insertNewItem("FitParameterLink", fitPar0->index());
+    auto fitPar0 = source.insertItem<FitParameterItem>(container->index());
+    auto link0 = source.insertItem<FitParameterLinkItem>(fitPar0->index());
     Q_UNUSED(link0);
 
-    SessionItem* fitPar1 = source.insertNewItem("FitParameter", container->index());
-    SessionItem* link1 = source.insertNewItem("FitParameterLink", fitPar1->index());
+    auto fitPar1 = source.insertItem<FitParameterItem>(container->index());
+    auto link1 = source.insertItem<FitParameterLinkItem>(fitPar1->index());
     Q_UNUSED(link1);
 
     // checking index of root

--- a/Tests/UnitTests/GUI/TestGroupItem.cpp
+++ b/Tests/UnitTests/GUI/TestGroupItem.cpp
@@ -55,7 +55,7 @@ TEST_F(TestGroupItem, test_CreateGroup)
     GroupInfo groupInfo = SessionItemUtils::GetGroupInfo("Form Factor");
     EXPECT_EQ(groupInfo.defaultType(), "Cylinder");
 
-    auto groupItem = dynamic_cast<GroupItem*>(model.insertNewItem("GroupProperty"));
+    auto groupItem = model.insertItem<GroupItem>();
     EXPECT_EQ(groupItem->children().size(), 0);
     EXPECT_TRUE(groupItem->currentItem() == nullptr);
     EXPECT_FALSE(groupItem->value().isValid());

--- a/Tests/UnitTests/GUI/TestLayerItems.cpp
+++ b/Tests/UnitTests/GUI/TestLayerItems.cpp
@@ -14,7 +14,7 @@ class TestLayerItems : public ::testing::Test {
 TEST_F(TestLayerItems, test_LayerDefaultMaterial)
 {
     ApplicationModels models;
-    auto layer = models.sampleModel()->insertNewItem("Layer");
+    auto layer = models.sampleModel()->insertItem<LayerItem>();
     auto materials = models.materialModel()->topItems();
     auto defMaterial = materials.front();
 

--- a/Tests/UnitTests/GUI/TestLinkInstrument.cpp
+++ b/Tests/UnitTests/GUI/TestLinkInstrument.cpp
@@ -76,8 +76,8 @@ TEST_F(TestLinkInstrument, test_canLinkToInstrument)
 
     // changing detector binning and checking that link is destroyed
     DetectorItem* detectorItem = instrument->detectorItem();
-    auto& x_axis = detectorItem->item<BasicAxisItem>(RectangularDetectorItem::P_X_AXIS);
-    x_axis.setItemValue(BasicAxisItem::P_NBINS, 10);
+    auto x_axis = detectorItem->item<BasicAxisItem>(RectangularDetectorItem::P_X_AXIS);
+    x_axis->setItemValue(BasicAxisItem::P_NBINS, 10);
 
     EXPECT_EQ(manager.linkedItems(instrument), QList<RealDataItem*>());
     EXPECT_EQ(realData->getItemValue(RealDataItem::P_INSTRUMENT_ID).toString(), QString());

--- a/Tests/UnitTests/GUI/TestLinkInstrument.cpp
+++ b/Tests/UnitTests/GUI/TestLinkInstrument.cpp
@@ -29,8 +29,7 @@ TEST_F(TestLinkInstrument, test_linkInstrumentManager)
     QSignalSpy spy(&manager, SIGNAL(instrumentMapUpdated()));
 
     // populating instrument model
-    GISASInstrumentItem* instrument =
-        dynamic_cast<GISASInstrumentItem*>(instrumentModel.insertNewItem("GISASInstrument"));
+    auto instrument = instrumentModel.insertItem<GISASInstrumentItem>();
     QString identifier = instrument->getItemValue(InstrumentItem::P_IDENTIFIER).toString();
 
     // checking that LinkInstrumentManager was notified about new instrument
@@ -56,8 +55,7 @@ TEST_F(TestLinkInstrument, test_canLinkToInstrument)
     manager.setModels(&instrumentModel, &realDataModel);
 
     // populating instrument model
-    GISASInstrumentItem* instrument =
-        dynamic_cast<GISASInstrumentItem*>(instrumentModel.insertNewItem("GISASInstrument"));
+    auto instrument = instrumentModel.insertItem<GISASInstrumentItem>();
     QString identifier = instrument->getItemValue(InstrumentItem::P_IDENTIFIER).toString();
 
     // populating real data model, setting intensity data

--- a/Tests/UnitTests/GUI/TestMapperCases.cpp
+++ b/Tests/UnitTests/GUI/TestMapperCases.cpp
@@ -1,5 +1,9 @@
 #include "GUI/coregui/Models/ComboProperty.h"
 #include "GUI/coregui/Models/DocumentModel.h"
+#include "GUI/coregui/Models/LayerItem.h"
+#include "GUI/coregui/Models/MultiLayerItem.h"
+#include "GUI/coregui/Models/ParticleCompositionItem.h"
+#include "GUI/coregui/Models/ParticleDistributionItem.h"
 #include "GUI/coregui/Models/ParticleItem.h"
 #include "GUI/coregui/Models/ParticleLayoutItem.h"
 #include "GUI/coregui/Models/SampleModel.h"
@@ -16,28 +20,28 @@ class TestMapperCases : public ::testing::Test {
 TEST_F(TestMapperCases, test_ParticeleCompositionUpdate)
 {
     SampleModel model;
-    SessionItem* multilayer = model.insertNewItem("MultiLayer");
-    SessionItem* layer = model.insertNewItem("Layer", multilayer->index());
-    SessionItem* layout = model.insertNewItem("ParticleLayout", layer->index());
+    auto multilayer = model.insertItem<MultiLayerItem>();
+    auto layer = model.insertItem<LayerItem>(multilayer->index());
+    auto layout = model.insertItem<ParticleLayoutItem>(layer->index());
 
     // composition added to layout should have abundance enabled
-    SessionItem* compositionFree = model.insertNewItem("ParticleComposition", layout->index());
+    auto compositionFree = model.insertItem<ParticleCompositionItem>(layout->index());
     EXPECT_TRUE(compositionFree->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
 
     // composition added to distribution should have abundance disabled
-    SessionItem* distribution = model.insertNewItem("ParticleDistribution", layout->index());
-    SessionItem* composition = model.insertNewItem("ParticleComposition", distribution->index());
+    auto distribution = model.insertItem<ParticleDistributionItem>(layout->index());
+    auto composition = model.insertItem<ParticleCompositionItem>(distribution->index());
     EXPECT_FALSE(composition->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
 
-    composition = distribution->takeRow(ParentRow(*composition));
-    EXPECT_TRUE(composition->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
-    delete composition;
+    auto taken = distribution->takeRow(ParentRow(*composition));
+    EXPECT_TRUE(taken->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
+    delete taken;
 }
 
 TEST_F(TestMapperCases, test_SimulationOptionsComputationToggle)
 {
     DocumentModel model;
-    model.insertNewItem("SimulationOptions");
+    model.insertItem<SimulationOptionsItem>();
 
     SimulationOptionsItem* item = model.simulationOptionsItem();
 

--- a/Tests/UnitTests/GUI/TestMapperForItem.cpp
+++ b/Tests/UnitTests/GUI/TestMapperForItem.cpp
@@ -1,5 +1,7 @@
 #include "GUI/coregui/Models/LayerItem.h"
+#include "GUI/coregui/Models/MaskItems.h"
 #include "GUI/coregui/Models/MultiLayerItem.h"
+#include "GUI/coregui/Models/ProjectionItems.h"
 #include "GUI/coregui/Models/SampleModel.h"
 #include "GUI/coregui/Models/SessionItemUtils.h"
 #include "Tests/GTestWrapper/google_test.h"
@@ -129,8 +131,8 @@ TEST_F(TestMapperForItem, test_onPropertyChange)
 {
     Widget w;
     SampleModel model;
-    SessionItem* multilayer = model.insertNewItem("MultiLayer");
-    SessionItem* layer = model.insertNewItem("Layer", model.indexOfItem(multilayer));
+    auto multilayer = model.insertItem<MultiLayerItem>();
+    auto layer = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
 
     // Mapper is looking on child; set property of child
     setItem(layer, &w);
@@ -189,8 +191,8 @@ TEST_F(TestMapperForItem, test_onParentChange)
 {
     Widget w;
     SampleModel model;
-    SessionItem* multilayer = model.insertNewItem("MultiLayer");
-    SessionItem* layer = model.insertNewItem("Layer", model.indexOfItem(multilayer));
+    auto multilayer = model.insertItem<MultiLayerItem>();
+    auto layer = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
 
     // Mapper is looking on child; changing child's parent
     setItem(layer, &w);
@@ -207,12 +209,12 @@ TEST_F(TestMapperForItem, test_onChildrenChange)
 {
     Widget w;
     SampleModel model;
-    SessionItem* multilayer = model.insertNewItem("MultiLayer");
+    auto multilayer = model.insertItem<MultiLayerItem>();
 
     // Mapper is looking on parent; adding new child to parent
     setItem(multilayer, &w);
     EXPECT_TRUE(m_mapped_item == multilayer);
-    model.insertNewItem("Layer", model.indexOfItem(multilayer));
+    model.insertItem<LayerItem>(model.indexOfItem(multilayer));
 
     EXPECT_EQ(w.m_onPropertyChangeCount, 0);
     EXPECT_EQ(w.m_onChildPropertyChangeCount, 2);
@@ -227,14 +229,13 @@ TEST_F(TestMapperForItem, test_onSiblingsChange)
 {
     Widget w;
     SampleModel model;
-    SessionItem* multilayer = model.insertNewItem("MultiLayer");
-    SessionItem* layer = model.insertNewItem("Layer", model.indexOfItem(multilayer));
+    auto multilayer = model.insertItem<MultiLayerItem>();
+    auto layer = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
 
     // Mapper is looking on child; adding another child to parent
     setItem(layer, &w);
     EXPECT_TRUE(m_mapped_item == layer);
-    SessionItem* layer2 = model.insertNewItem("Layer", model.indexOfItem(multilayer));
-    Q_UNUSED(layer2);
+    model.insertItem<LayerItem>(model.indexOfItem(multilayer));
 
     EXPECT_EQ(w.m_onPropertyChangeCount, 0);
     EXPECT_EQ(w.m_onChildPropertyChangeCount, 0);
@@ -252,8 +253,8 @@ TEST_F(TestMapperForItem, test_Subscription)
 {
     Widget w;
     SampleModel model;
-    SessionItem* multilayer = model.insertNewItem("MultiLayer");
-    SessionItem* layer = model.insertNewItem("Layer", model.indexOfItem(multilayer));
+    auto multilayer = model.insertItem<MultiLayerItem>();
+    auto layer = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
 
     // Mapper is looking on child; set property of child
     setItem(layer, &w, true);
@@ -281,8 +282,8 @@ TEST_F(TestMapperForItem, test_TwoWidgetsSubscription)
 {
     Widget w1, w2;
     SampleModel model;
-    SessionItem* multilayer = model.insertNewItem("MultiLayer");
-    SessionItem* layer = model.insertNewItem("Layer", model.indexOfItem(multilayer));
+    auto multilayer = model.insertItem<MultiLayerItem>();
+    auto layer = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
 
     // Mapper is looking on child; set property of child
     setItem(layer);
@@ -305,9 +306,8 @@ TEST_F(TestMapperForItem, test_AboutToRemoveChild)
 {
     Widget w;
     SampleModel model;
-    SessionItem* container = model.insertNewItem("ProjectionContainer");
-
-    SessionItem* line = model.insertNewItem("HorizontalLineMask", container->index());
+    auto container = model.insertItem<ProjectionContainerItem>();
+    auto line = model.insertItem<HorizontalLineItem>(container->index());
 
     setItem(container, &w);
     EXPECT_EQ(w.m_onAboutToRemoveChild, 0);

--- a/Tests/UnitTests/GUI/TestMaterialPropertyController.cpp
+++ b/Tests/UnitTests/GUI/TestMaterialPropertyController.cpp
@@ -66,9 +66,9 @@ TEST_F(TestMaterialPropertyController, test_ControllerInEditorContext)
     auto mat3 = materialModel.addRefractiveMaterial("name3", 1.0, 2.0);
 
     SampleModel sampleModel;
-    auto layer1 = sampleModel.insertNewItem("Layer");
-    auto layer2 = sampleModel.insertNewItem("Layer");
-    auto layer3 = sampleModel.insertNewItem("Layer");
+    auto layer1 = sampleModel.insertItem<LayerItem>();
+    auto layer2 = sampleModel.insertItem<LayerItem>();
+    auto layer3 = sampleModel.insertItem<LayerItem>();
 
     MaterialPropertyController controller;
     controller.setModels(&materialModel, &sampleModel);

--- a/Tests/UnitTests/GUI/TestModelUtils.cpp
+++ b/Tests/UnitTests/GUI/TestModelUtils.cpp
@@ -1,5 +1,6 @@
 #include "GUI/coregui/Models/LayerItem.h"
 #include "GUI/coregui/Models/ModelUtils.h"
+#include "GUI/coregui/Models/MultiLayerItem.h"
 #include "GUI/coregui/Models/SessionModel.h"
 #include "GUI/coregui/Models/VectorItem.h"
 #include "Tests/GTestWrapper/google_test.h"
@@ -31,10 +32,10 @@ TEST_F(TestModelUtils, test_topItemNames)
     EXPECT_TRUE(ModelUtils::topItemNames(&model).isEmpty());
 
     // inserting three top items
-    auto item = model.insertNewItem("MultiLayer");
+    auto item = model.insertItem<MultiLayerItem>();
     item->setItemName("name1");
-    model.insertNewItem("Layer");
-    item = model.insertNewItem("MultiLayer");
+    model.insertItem<LayerItem>();
+    item = model.insertItem<MultiLayerItem>();
     item->setItemName("name2");
 
     // checking names of items of certain type
@@ -66,7 +67,7 @@ TEST_F(TestModelUtils, test_emptyModel)
 TEST_F(TestModelUtils, test_vectorItem)
 {
     SessionModel model("TestModel");
-    SessionItem* vectorItem = model.insertNewItem("Vector");
+    auto vectorItem = model.insertItem<VectorItem>();
 
     QVector<QModelIndex> indices;
 
@@ -92,8 +93,8 @@ TEST_F(TestModelUtils, test_vectorItem)
 TEST_F(TestModelUtils, test_iterateIf)
 {
     SessionModel model("TestModel");
-    SessionItem* multilayer = model.insertNewItem("MultiLayer");
-    SessionItem* layer = model.insertNewItem("Layer", model.indexOfItem(multilayer));
+    auto multilayer = model.insertItem<MultiLayerItem>();
+    SessionItem* layer = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
     SessionItem* thicknessItem = layer->getItem(LayerItem::P_THICKNESS);
 
     layer->setVisible(true);

--- a/Tests/UnitTests/GUI/TestMultiLayerItem.cpp
+++ b/Tests/UnitTests/GUI/TestMultiLayerItem.cpp
@@ -14,9 +14,9 @@ TEST_F(TestMultiLayerItem, test_twoLayerSystem)
 {
     SampleModel model;
 
-    auto multilayer = model.insertNewItem("MultiLayer");
-    auto top = model.insertNewItem("Layer", model.indexOfItem(multilayer));
-    auto bottom = model.insertNewItem("Layer", model.indexOfItem(multilayer));
+    auto multilayer = model.insertItem<MultiLayerItem>();
+    auto top = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
+    auto bottom = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
 
     // Thickness property should be disabled for top and bottom layers
     EXPECT_FALSE(top->getItem(LayerItem::P_THICKNESS)->isEnabled());
@@ -43,10 +43,10 @@ TEST_F(TestMultiLayerItem, test_threeLayerSystem)
 {
     SampleModel model;
 
-    auto multilayer = model.insertNewItem("MultiLayer");
-    auto top = model.insertNewItem("Layer", model.indexOfItem(multilayer));
-    auto middle = model.insertNewItem("Layer", model.indexOfItem(multilayer));
-    auto bottom = model.insertNewItem("Layer", model.indexOfItem(multilayer));
+    auto multilayer = model.insertItem<MultiLayerItem>();
+    auto top = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
+    auto middle = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
+    auto bottom = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
 
     // Thickness property should be disabled for top and bottom layers and enabled for middle
     EXPECT_FALSE(top->getItem(LayerItem::P_THICKNESS)->isEnabled());
@@ -78,10 +78,10 @@ TEST_F(TestMultiLayerItem, test_movingMiddleLayerOnTop)
 {
     SampleModel model;
 
-    auto multilayer = model.insertNewItem("MultiLayer");
-    auto top = model.insertNewItem("Layer", model.indexOfItem(multilayer));
-    auto middle = model.insertNewItem("Layer", model.indexOfItem(multilayer));
-    auto bottom = model.insertNewItem("Layer", model.indexOfItem(multilayer));
+    auto multilayer = model.insertItem<MultiLayerItem>();
+    auto top = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
+    auto middle = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
+    auto bottom = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
 
     const double thickness = 10.0;
     middle->setItemValue(LayerItem::P_THICKNESS, thickness);
@@ -126,9 +126,9 @@ TEST_F(TestMultiLayerItem, test_movingLayerOnCanvas)
 {
     SampleModel model;
 
-    auto multilayer = model.insertNewItem("MultiLayer");
-    auto top = model.insertNewItem("Layer", model.indexOfItem(multilayer));
-    model.insertNewItem("Layer", model.indexOfItem(multilayer));
+    auto multilayer = model.insertItem<MultiLayerItem>();
+    auto top = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
+    model.insertItem<LayerItem>(model.indexOfItem(multilayer));
 
     // Moving top layer to canvas
     model.moveItem(top, nullptr);

--- a/Tests/UnitTests/GUI/TestOutputDataIOService.cpp
+++ b/Tests/UnitTests/GUI/TestOutputDataIOService.cpp
@@ -1,6 +1,7 @@
 #include "Device/Histo/IntensityDataIOFactory.h"
 #include "GUI/coregui/Models/ApplicationModels.h"
 #include "GUI/coregui/Models/DataItem.h"
+#include "GUI/coregui/Models/IntensityDataItem.h"
 #include "GUI/coregui/Models/JobItem.h"
 #include "GUI/coregui/Models/JobItemUtils.h"
 #include "GUI/coregui/Models/JobModel.h"
@@ -41,21 +42,20 @@ TEST_F(TestOutputDataIOService, test_nonXMLData)
     EXPECT_EQ(dataItems.size(), 0);
 
     // adding RealDataItem
-    RealDataItem* realData =
-        dynamic_cast<RealDataItem*>(models.realDataModel()->insertNewItem("RealData"));
+    auto realData = models.realDataModel()->insertItem<RealDataItem>();
     EXPECT_EQ(models.realDataModel()->nonXMLData().size(), 0);
     realData->setOutputData(GuiUnittestUtils::createData().release());
     EXPECT_EQ(models.realDataModel()->nonXMLData().size(), 1);
 
     // adding JobItem
-    SessionItem* jobItem = models.jobModel()->insertNewItem("JobItem");
-    SessionItem* dataItem =
-        models.jobModel()->insertNewItem("IntensityData", jobItem->index(), -1, JobItem::T_OUTPUT);
+    auto jobItem = models.jobModel()->insertItem<JobItem>();
+    auto dataItem =
+        models.jobModel()->insertItem<IntensityDataItem>(jobItem->index(), -1, JobItem::T_OUTPUT);
     EXPECT_EQ(models.jobModel()->nonXMLData().size(), 1);
 
     // adding RealDataItem to jobItem
-    RealDataItem* realData2 = dynamic_cast<RealDataItem*>(
-        models.jobModel()->insertNewItem("RealData", jobItem->index(), -1, JobItem::T_REALDATA));
+    RealDataItem* realData2 =
+        models.jobModel()->insertItem<RealDataItem>(jobItem->index(), -1, JobItem::T_REALDATA);
     EXPECT_EQ(models.jobModel()->nonXMLData().size(), 1);
     realData2->setOutputData(
         GuiUnittestUtils::createData(0.0, GuiUnittestUtils::DIM::D1).release());
@@ -88,7 +88,7 @@ TEST_F(TestOutputDataIOService, test_nonXMLData)
 TEST_F(TestOutputDataIOService, test_OutputDataSaveInfo)
 {
     SessionModel model("TempModel");
-    DataItem* item = dynamic_cast<DataItem*>(model.insertNewItem("IntensityData"));
+    auto item = model.insertItem<IntensityDataItem>();
 
     item->setLastModified(QDateTime::currentDateTime());
 
@@ -109,9 +109,8 @@ TEST_F(TestOutputDataIOService, test_OutputDataSaveInfo)
 TEST_F(TestOutputDataIOService, test_OutputDataDirHistory)
 {
     SessionModel model("TempModel");
-    DataItem* item1 = dynamic_cast<DataItem*>(model.insertNewItem("IntensityData"));
-
-    DataItem* item2 = dynamic_cast<DataItem*>(model.insertNewItem("IntensityData"));
+    auto item1 = model.insertItem<IntensityDataItem>();
+    auto item2 = model.insertItem<IntensityDataItem>();
     item1->setOutputData(m_data.clone());
     item1->setLastModified(QDateTime::currentDateTime());
     item2->setLastModified(QDateTime::currentDateTime());
@@ -146,9 +145,9 @@ TEST_F(TestOutputDataIOService, test_OutputDataDirHistory)
 TEST_F(TestOutputDataIOService, test_OutputDataIOHistory)
 {
     SessionModel model("TempModel");
-    DataItem* item1 = dynamic_cast<DataItem*>(model.insertNewItem("IntensityData"));
+    auto item1 = model.insertItem<IntensityDataItem>();
 
-    DataItem* item2 = dynamic_cast<DataItem*>(model.insertNewItem("IntensityData"));
+    auto item2 = model.insertItem<IntensityDataItem>();
     item1->setOutputData(m_data.clone());
     item2->setOutputData(m_data.clone());
 
@@ -250,8 +249,7 @@ TEST_F(TestOutputDataIOService, test_RealDataItemWithNativeData)
     EXPECT_EQ(dataItems.size(), 0);
 
     // adding RealDataItem
-    RealDataItem* realData =
-        dynamic_cast<RealDataItem*>(models.realDataModel()->insertNewItem("RealData"));
+    auto realData = models.realDataModel()->insertItem<RealDataItem>();
     EXPECT_EQ(models.realDataModel()->nonXMLData().size(), 0);
 
     ImportDataInfo import_data(std::unique_ptr<OutputData<double>>(m_data.clone()), "nbins");
@@ -261,9 +259,9 @@ TEST_F(TestOutputDataIOService, test_RealDataItemWithNativeData)
     realData->setItemValue(RealDataItem::P_NAME, "RealData");
 
     // adding JobItem
-    JobItem* jobItem = dynamic_cast<JobItem*>(models.jobModel()->insertNewItem("JobItem"));
+    auto jobItem = models.jobModel()->insertItem<JobItem>();
     jobItem->setIdentifier(GUIHelpers::createUuid());
-    models.jobModel()->insertNewItem("IntensityData", jobItem->index(), -1, JobItem::T_OUTPUT);
+    models.jobModel()->insertItem<IntensityDataItem>(jobItem->index(), -1, JobItem::T_OUTPUT);
     EXPECT_EQ(models.jobModel()->nonXMLData().size(), 1);
 
     // copying RealDataItem to JobItem

--- a/Tests/UnitTests/GUI/TestParameterTreeUtils.cpp
+++ b/Tests/UnitTests/GUI/TestParameterTreeUtils.cpp
@@ -63,6 +63,6 @@ TEST_F(TestParameterTreeUtils, test_linkItemFromParameterName)
     EXPECT_EQ(ffItem->getItem(CylinderItem::P_HEIGHT),
               ParameterTreeUtils::parameterNameToLinkedItem("Particle/Cylinder/Height", particle));
     EXPECT_EQ(
-        particle->getItem(ParticleItem::P_POSITION)->getItem(VectorItem::P_X),
+        particle->item<VectorItem>(ParticleItem::P_POSITION).getItem(VectorItem::P_X),
         ParameterTreeUtils::parameterNameToLinkedItem("Particle/Position Offset/X", particle));
 }

--- a/Tests/UnitTests/GUI/TestParameterTreeUtils.cpp
+++ b/Tests/UnitTests/GUI/TestParameterTreeUtils.cpp
@@ -52,7 +52,7 @@ TEST_F(TestParameterTreeUtils, test_linkItemFromParameterName)
 {
     SampleModel model;
 
-    SessionItem* particle = model.insertNewItem("Particle");
+    auto particle = model.insertItem<ParticleItem>();
 
     auto ffItem = static_cast<FormFactorItem*>(particle->getGroupItem(ParticleItem::P_FORM_FACTOR));
     ASSERT(ffItem);
@@ -63,6 +63,6 @@ TEST_F(TestParameterTreeUtils, test_linkItemFromParameterName)
     EXPECT_EQ(ffItem->getItem(CylinderItem::P_HEIGHT),
               ParameterTreeUtils::parameterNameToLinkedItem("Particle/Cylinder/Height", particle));
     EXPECT_EQ(
-        particle->item<VectorItem>(ParticleItem::P_POSITION)->getItem(VectorItem::P_X),
+        particle->positionItem()->getItem(VectorItem::P_X),
         ParameterTreeUtils::parameterNameToLinkedItem("Particle/Position Offset/X", particle));
 }

--- a/Tests/UnitTests/GUI/TestParameterTreeUtils.cpp
+++ b/Tests/UnitTests/GUI/TestParameterTreeUtils.cpp
@@ -63,6 +63,6 @@ TEST_F(TestParameterTreeUtils, test_linkItemFromParameterName)
     EXPECT_EQ(ffItem->getItem(CylinderItem::P_HEIGHT),
               ParameterTreeUtils::parameterNameToLinkedItem("Particle/Cylinder/Height", particle));
     EXPECT_EQ(
-        particle->item<VectorItem>(ParticleItem::P_POSITION).getItem(VectorItem::P_X),
+        particle->item<VectorItem>(ParticleItem::P_POSITION)->getItem(VectorItem::P_X),
         ParameterTreeUtils::parameterNameToLinkedItem("Particle/Position Offset/X", particle));
 }

--- a/Tests/UnitTests/GUI/TestParticleCoreShell.cpp
+++ b/Tests/UnitTests/GUI/TestParticleCoreShell.cpp
@@ -57,7 +57,7 @@ TEST_F(TestParticleCoreShell, test_propertyAppearance)
     EXPECT_TRUE(coreshell->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
     EXPECT_EQ(coreshell->getItemValue(ParticleItem::P_ABUNDANCE).toDouble(), 1.0);
     EXPECT_TRUE(coreshell->getItem(ParticleItem::P_POSITION)->isEnabled());
-    kvector_t pos = GetVectorItem(*coreshell, ParticleItem::P_POSITION);
+    kvector_t pos = coreshell->item<VectorItem>(ParticleItem::P_POSITION).getVector();
     EXPECT_EQ(pos.x(), 0.0);
     EXPECT_EQ(pos.y(), 0.0);
     EXPECT_EQ(pos.z(), 0.0);

--- a/Tests/UnitTests/GUI/TestParticleCoreShell.cpp
+++ b/Tests/UnitTests/GUI/TestParticleCoreShell.cpp
@@ -57,7 +57,7 @@ TEST_F(TestParticleCoreShell, test_propertyAppearance)
     EXPECT_TRUE(coreshell->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
     EXPECT_EQ(coreshell->getItemValue(ParticleItem::P_ABUNDANCE).toDouble(), 1.0);
     EXPECT_TRUE(coreshell->getItem(ParticleItem::P_POSITION)->isEnabled());
-    kvector_t pos = coreshell->item<VectorItem>(ParticleItem::P_POSITION).getVector();
+    kvector_t pos = coreshell->item<VectorItem>(ParticleItem::P_POSITION)->getVector();
     EXPECT_EQ(pos.x(), 0.0);
     EXPECT_EQ(pos.y(), 0.0);
     EXPECT_EQ(pos.z(), 0.0);
@@ -76,17 +76,17 @@ TEST_F(TestParticleCoreShell, test_propertyAppearance)
 
     // creating shell (not yet attached to the coreshell)
     SessionItem* shell = model.insertNewItem("Particle");
-    auto& positionItem = shell->item<VectorItem>(ParticleItem::P_POSITION);
+    auto positionItem = shell->item<VectorItem>(ParticleItem::P_POSITION);
     // putting some values to position and abundance
     shell->setItemValue(ParticleItem::P_ABUNDANCE, 0.2);
-    positionItem.setX(1.0);
+    positionItem->setX(1.0);
 
     // attaching shell to coreshell and checking abundance disabled
     model.moveItem(shell, coreshell, -1, ParticleCoreShellItem::T_SHELL);
     EXPECT_FALSE(shell->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
     EXPECT_FALSE(shell->getItem(ParticleItem::P_POSITION)->isEnabled());
     // checking that position and abundance values were reset to defaults
-    EXPECT_EQ(positionItem.x(), 0.0);
+    EXPECT_EQ(positionItem->x(), 0.0);
     EXPECT_EQ(shell->getItemValue(ParticleItem::P_ABUNDANCE).toDouble(), 1.0);
 
     // removing shell and checking abundance, position restored

--- a/Tests/UnitTests/GUI/TestParticleCoreShell.cpp
+++ b/Tests/UnitTests/GUI/TestParticleCoreShell.cpp
@@ -53,46 +53,45 @@ TEST_F(TestParticleCoreShell, test_propertyAppearance)
     SampleModel model;
 
     // empty coreshell particle
-    SessionItem* coreshell = model.insertNewItem("ParticleCoreShell");
+    auto coreshell = model.insertItem<ParticleCoreShellItem>();
     EXPECT_TRUE(coreshell->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
     EXPECT_EQ(coreshell->getItemValue(ParticleItem::P_ABUNDANCE).toDouble(), 1.0);
-    EXPECT_TRUE(coreshell->getItem(ParticleItem::P_POSITION)->isEnabled());
-    kvector_t pos = coreshell->item<VectorItem>(ParticleItem::P_POSITION)->getVector();
+    EXPECT_TRUE(coreshell->positionItem()->isEnabled());
+    kvector_t pos = coreshell->positionItem()->getVector();
     EXPECT_EQ(pos.x(), 0.0);
     EXPECT_EQ(pos.y(), 0.0);
     EXPECT_EQ(pos.z(), 0.0);
 
     // adding core, and checking that abundance is disabled
-    SessionItem* core =
-        model.insertNewItem("Particle", coreshell->index(), -1, ParticleCoreShellItem::T_CORE);
+    auto core =
+        model.insertItem<ParticleItem>(coreshell->index(), -1, ParticleCoreShellItem::T_CORE);
     EXPECT_FALSE(core->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
-    EXPECT_TRUE(core->getItem(ParticleItem::P_POSITION)->isEnabled());
+    EXPECT_TRUE(core->positionItem()->isEnabled());
 
     // removing core, checking that abundance restored
     coreshell->takeRow(ParentRow(*core));
     EXPECT_TRUE(core->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
-    EXPECT_TRUE(core->getItem(ParticleItem::P_POSITION)->isEnabled());
+    EXPECT_TRUE(core->positionItem()->isEnabled());
     delete core;
 
     // creating shell (not yet attached to the coreshell)
-    SessionItem* shell = model.insertNewItem("Particle");
-    auto positionItem = shell->item<VectorItem>(ParticleItem::P_POSITION);
+    auto shell = model.insertItem<ParticleItem>();
     // putting some values to position and abundance
     shell->setItemValue(ParticleItem::P_ABUNDANCE, 0.2);
-    positionItem->setX(1.0);
+    shell->positionItem()->setX(1.0);
 
     // attaching shell to coreshell and checking abundance disabled
     model.moveItem(shell, coreshell, -1, ParticleCoreShellItem::T_SHELL);
     EXPECT_FALSE(shell->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
-    EXPECT_FALSE(shell->getItem(ParticleItem::P_POSITION)->isEnabled());
+    EXPECT_FALSE(shell->positionItem()->isEnabled());
     // checking that position and abundance values were reset to defaults
-    EXPECT_EQ(positionItem->x(), 0.0);
+    EXPECT_EQ(shell->positionItem()->x(), 0.0);
     EXPECT_EQ(shell->getItemValue(ParticleItem::P_ABUNDANCE).toDouble(), 1.0);
 
     // removing shell and checking abundance, position restored
     coreshell->takeRow(ParentRow(*shell));
     EXPECT_TRUE(shell->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
-    EXPECT_TRUE(shell->getItem(ParticleItem::P_POSITION)->isEnabled());
+    EXPECT_TRUE(shell->positionItem()->isEnabled());
     delete shell;
 }
 

--- a/Tests/UnitTests/GUI/TestParticleCoreShell.cpp
+++ b/Tests/UnitTests/GUI/TestParticleCoreShell.cpp
@@ -76,17 +76,17 @@ TEST_F(TestParticleCoreShell, test_propertyAppearance)
 
     // creating shell (not yet attached to the coreshell)
     SessionItem* shell = model.insertNewItem("Particle");
-    SessionItem* positionItem = shell->getItem(ParticleItem::P_POSITION);
+    auto& positionItem = shell->item<VectorItem>(ParticleItem::P_POSITION);
     // putting some values to position and abundance
     shell->setItemValue(ParticleItem::P_ABUNDANCE, 0.2);
-    positionItem->setItemValue(VectorItem::P_X, 1.0);
+    positionItem.setX(1.0);
 
     // attaching shell to coreshell and checking abundance disabled
     model.moveItem(shell, coreshell, -1, ParticleCoreShellItem::T_SHELL);
     EXPECT_FALSE(shell->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
     EXPECT_FALSE(shell->getItem(ParticleItem::P_POSITION)->isEnabled());
     // checking that position and abundance values were reset to defaults
-    EXPECT_EQ(positionItem->getItemValue(VectorItem::P_X).toDouble(), 0.0);
+    EXPECT_EQ(positionItem.x(), 0.0);
     EXPECT_EQ(shell->getItemValue(ParticleItem::P_ABUNDANCE).toDouble(), 1.0);
 
     // removing shell and checking abundance, position restored

--- a/Tests/UnitTests/GUI/TestSavingSpecularData.cpp
+++ b/Tests/UnitTests/GUI/TestSavingSpecularData.cpp
@@ -5,6 +5,7 @@
 #include "GUI/coregui/Models/GroupItem.h"
 #include "GUI/coregui/Models/InstrumentItems.h"
 #include "GUI/coregui/Models/InstrumentModel.h"
+#include "GUI/coregui/Models/IntensityDataItem.h"
 #include "GUI/coregui/Models/ItemFileNameUtils.h"
 #include "GUI/coregui/Models/JobItem.h"
 #include "GUI/coregui/Models/JobModel.h"
@@ -38,14 +39,12 @@ TestSavingSpecularData::TestSavingSpecularData()
 
 SpecularInstrumentItem* TestSavingSpecularData::createSpecularInstrument(ApplicationModels& models)
 {
-    return dynamic_cast<SpecularInstrumentItem*>(
-        models.instrumentModel()->insertNewItem("SpecularInstrument"));
+    return models.instrumentModel()->insertItem<SpecularInstrumentItem>();
 }
 
 PointwiseAxisItem* TestSavingSpecularData::createPointwiseAxisItem(SessionModel& model)
 {
-    auto instrument_item =
-        dynamic_cast<SpecularInstrumentItem*>(model.insertNewItem("SpecularInstrument"));
+    auto instrument_item = model.insertItem<SpecularInstrumentItem>();
     return dynamic_cast<PointwiseAxisItem*>(
         getAxisGroup(instrument_item)->getChildOfType("PointwiseAxis"));
 }
@@ -104,14 +103,14 @@ TEST_F(TestSavingSpecularData, test_InstrumentInJobItem)
     ApplicationModels models;
 
     // adding JobItem
-    SessionItem* jobItem = models.jobModel()->insertNewItem("JobItem");
-    SessionItem* dataItem =
-        models.jobModel()->insertNewItem("IntensityData", jobItem->index(), -1, JobItem::T_OUTPUT);
+    auto jobItem = models.jobModel()->insertItem<JobItem>();
+    auto dataItem =
+        models.jobModel()->insertItem<IntensityDataItem>(jobItem->index(), -1, JobItem::T_OUTPUT);
     EXPECT_EQ(models.jobModel()->nonXMLData().size(), 1);
 
     // adding instrument
-    auto instrument = dynamic_cast<SpecularInstrumentItem*>(models.jobModel()->insertNewItem(
-        "SpecularInstrument", jobItem->index(), -1, JobItem::T_INSTRUMENT));
+    auto instrument = models.jobModel()->insertItem<SpecularInstrumentItem>(jobItem->index(), -1,
+                                                                            JobItem::T_INSTRUMENT);
     // instrument contains hidden pointwise axis item
     EXPECT_EQ(models.jobModel()->nonXMLData().size(), 2);
 

--- a/Tests/UnitTests/GUI/TestSessionItemController.cpp
+++ b/Tests/UnitTests/GUI/TestSessionItemController.cpp
@@ -39,7 +39,7 @@ TEST_F(TestSessionItemController, test_setItem)
     TestListener listener;
     TestObject object(&listener);
     SessionModel model("TestModel");
-    SessionItem* item = model.insertNewItem("BasicAxis");
+    auto item = model.insertItem<BasicAxisItem>();
 
     object.setItem(item);
     EXPECT_EQ(object.currentItem(), item);
@@ -55,7 +55,7 @@ TEST_F(TestSessionItemController, test_setItemAndSubscribeItem)
     TestListener listener;
     TestObject object(&listener);
     SessionModel model("TestModel");
-    SessionItem* item = model.insertNewItem("BasicAxis");
+    auto item = model.insertItem<BasicAxisItem>();
 
     object.setItem(item);
     object.setVisible(true);
@@ -72,7 +72,7 @@ TEST_F(TestSessionItemController, test_onPropertyChange)
     TestListener listener;
     TestObject object(&listener);
     SessionModel model("TestModel");
-    SessionItem* item = model.insertNewItem("BasicAxis");
+    auto item = model.insertItem<BasicAxisItem>();
 
     object.setItem(item);
     EXPECT_EQ(object.currentItem(), item);
@@ -119,7 +119,7 @@ TEST_F(TestSessionItemController, test_onItemDestroyWidgetVisible)
     TestListener listener;
     TestObject object(&listener);
     SessionModel model("TestModel");
-    SessionItem* item = model.insertNewItem("BasicAxis");
+    auto item = model.insertItem<BasicAxisItem>();
 
     object.setItem(item);
     object.setVisible(true);
@@ -145,7 +145,7 @@ TEST_F(TestSessionItemController, test_onItemDestroyWidgetHidden)
     TestListener listener;
     TestObject object(&listener);
     SessionModel model("TestModel");
-    SessionItem* item = model.insertNewItem("BasicAxis");
+    auto item = model.insertItem<BasicAxisItem>();
 
     object.setItem(item);
     object.setVisible(true);
@@ -178,8 +178,8 @@ TEST_F(TestSessionItemController, test_onTwoItems)
     TestListener listener;
     TestObject object(&listener);
     SessionModel model("TestModel");
-    SessionItem* item1 = model.insertNewItem("BasicAxis");
-    SessionItem* item2 = model.insertNewItem("BasicAxis");
+    auto item1 = model.insertItem<BasicAxisItem>();
+    auto item2 = model.insertItem<BasicAxisItem>();
 
     object.setItem(item1);
     EXPECT_EQ(object.currentItem(), item1);
@@ -212,8 +212,8 @@ TEST_F(TestSessionItemController, test_onTwoItemsWhenHidden)
     TestListener listener;
     TestObject object(&listener);
     SessionModel model("TestModel");
-    SessionItem* item1 = model.insertNewItem("BasicAxis");
-    SessionItem* item2 = model.insertNewItem("BasicAxis");
+    auto item1 = model.insertItem<BasicAxisItem>();
+    auto item2 = model.insertItem<BasicAxisItem>();
 
     object.setVisible(false);
 
@@ -245,7 +245,7 @@ TEST_F(TestSessionItemController, test_deleteWidget)
     TestListener listener;
     TestObject* object = new TestObject(&listener);
     SessionModel model("TestModel");
-    SessionItem* item = model.insertNewItem("BasicAxis");
+    auto item = model.insertItem<BasicAxisItem>();
 
     object->setItem(item);
     object->setVisible(true);

--- a/Tests/UnitTests/GUI/TestSessionItemUtils.cpp
+++ b/Tests/UnitTests/GUI/TestSessionItemUtils.cpp
@@ -2,6 +2,7 @@
 #include "GUI/coregui/Models/SessionItemUtils.h"
 #include "GUI/coregui/Models/SessionModel.h"
 #include "GUI/coregui/Models/VectorItem.h"
+#include "GUI/coregui/Models/PropertyItem.h"
 #include "GUI/coregui/Views/MaterialEditor/ExternalProperty.h"
 #include "Tests/GTestWrapper/google_test.h"
 
@@ -15,9 +16,9 @@ TEST_F(TestSessionItemUtils, test_ParentVisibleRow)
     SessionModel model("TestModel");
 
     // 3 property items in root, all visible
-    auto item1 = model.insertNewItem("Property");
-    auto item2 = model.insertNewItem("Property");
-    auto item3 = model.insertNewItem("Property");
+    auto item1 = model.insertItem<PropertyItem>();
+    auto item2 = model.insertItem<PropertyItem>();
+    auto item3 = model.insertItem<PropertyItem>();
     EXPECT_EQ(SessionItemUtils::ParentVisibleRow(*item1), 0);
     EXPECT_EQ(SessionItemUtils::ParentVisibleRow(*item2), 1);
     EXPECT_EQ(SessionItemUtils::ParentVisibleRow(*item3), 2);
@@ -29,8 +30,8 @@ TEST_F(TestSessionItemUtils, test_ParentVisibleRow)
     EXPECT_EQ(SessionItemUtils::ParentVisibleRow(*item3), 1);
 
     // two more items
-    auto item4 = model.insertNewItem("Property");
-    auto item5 = model.insertNewItem("Property");
+    auto item4 = model.insertItem<PropertyItem>();
+    auto item5 = model.insertItem<PropertyItem>();
     item5->setVisible(false);
     EXPECT_EQ(SessionItemUtils::ParentVisibleRow(*item1), 0);
     EXPECT_EQ(SessionItemUtils::ParentVisibleRow(*item2), -1);

--- a/Tests/UnitTests/GUI/TestSessionItemUtils.cpp
+++ b/Tests/UnitTests/GUI/TestSessionItemUtils.cpp
@@ -39,7 +39,7 @@ TEST_F(TestSessionItemUtils, test_ParentVisibleRow)
     EXPECT_EQ(SessionItemUtils::ParentVisibleRow(*item5), -1);
 
     // adding vector item
-    SessionItem* vector = model.insertNewItem("Vector");
+    auto vector = model.insertItem<VectorItem>();
     auto x = vector->getItem(VectorItem::P_X);
     auto y = vector->getItem(VectorItem::P_Y);
     auto z = vector->getItem(VectorItem::P_Z);

--- a/Tests/UnitTests/GUI/TestSessionModel.cpp
+++ b/Tests/UnitTests/GUI/TestSessionModel.cpp
@@ -1,12 +1,16 @@
+#include "GUI/coregui/Models/InstrumentItems.h"
 #include "GUI/coregui/Models/InstrumentModel.h"
 #include "GUI/coregui/Models/JobItem.h"
 #include "GUI/coregui/Models/JobModel.h"
+#include "GUI/coregui/Models/LayerItem.h"
 #include "GUI/coregui/Models/MaskItems.h"
 #include "GUI/coregui/Models/MaterialModel.h"
+#include "GUI/coregui/Models/MultiLayerItem.h"
+#include "GUI/coregui/Models/PropertyItem.h"
 #include "GUI/coregui/Models/SampleModel.h"
 #include "GUI/coregui/Models/SessionItemTags.h"
-#include "Tests/GTestWrapper/google_test.h"
 #include "GUI/coregui/Models/VectorItem.h"
+#include "Tests/GTestWrapper/google_test.h"
 #include <QSignalSpy>
 #include <QXmlStreamWriter>
 #include <memory>
@@ -19,7 +23,7 @@ class TestSessionModel : public ::testing::Test {
 TEST_F(TestSessionModel, setData)
 {
     SessionModel model("TestModel");
-    auto item = model.insertNewItem("Property");
+    auto item = model.insertItem<PropertyItem>();
 
     QSignalSpy spy(&model, &SessionModel::dataChanged);
 
@@ -46,10 +50,10 @@ TEST_F(TestSessionModel, SampleModelCopy)
     std::unique_ptr<MaterialModel> P_materialModel(new MaterialModel());
 
     SampleModel model1;
-    SessionItem* multilayer = model1.insertNewItem("MultiLayer");
+    auto multilayer = model1.insertItem<MultiLayerItem>();
     multilayer->setItemName("multilayer");
-    model1.insertNewItem("Layer", model1.indexOfItem(multilayer));
-    SessionItem* multilayer2 = model1.insertNewItem("MultiLayer");
+    model1.insertItem<LayerItem>(model1.indexOfItem(multilayer));
+    auto multilayer2 = model1.insertItem<MultiLayerItem>();
     multilayer2->setItemName("multilayer2");
 
     QString buffer1;
@@ -69,11 +73,11 @@ TEST_F(TestSessionModel, SampleModelPartialCopy)
     std::unique_ptr<MaterialModel> P_materialModel(new MaterialModel());
 
     SampleModel model1;
-    SessionItem* multilayer1 = model1.insertNewItem("MultiLayer");
+    auto multilayer1 = model1.insertItem<MultiLayerItem>();
     multilayer1->setItemName("multilayer1");
-    model1.insertNewItem("Layer", model1.indexOfItem(multilayer1));
+    model1.insertItem<LayerItem>(model1.indexOfItem(multilayer1));
 
-    SessionItem* multilayer2 = model1.insertNewItem("MultiLayer");
+    auto multilayer2 = model1.insertItem<MultiLayerItem>();
     multilayer2->setItemName("multilayer2");
 
     std::unique_ptr<SampleModel> model2(model1.createCopy(multilayer1));
@@ -86,10 +90,10 @@ TEST_F(TestSessionModel, SampleModelPartialCopy)
 TEST_F(TestSessionModel, InstrumentModelCopy)
 {
     InstrumentModel model1;
-    SessionItem* instrument1 = model1.insertNewItem("GISASInstrument");
+    auto instrument1 = model1.insertItem<GISASInstrumentItem>();
     instrument1->setItemName("instrument1");
 
-    SessionItem* instrument2 = model1.insertNewItem("GISASInstrument");
+    auto instrument2 = model1.insertItem<GISASInstrumentItem>();
     instrument2->setItemName("instrument2");
 
     QString buffer1;
@@ -107,10 +111,10 @@ TEST_F(TestSessionModel, InstrumentModelCopy)
 TEST_F(TestSessionModel, InstrumentModelPartialCopy)
 {
     InstrumentModel model1;
-    SessionItem* instrument1 = model1.insertNewItem("GISASInstrument");
+    auto instrument1 = model1.insertItem<GISASInstrumentItem>();
     instrument1->setItemName("instrument1");
 
-    SessionItem* instrument2 = model1.insertNewItem("GISASInstrument");
+    auto instrument2 = model1.insertItem<GISASInstrumentItem>();
     instrument2->setItemName("instrument2");
 
     std::unique_ptr<InstrumentModel> model2(model1.createCopy(instrument2));
@@ -126,16 +130,16 @@ TEST_F(TestSessionModel, copyItem)
     std::unique_ptr<MaterialModel> P_materialModel(new MaterialModel());
 
     SampleModel sampleModel;
-    SessionItem* multilayer1 = sampleModel.insertNewItem("MultiLayer");
+    auto multilayer1 = sampleModel.insertItem<MultiLayerItem>();
     multilayer1->setItemName("multilayer1");
-    sampleModel.insertNewItem("Layer", sampleModel.indexOfItem(multilayer1));
+    sampleModel.insertItem<LayerItem>(sampleModel.indexOfItem(multilayer1));
 
     InstrumentModel instrumentModel;
-    SessionItem* instrument1 = instrumentModel.insertNewItem("GISASInstrument");
+    auto instrument1 = instrumentModel.insertItem<GISASInstrumentItem>();
     instrument1->setItemName("instrument1");
 
     JobModel jobModel;
-    SessionItem* jobItem = jobModel.insertNewItem("JobItem");
+    auto jobItem = jobModel.insertItem<JobItem>();
 
     jobModel.copyItem(multilayer1, jobItem, JobItem::T_SAMPLE);
     EXPECT_EQ(jobItem->sessionItemTags()->childCount(JobItem::T_SAMPLE), 1);
@@ -147,8 +151,8 @@ TEST_F(TestSessionModel, copyItem)
 TEST_F(TestSessionModel, moveItemFromRoot)
 {
     SessionModel model("TestModel");
-    auto poly = model.insertNewItem("PolygonMask");
-    auto point = model.insertNewItem("PolygonPoint");
+    auto poly = model.insertItem<PolygonItem>();
+    auto point = model.insertItem<PolygonPointItem>();
 
     EXPECT_EQ(poly->parent(), model.rootItem());
     EXPECT_EQ(point->parent(), model.rootItem());
@@ -172,10 +176,10 @@ TEST_F(TestSessionModel, moveItemFromRoot)
 TEST_F(TestSessionModel, moveBetweenParents)
 {
     SessionModel model("TestModel");
-    auto poly1 = model.insertNewItem("PolygonMask");
-    auto point11 = model.insertNewItem("PolygonPoint", model.indexOfItem(poly1));
-    auto point12 = model.insertNewItem("PolygonPoint", model.indexOfItem(poly1));
-    auto poly2 = model.insertNewItem("PolygonMask");
+    auto poly1 = model.insertItem<PolygonItem>();
+    auto point11 = model.insertItem<PolygonPointItem>(model.indexOfItem(poly1));
+    auto point12 = model.insertItem<PolygonPointItem>(model.indexOfItem(poly1));
+    auto poly2 = model.insertItem<PolygonItem>();
 
     EXPECT_EQ(point11->parent(), poly1);
     EXPECT_EQ(point12->parent(), poly1);
@@ -190,12 +194,12 @@ TEST_F(TestSessionModel, moveBetweenParents)
 TEST_F(TestSessionModel, moveWithinSameParent)
 {
     SessionModel model("TestModel");
-    auto poly = model.insertNewItem("PolygonMask");
-    auto pA = model.insertNewItem("PolygonPoint", model.indexOfItem(poly));
-    auto pB = model.insertNewItem("PolygonPoint", model.indexOfItem(poly));
-    auto pC = model.insertNewItem("PolygonPoint", model.indexOfItem(poly));
-    auto pD = model.insertNewItem("PolygonPoint", model.indexOfItem(poly));
-    auto pE = model.insertNewItem("PolygonPoint", model.indexOfItem(poly));
+    auto poly = model.insertItem<PolygonItem>();
+    auto pA = model.insertItem<PolygonPointItem>(model.indexOfItem(poly));
+    auto pB = model.insertItem<PolygonPointItem>(model.indexOfItem(poly));
+    auto pC = model.insertItem<PolygonPointItem>(model.indexOfItem(poly));
+    auto pD = model.insertItem<PolygonPointItem>(model.indexOfItem(poly));
+    auto pE = model.insertItem<PolygonPointItem>(model.indexOfItem(poly));
 
     // 0  pA -> pA
     // 1  pB -> pC

--- a/Tests/UnitTests/GUI/TestSessionModel.cpp
+++ b/Tests/UnitTests/GUI/TestSessionModel.cpp
@@ -6,6 +6,7 @@
 #include "GUI/coregui/Models/SampleModel.h"
 #include "GUI/coregui/Models/SessionItemTags.h"
 #include "Tests/GTestWrapper/google_test.h"
+#include "GUI/coregui/Models/VectorItem.h"
 #include <QSignalSpy>
 #include <QXmlStreamWriter>
 #include <memory>
@@ -208,4 +209,11 @@ TEST_F(TestSessionModel, moveWithinSameParent)
     EXPECT_EQ(poly->getItems().indexOf(pC), 1);
     EXPECT_EQ(poly->getItems().indexOf(pD), 3);
     EXPECT_EQ(poly->getItems().indexOf(pE), 4);
+}
+
+TEST_F(TestSessionModel, insertItem)
+{
+    SessionModel model("TestModel");
+    auto vectorItem = model.insertItem<VectorItem>();
+    EXPECT_TRUE(dynamic_cast<VectorItem*>(vectorItem) != nullptr);
 }

--- a/Tests/UnitTests/GUI/TestSessionXML.cpp
+++ b/Tests/UnitTests/GUI/TestSessionXML.cpp
@@ -1,5 +1,8 @@
 #include "GUI/coregui/Models/FormFactorItems.h"
+#include "GUI/coregui/Models/LayerItem.h"
+#include "GUI/coregui/Models/MultiLayerItem.h"
 #include "GUI/coregui/Models/ParticleItem.h"
+#include "GUI/coregui/Models/PropertyItem.h"
 #include "GUI/coregui/Models/SessionModel.h"
 #include "Tests/GTestWrapper/google_test.h"
 #include <QXmlStreamReader>
@@ -32,7 +35,7 @@ TEST_F(TestSessionXML, test_sessionItem)
     QString expected;
 
     SessionModel source("TestModel");
-    source.insertNewItem("Property");
+    source.insertItem<PropertyItem>();
 
     expected = "<TestModel Name=\"DefaultName\">"
                "<Item ModelType=\"Property\" Tag=\"rootTag\" DisplayName=\"Property\"/>"
@@ -55,7 +58,7 @@ TEST_F(TestSessionXML, test_FullSphereItem)
 {
     // source model, to xml
     SessionModel source("TestModel");
-    SessionItem* sphere = source.insertNewItem("FullSphere");
+    auto sphere = source.insertItem<FullSphereItem>();
     SessionItem* radius = sphere->getItem(FullSphereItem::P_RADIUS);
     QString buffer = itemToXML(source.rootItem());
 
@@ -88,9 +91,9 @@ TEST_F(TestSessionXML, test_twoFullSphereItems)
 {
     // source model, to xml
     SessionModel source("TestModel");
-    SessionItem* sphere1 = source.insertNewItem("FullSphere");
+    auto sphere1 = source.insertItem<FullSphereItem>();
     sphere1->setItemValue(FullSphereItem::P_RADIUS, 1.0);
-    SessionItem* sphere2 = source.insertNewItem("FullSphere");
+    auto sphere2 = source.insertItem<FullSphereItem>();
     sphere2->setItemValue(FullSphereItem::P_RADIUS, 2.0);
     QString buffer = itemToXML(source.rootItem());
 
@@ -104,7 +107,7 @@ TEST_F(TestSessionXML, test_twoFullSphereItems)
 TEST_F(TestSessionXML, test_emptyMultiLayer)
 {
     SessionModel source("TestModel");
-    source.insertNewItem("MultiLayer");
+    source.insertItem<MultiLayerItem>();
     QString buffer = itemToXML(source.rootItem());
 
     SessionModel target("TestModel");
@@ -117,7 +120,7 @@ TEST_F(TestSessionXML, test_emptyMultiLayer)
 TEST_F(TestSessionXML, test_Layer)
 {
     SessionModel source("TestModel");
-    source.insertNewItem("Layer");
+    source.insertItem<LayerItem>();
     QString buffer = itemToXML(source.rootItem());
 
     SessionModel target("TestModel");
@@ -130,7 +133,7 @@ TEST_F(TestSessionXML, test_Layer)
 TEST_F(TestSessionXML, test_Particle)
 {
     SessionModel source("TestModel");
-    source.insertNewItem("Particle");
+    source.insertItem<ParticleItem>();
     QString buffer = itemToXML(source.rootItem());
 
     SessionModel target("TestModel");
@@ -143,7 +146,7 @@ TEST_F(TestSessionXML, test_Particle)
 TEST_F(TestSessionXML, test_ParticleWithFF)
 {
     SessionModel source("TestModel");
-    SessionItem* particle = source.insertNewItem("Particle");
+    auto particle = source.insertItem<ParticleItem>();
 
     particle->setGroupProperty(ParticleItem::P_FORM_FACTOR, "AnisoPyramid");
     QString buffer = itemToXML(source.rootItem());

--- a/Tests/UnitTests/GUI/TestTranslations.cpp
+++ b/Tests/UnitTests/GUI/TestTranslations.cpp
@@ -17,10 +17,9 @@ TEST_F(TestTranslations, test_TranslatePosition)
     SessionItem* multilayer = model.insertNewItem("MultiLayer");
     SessionItem* layer = model.insertNewItem("Layer", multilayer->index());
     SessionItem* layout = model.insertNewItem("ParticleLayout", layer->index());
-    SessionItem* particle = model.insertNewItem("Particle", layout->index());
+    auto particle = model.insertItem<ParticleItem>(layout->index());
 
-    auto positionItem = particle->item<VectorItem>(ParticleItem::P_POSITION);
-    SessionItem* xItem = positionItem->getItem(VectorItem::P_X);
+    auto xItem = particle->positionItem()->getItem(VectorItem::P_X);
 
     EXPECT_EQ(ModelPath::itemPathTranslation(*xItem, multilayer->parent()),
               "MultiLayer/Layer/ParticleLayout/Particle/PositionX");

--- a/Tests/UnitTests/GUI/TestTranslations.cpp
+++ b/Tests/UnitTests/GUI/TestTranslations.cpp
@@ -19,8 +19,8 @@ TEST_F(TestTranslations, test_TranslatePosition)
     SessionItem* layout = model.insertNewItem("ParticleLayout", layer->index());
     SessionItem* particle = model.insertNewItem("Particle", layout->index());
 
-    auto& positionItem = particle->item<VectorItem>(ParticleItem::P_POSITION);
-    SessionItem* xItem = positionItem.getItem(VectorItem::P_X);
+    auto positionItem = particle->item<VectorItem>(ParticleItem::P_POSITION);
+    SessionItem* xItem = positionItem->getItem(VectorItem::P_X);
 
     EXPECT_EQ(ModelPath::itemPathTranslation(*xItem, multilayer->parent()),
               "MultiLayer/Layer/ParticleLayout/Particle/PositionX");

--- a/Tests/UnitTests/GUI/TestTranslations.cpp
+++ b/Tests/UnitTests/GUI/TestTranslations.cpp
@@ -19,8 +19,8 @@ TEST_F(TestTranslations, test_TranslatePosition)
     SessionItem* layout = model.insertNewItem("ParticleLayout", layer->index());
     SessionItem* particle = model.insertNewItem("Particle", layout->index());
 
-    SessionItem* positionItem = particle->getItem(ParticleItem::P_POSITION);
-    SessionItem* xItem = positionItem->getItem(VectorItem::P_X);
+    auto& positionItem = particle->item<VectorItem>(ParticleItem::P_POSITION);
+    SessionItem* xItem = positionItem.getItem(VectorItem::P_X);
 
     EXPECT_EQ(ModelPath::itemPathTranslation(*xItem, multilayer->parent()),
               "MultiLayer/Layer/ParticleLayout/Particle/PositionX");

--- a/Tests/UnitTests/GUI/TestTranslations.cpp
+++ b/Tests/UnitTests/GUI/TestTranslations.cpp
@@ -1,7 +1,10 @@
 #include "GUI/coregui/Models/BeamDistributionItem.h"
 #include "GUI/coregui/Models/InstrumentItems.h"
+#include "GUI/coregui/Models/LayerItem.h"
 #include "GUI/coregui/Models/ModelPath.h"
+#include "GUI/coregui/Models/MultiLayerItem.h"
 #include "GUI/coregui/Models/ParticleItem.h"
+#include "GUI/coregui/Models/ParticleLayoutItem.h"
 #include "GUI/coregui/Models/RotationItems.h"
 #include "GUI/coregui/Models/SampleModel.h"
 #include "GUI/coregui/Models/TransformationItem.h"
@@ -14,9 +17,9 @@ class TestTranslations : public ::testing::Test {
 TEST_F(TestTranslations, test_TranslatePosition)
 {
     SampleModel model;
-    SessionItem* multilayer = model.insertNewItem("MultiLayer");
-    SessionItem* layer = model.insertNewItem("Layer", multilayer->index());
-    SessionItem* layout = model.insertNewItem("ParticleLayout", layer->index());
+    auto multilayer = model.insertItem<MultiLayerItem>();
+    auto layer = model.insertItem<LayerItem>(multilayer->index());
+    auto layout = model.insertItem<ParticleLayoutItem>(layer->index());
     auto particle = model.insertItem<ParticleItem>(layout->index());
 
     auto xItem = particle->positionItem()->getItem(VectorItem::P_X);
@@ -28,13 +31,13 @@ TEST_F(TestTranslations, test_TranslatePosition)
 TEST_F(TestTranslations, test_TranslateRotation)
 {
     SampleModel model;
-    SessionItem* multilayer = model.insertNewItem("MultiLayer");
-    SessionItem* layer = model.insertNewItem("Layer", multilayer->index());
-    SessionItem* layout = model.insertNewItem("ParticleLayout", layer->index());
-    SessionItem* particle = model.insertNewItem("Particle", layout->index());
+    auto multilayer = model.insertItem<MultiLayerItem>();
+    auto layer = model.insertItem<LayerItem>(multilayer->index());
+    auto layout = model.insertItem<ParticleLayoutItem>(layer->index());
+    auto particle = model.insertItem<ParticleItem>(layout->index());
 
-    SessionItem* transformation =
-        model.insertNewItem("Rotation", particle->index(), -1, ParticleItem::T_TRANSFORMATION);
+    auto transformation =
+        model.insertItem<TransformationItem>(particle->index(), -1, ParticleItem::T_TRANSFORMATION);
 
     SessionItem* rotationItem =
         transformation->setGroupProperty(TransformationItem::P_ROT, "XRotation");
@@ -47,7 +50,7 @@ TEST_F(TestTranslations, test_TranslateRotation)
 TEST_F(TestTranslations, test_BeamDistributionNone)
 {
     SampleModel model;
-    SessionItem* instrument = model.insertNewItem("GISASInstrument");
+    auto instrument = model.insertItem<GISASInstrumentItem>();
     SessionItem* beam = instrument->getItem(Instrument2DItem::P_BEAM);
 
     SessionItem* wavelength = beam->getItem(BeamItem::P_WAVELENGTH);

--- a/Tests/UnitTests/GUI/TestVectorItem.cpp
+++ b/Tests/UnitTests/GUI/TestVectorItem.cpp
@@ -1,0 +1,43 @@
+#include "GUI/coregui/Models/VectorItem.h"
+#include "Tests/GTestWrapper/google_test.h"
+
+//! Tests VectorItem class.
+
+class TestVectorItem : public ::testing::Test {
+};
+
+//! The initial state.
+
+TEST_F(TestVectorItem, initialState)
+{
+    VectorItem item;
+
+    EXPECT_EQ(item.x(), 0.0);
+    EXPECT_EQ(item.y(), 0.0);
+    EXPECT_EQ(item.z(), 0.0);
+
+    auto kvec = item.getVector();
+    EXPECT_EQ(kvec.x(), 0.0);
+    EXPECT_EQ(kvec.y(), 0.0);
+    EXPECT_EQ(kvec.z(), 0.0);
+}
+
+//! Setters.
+
+TEST_F(TestVectorItem, setXYZ)
+{
+    VectorItem item;
+
+    item.setX(1.0);
+    item.setY(2.0);
+    item.setZ(3.0);
+
+    EXPECT_EQ(item.x(), 1.0);
+    EXPECT_EQ(item.y(), 2.0);
+    EXPECT_EQ(item.z(), 3.0);
+
+    auto kvec = item.getVector();
+    EXPECT_EQ(kvec.x(), 1.0);
+    EXPECT_EQ(kvec.y(), 2.0);
+    EXPECT_EQ(kvec.z(), 3.0);
+}

--- a/Tests/UnitTests/GUI/Utils.cpp
+++ b/Tests/UnitTests/GUI/Utils.cpp
@@ -50,7 +50,7 @@ std::unique_ptr<OutputData<double>> GuiUnittestUtils::createData(double value, D
 RealDataItem* GuiUnittestUtils::createRealData(const QString& name, SessionModel& model,
                                                double value, DIM n_dim)
 {
-    RealDataItem* result = dynamic_cast<RealDataItem*>(model.insertNewItem("RealData"));
+    auto result = model.insertItem<RealDataItem>();
     result->setOutputData(createData(value, n_dim).release());
     result->setItemValue(SessionItem::P_NAME, name);
     return result;

--- a/mvvm/model/mvvm/model/sessionmodel.cpp
+++ b/mvvm/model/mvvm/model/sessionmodel.cpp
@@ -193,6 +193,8 @@ void SessionModel::setUndoRedoEnabled(bool value)
 
 void SessionModel::clear(std::function<void(SessionItem*)> callback)
 {
+    if (undoStack())
+        undoStack()->clear();
     mapper()->callOnModelAboutToBeReset();
     p_impl->createRootItem();
     if (callback)


### PR DESCRIPTION
Following changes toward better type safety.

+ Switch to item<T> access method instead of getItem(P_SOMETHING)
+ Switch to SessionModel::insertItem<T> instead of insertNewItem(QString)