### PR TITLE
Insert new item review

### DIFF
--- a/GUI/coregui/Models/DetectorItems.cpp
+++ b/GUI/coregui/Models/DetectorItems.cpp
@@ -88,7 +88,7 @@ MaskContainerItem* DetectorItem::maskContainerItem() const
 void DetectorItem::createMaskContainer()
 {
     if (!maskContainerItem())
-        model()->insertItem<MaskContainerItem>(this->index());
+        model()->insertItem<MaskContainerItem>(this);
 }
 
 void DetectorItem::importMasks(const MaskContainerItem* maskContainer)

--- a/GUI/coregui/Models/FitParameterHelper.cpp
+++ b/GUI/coregui/Models/FitParameterHelper.cpp
@@ -69,7 +69,7 @@ void FitParameterHelper::addToFitParameter(FitParameterContainerItem* container,
     removeFromFitParameters(container, parameterItem);
     for (auto fitPar : container->getItems(FitParameterContainerItem::T_FIT_PARAMETERS)) {
         if (fitPar->displayName() == fitParName) {
-            SessionItem* link = fitPar->model()->insertNewItem("FitParameterLink", fitPar->index());
+            SessionItem* link = fitPar->model()->insertNewItem("FitParameterLink", fitPar);
             link->setItemValue(FitParameterLinkItem::P_LINK, getParameterItemPath(parameterItem));
             break;
         }

--- a/GUI/coregui/Models/FitParameterHelper.cpp
+++ b/GUI/coregui/Models/FitParameterHelper.cpp
@@ -31,9 +31,9 @@ void FitParameterHelper::createFitParameter(FitParameterContainerItem* container
     removeFromFitParameters(container, parameterItem);
 
     auto model = container->model();
-    auto fitPar = model->insertItem<FitParameterItem>(container->index());
+    auto fitPar = model->insertItem<FitParameterItem>(container);
     fitPar->setDisplayName("par");
-    auto link = model->insertItem<FitParameterLinkItem>(fitPar->index());
+    auto link = model->insertItem<FitParameterLinkItem>(fitPar);
     fitPar->setItemValue(FitParameterItem::P_START_VALUE, parameterItem->value());
     link->setItemValue(FitParameterLinkItem::P_LINK, getParameterItemPath(parameterItem));
 

--- a/GUI/coregui/Models/GUIDomainSampleVisitor.cpp
+++ b/GUI/coregui/Models/GUIDomainSampleVisitor.cpp
@@ -539,8 +539,8 @@ void GUIDomainSampleVisitor::visit(const RotationY* sample)
     SessionItem* parent = m_levelToParentItem[depth() - 1];
     ASSERT(parent);
 
-    auto transformation_item = m_sampleModel->insertItem<TransformationItem>(
-        parent, -1, ParticleItem::T_TRANSFORMATION);
+    auto transformation_item =
+        m_sampleModel->insertItem<TransformationItem>(parent, -1, ParticleItem::T_TRANSFORMATION);
     SessionItem* rotationItem =
         transformation_item->setGroupProperty(TransformationItem::P_ROT, "YRotation");
     rotationItem->setItemValue(YRotationItem::P_ANGLE, Units::rad2deg(sample->getAngle()));
@@ -552,8 +552,8 @@ void GUIDomainSampleVisitor::visit(const RotationZ* sample)
     SessionItem* parent = m_levelToParentItem[depth() - 1];
     ASSERT(parent);
 
-    auto transformation_item = m_sampleModel->insertItem<TransformationItem>(
-        parent, -1, ParticleItem::T_TRANSFORMATION);
+    auto transformation_item =
+        m_sampleModel->insertItem<TransformationItem>(parent, -1, ParticleItem::T_TRANSFORMATION);
     SessionItem* rotationItem =
         transformation_item->setGroupProperty(TransformationItem::P_ROT, "ZRotation");
     rotationItem->setItemValue(ZRotationItem::P_ANGLE, Units::rad2deg(sample->getAngle()));
@@ -565,8 +565,8 @@ void GUIDomainSampleVisitor::visit(const RotationEuler* sample)
     SessionItem* parent = m_levelToParentItem[depth() - 1];
     ASSERT(parent);
 
-    auto transformation_item = m_sampleModel->insertItem<TransformationItem>(
-        parent, -1, ParticleItem::T_TRANSFORMATION);
+    auto transformation_item =
+        m_sampleModel->insertItem<TransformationItem>(parent, -1, ParticleItem::T_TRANSFORMATION);
     SessionItem* rotationItem =
         transformation_item->setGroupProperty(TransformationItem::P_ROT, "EulerRotation");
     rotationItem->setItemValue(EulerRotationItem::P_ALPHA, Units::rad2deg(sample->getAlpha()));
@@ -627,8 +627,7 @@ SessionItem* GUIDomainSampleVisitor::InsertIParticle(const IParticle* particle, 
             }
         }
     }
-    SessionItem* particle_item =
-        m_sampleModel->insertNewItem(model_type, m_sampleModel->indexOfItem(parent), -1, tag);
+    SessionItem* particle_item = m_sampleModel->insertNewItem(model_type, parent, -1, tag);
 
     ASSERT(particle_item);
     particle_item->setItemValue(ParticleItem::P_ABUNDANCE, particle->abundance());

--- a/GUI/coregui/Models/GUIDomainSampleVisitor.cpp
+++ b/GUI/coregui/Models/GUIDomainSampleVisitor.cpp
@@ -94,8 +94,7 @@ SessionItem* GUIDomainSampleVisitor::populateSampleModel(SampleModel* sampleMode
 void GUIDomainSampleVisitor::visit(const ParticleLayout* sample)
 {
     SessionItem* parent = m_levelToParentItem[depth() - 1];
-    auto layout_item = m_sampleModel->insertItem<ParticleLayoutItem>(
-        parent ? m_sampleModel->indexOfItem(parent) : QModelIndex());
+    auto layout_item = m_sampleModel->insertItem<ParticleLayoutItem>(parent);
     layout_item->setItemValue(ParticleLayoutItem::P_TOTAL_DENSITY,
                               sample->totalParticleSurfaceDensity());
     layout_item->setItemValue(ParticleLayoutItem::P_WEIGHT, sample->weight());
@@ -113,8 +112,7 @@ void GUIDomainSampleVisitor::visit(const Layer* sample)
     const LayerInterface* top_interface =
         layer_index == 0 ? nullptr : multilayer->layerInterface(layer_index - 1);
 
-    SessionItem* layer_item =
-        m_sampleModel->insertItem<LayerItem>(m_sampleModel->indexOfItem(parent));
+    SessionItem* layer_item = m_sampleModel->insertItem<LayerItem>(parent);
     layer_item->setItemValue(LayerItem::P_MATERIAL,
                              createMaterialFromDomain(sample->material()).variant());
 
@@ -145,8 +143,8 @@ void GUIDomainSampleVisitor::visit(const ParticleDistribution* sample)
 {
     SessionItem* layout_item = m_levelToParentItem[depth() - 1];
     ASSERT(layout_item);
-    auto particle_distribution_item = m_sampleModel->insertItem<ParticleDistributionItem>(
-        m_sampleModel->indexOfItem(layout_item));
+    auto particle_distribution_item =
+        m_sampleModel->insertItem<ParticleDistributionItem>(layout_item);
 
     TransformFromDomain::setParticleDistributionItem(particle_distribution_item, *sample);
 
@@ -468,7 +466,7 @@ void GUIDomainSampleVisitor::visit(const InterferenceFunction1DLattice* sample)
     SessionItem* parent = m_levelToParentItem[depth() - 1];
     ASSERT(parent);
     auto item = m_sampleModel->insertItem<InterferenceFunction1DLatticeItem>(
-        m_sampleModel->indexOfItem(parent), -1, ParticleLayoutItem::T_INTERFERENCE);
+        parent, -1, ParticleLayoutItem::T_INTERFERENCE);
     TransformFromDomain::set1DLatticeItem(item, *sample);
     m_levelToParentItem[depth()] = item;
 }
@@ -478,7 +476,7 @@ void GUIDomainSampleVisitor::visit(const InterferenceFunction2DLattice* sample)
     SessionItem* parent = m_levelToParentItem[depth() - 1];
     ASSERT(parent);
     auto item = m_sampleModel->insertItem<InterferenceFunction2DLatticeItem>(
-        m_sampleModel->indexOfItem(parent), -1, ParticleLayoutItem::T_INTERFERENCE);
+        parent, -1, ParticleLayoutItem::T_INTERFERENCE);
     TransformFromDomain::set2DLatticeItem(item, *sample);
     m_levelToParentItem[depth()] = item;
 }
@@ -488,7 +486,7 @@ void GUIDomainSampleVisitor::visit(const InterferenceFunction2DParaCrystal* samp
     SessionItem* parent = m_levelToParentItem[depth() - 1];
     ASSERT(parent);
     auto item = m_sampleModel->insertItem<InterferenceFunction2DParaCrystalItem>(
-        m_sampleModel->indexOfItem(parent), -1, ParticleLayoutItem::T_INTERFERENCE);
+        parent, -1, ParticleLayoutItem::T_INTERFERENCE);
     TransformFromDomain::set2DParaCrystalItem(item, *sample);
     m_levelToParentItem[depth()] = item;
 }
@@ -498,7 +496,7 @@ void GUIDomainSampleVisitor::visit(const InterferenceFunctionFinite2DLattice* sa
     SessionItem* parent = m_levelToParentItem[depth() - 1];
     ASSERT(parent);
     auto item = m_sampleModel->insertItem<InterferenceFunctionFinite2DLatticeItem>(
-        m_sampleModel->indexOfItem(parent), -1, ParticleLayoutItem::T_INTERFERENCE);
+        parent, -1, ParticleLayoutItem::T_INTERFERENCE);
     TransformFromDomain::setFinite2DLatticeItem(item, *sample);
     m_levelToParentItem[depth()] = item;
 }
@@ -508,7 +506,7 @@ void GUIDomainSampleVisitor::visit(const InterferenceFunctionHardDisk* sample)
     SessionItem* parent = m_levelToParentItem[depth() - 1];
     ASSERT(parent);
     auto item = m_sampleModel->insertItem<InterferenceFunctionHardDiskItem>(
-        m_sampleModel->indexOfItem(parent), -1, ParticleLayoutItem::T_INTERFERENCE);
+        parent, -1, ParticleLayoutItem::T_INTERFERENCE);
     TransformFromDomain::setHardDiskItem(item, *sample);
     m_levelToParentItem[depth()] = item;
 }
@@ -518,7 +516,7 @@ void GUIDomainSampleVisitor::visit(const InterferenceFunctionRadialParaCrystal* 
     SessionItem* parent = m_levelToParentItem[depth() - 1];
     ASSERT(parent);
     auto item = m_sampleModel->insertItem<InterferenceFunctionRadialParaCrystalItem>(
-        m_sampleModel->indexOfItem(parent), -1, ParticleLayoutItem::T_INTERFERENCE);
+        parent, -1, ParticleLayoutItem::T_INTERFERENCE);
     TransformFromDomain::setRadialParaCrystalItem(item, *sample);
     m_levelToParentItem[depth()] = item;
 }
@@ -528,8 +526,8 @@ void GUIDomainSampleVisitor::visit(const RotationX* sample)
     SessionItem* parent = m_levelToParentItem[depth() - 1];
     ASSERT(parent);
 
-    auto transformation_item = m_sampleModel->insertItem<TransformationItem>(
-        m_sampleModel->indexOfItem(parent), -1, ParticleItem::T_TRANSFORMATION);
+    auto transformation_item =
+        m_sampleModel->insertItem<TransformationItem>(parent, -1, ParticleItem::T_TRANSFORMATION);
     SessionItem* rotationItem =
         transformation_item->setGroupProperty(TransformationItem::P_ROT, "XRotation");
     rotationItem->setItemValue(XRotationItem::P_ANGLE, Units::rad2deg(sample->getAngle()));
@@ -542,7 +540,7 @@ void GUIDomainSampleVisitor::visit(const RotationY* sample)
     ASSERT(parent);
 
     auto transformation_item = m_sampleModel->insertItem<TransformationItem>(
-        m_sampleModel->indexOfItem(parent), -1, ParticleItem::T_TRANSFORMATION);
+        parent, -1, ParticleItem::T_TRANSFORMATION);
     SessionItem* rotationItem =
         transformation_item->setGroupProperty(TransformationItem::P_ROT, "YRotation");
     rotationItem->setItemValue(YRotationItem::P_ANGLE, Units::rad2deg(sample->getAngle()));
@@ -555,7 +553,7 @@ void GUIDomainSampleVisitor::visit(const RotationZ* sample)
     ASSERT(parent);
 
     auto transformation_item = m_sampleModel->insertItem<TransformationItem>(
-        m_sampleModel->indexOfItem(parent), -1, ParticleItem::T_TRANSFORMATION);
+        parent, -1, ParticleItem::T_TRANSFORMATION);
     SessionItem* rotationItem =
         transformation_item->setGroupProperty(TransformationItem::P_ROT, "ZRotation");
     rotationItem->setItemValue(ZRotationItem::P_ANGLE, Units::rad2deg(sample->getAngle()));
@@ -568,7 +566,7 @@ void GUIDomainSampleVisitor::visit(const RotationEuler* sample)
     ASSERT(parent);
 
     auto transformation_item = m_sampleModel->insertItem<TransformationItem>(
-        m_sampleModel->indexOfItem(parent), -1, ParticleItem::T_TRANSFORMATION);
+        parent, -1, ParticleItem::T_TRANSFORMATION);
     SessionItem* rotationItem =
         transformation_item->setGroupProperty(TransformationItem::P_ROT, "EulerRotation");
     rotationItem->setItemValue(EulerRotationItem::P_ALPHA, Units::rad2deg(sample->getAlpha()));

--- a/GUI/coregui/Models/JobModelFunctions.cpp
+++ b/GUI/coregui/Models/JobModelFunctions.cpp
@@ -68,10 +68,10 @@ void JobModelFunctions::initDataView(JobItem* job_item)
     ASSERT(!job_item->getItem(JobItem::T_DATAVIEW));
 
     SessionModel* model = job_item->model();
-    auto view_item = model->insertItem<Data1DViewItem>(job_item->index(), -1, JobItem::T_DATAVIEW);
+    auto view_item = model->insertItem<Data1DViewItem>(job_item, -1, JobItem::T_DATAVIEW);
 
     auto property_container = model->insertItem<DataPropertyContainer>(
-        view_item->index(), -1, Data1DViewItem::T_DATA_PROPERTIES);
+        view_item, -1, Data1DViewItem::T_DATA_PROPERTIES);
 
     property_container->addItem(job_item->realDataItem()->dataItem());
     property_container->addItem(job_item->dataItem());
@@ -92,7 +92,7 @@ void JobModelFunctions::setupJobItemSampleData(JobItem* jobItem, const MultiLaye
 
     // copying materials
     auto container = jobItem->model()->insertItem<MaterialItemContainer>(
-        jobItem->index(), -1, JobItem::T_MATERIAL_CONTAINER);
+        jobItem, -1, JobItem::T_MATERIAL_CONTAINER);
 
     std::map<MaterialItem*, QString> materials;
     for (auto property_item : multilayer->materialPropertyItems()) {
@@ -144,11 +144,11 @@ void JobModelFunctions::setupJobItemOutput(JobItem* jobItem)
 
     auto instrumentType = jobItem->instrumentItem()->modelType();
     if (instrumentType == "SpecularInstrument") {
-        model->insertItem<SpecularDataItem>(model->indexOfItem(jobItem), -1, JobItem::T_OUTPUT);
+        model->insertItem<SpecularDataItem>(jobItem, -1, JobItem::T_OUTPUT);
 
     } else if (instrumentType == "GISASInstrument" || instrumentType == "OffSpecularInstrument"
                || instrumentType == "DepthProbeInstrument") {
-        model->insertItem<IntensityDataItem>(model->indexOfItem(jobItem), -1, JobItem::T_OUTPUT);
+        model->insertItem<IntensityDataItem>(jobItem, -1, JobItem::T_OUTPUT);
 
     } else {
         throw GUIHelpers::Error("JobModelFunctions::setupJobItemOutput() -> Error. "
@@ -269,7 +269,7 @@ void createFitContainers(JobItem* jobItem)
                                 "a second FitSuiteItem.");
     }
 
-    fitSuiteItem = model->insertItem<FitSuiteItem>(jobItem->index(), -1, JobItem::T_FIT_SUITE);
+    fitSuiteItem = model->insertItem<FitSuiteItem>(jobItem, -1, JobItem::T_FIT_SUITE);
 
     SessionItem* parsContainerItem =
         fitSuiteItem->getItem(FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
@@ -278,7 +278,7 @@ void createFitContainers(JobItem* jobItem)
                                 "a second FitParameterContainer.");
     }
 
-    model->insertItem<FitParameterContainerItem>(fitSuiteItem->index(), -1,
+    model->insertItem<FitParameterContainerItem>(fitSuiteItem, -1,
                                                  FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
 
     // Minimizer settings
@@ -288,7 +288,7 @@ void createFitContainers(JobItem* jobItem)
                                 "a second MinimizerContainer.");
     }
 
-    model->insertItem<MinimizerContainerItem>(fitSuiteItem->index(), -1, FitSuiteItem::T_MINIMIZER);
+    model->insertItem<MinimizerContainerItem>(fitSuiteItem, -1, FitSuiteItem::T_MINIMIZER);
 }
 
 PointwiseAxisItem* getPointwiseAxisItem(const SpecularInstrumentItem* instrument)

--- a/GUI/coregui/Models/ParameterTreeUtils.cpp
+++ b/GUI/coregui/Models/ParameterTreeUtils.cpp
@@ -56,7 +56,7 @@ void handleItem(SessionItem* tree, const SessionItem* source);
 void ParameterTreeUtils::createParameterTree(JobItem* jobItem)
 {
     auto container = jobItem->model()->insertItem<ParameterContainerItem>(
-        jobItem->index(), -1, JobItem::T_PARAMETER_TREE);
+        jobItem, -1, JobItem::T_PARAMETER_TREE);
 
     populateParameterContainer(container, jobItem->getItem(JobItem::T_MATERIAL_CONTAINER));
 
@@ -82,7 +82,7 @@ void ParameterTreeUtils::populateParameterContainer(SessionItem* container,
         throw GUIHelpers::Error("ParameterTreeUtils::populateParameterContainer() -> Error. "
                                 "Not a ParameterContainerType.");
 
-    auto sourceLabel = container->model()->insertItem<ParameterLabelItem>(container->index());
+    auto sourceLabel = container->model()->insertItem<ParameterLabelItem>(container);
     handleItem(sourceLabel, source);
 }
 
@@ -244,18 +244,18 @@ void handleItem(SessionItem* tree, const SessionItem* source)
         if (child->isVisible() && child->isEnabled()) {
             if (child->modelType() == "Property") {
                 if (child->value().type() == QVariant::Double) {
-                    auto branch = tree->model()->insertItem<ParameterItem>(tree->index());
+                    auto branch = tree->model()->insertItem<ParameterItem>(tree);
                     handleItem(branch, child);
                 }
 
             } else if (child->modelType() == "GroupProperty") {
                 SessionItem* currentItem = dynamic_cast<GroupItem*>(child)->currentItem();
                 if (currentItem && currentItem->numberOfChildren() > 0) {
-                    auto branch = tree->model()->insertItem<ParameterLabelItem>(tree->index());
+                    auto branch = tree->model()->insertItem<ParameterLabelItem>(tree);
                     handleItem(branch, currentItem);
                 }
             } else {
-                auto branch = tree->model()->insertItem<ParameterLabelItem>(tree->index());
+                auto branch = tree->model()->insertItem<ParameterLabelItem>(tree);
                 handleItem(branch, child);
             }
         }

--- a/GUI/coregui/Models/RealDataItem.cpp
+++ b/GUI/coregui/Models/RealDataItem.cpp
@@ -113,7 +113,7 @@ void RealDataItem::setOutputData(OutputData<double>* data)
         throw GUIHelpers::Error("Error in RealDataItem::setOutputData: trying to set data "
                                 "incompatible with underlying data item");
     if (!data_item) {
-        model()->insertNewItem(target_model_type, this->index(), 0, T_INTENSITY_DATA);
+        model()->insertNewItem(target_model_type, this, 0, T_INTENSITY_DATA);
         ASSERT(getItem(T_INTENSITY_DATA)
                && "Assertion failed in RealDataItem::setOutputData: inserting data item failed.");
     }
@@ -129,7 +129,7 @@ void RealDataItem::initDataItem(size_t data_rank, const QString& tag)
         throw GUIHelpers::Error("Error in RealDataItem::initDataItem: trying to set data "
                                 "incompatible with underlying data item");
     if (!data_item)
-        model()->insertNewItem(target_model_type, this->index(), 0, tag);
+        model()->insertNewItem(target_model_type, this, 0, tag);
 }
 
 void RealDataItem::setImportData(ImportDataInfo data)

--- a/GUI/coregui/Models/SessionModel.cpp
+++ b/GUI/coregui/Models/SessionModel.cpp
@@ -283,6 +283,12 @@ SessionItem* SessionModel::insertNewItem(QString model_type, SessionItem* parent
     return new_item;
 }
 
+SessionItem* SessionModel::insertNewItem(QString model_type, const QModelIndex& parent_item,
+                                         int row, QString tag)
+{
+    return insertNewItem(model_type, itemForIndex(parent_item), row, tag);
+}
+
 QVector<QString> SessionModel::acceptableDefaultItemTypes(const QModelIndex& parent) const
 {
     QVector<QString> result;

--- a/GUI/coregui/Models/SessionModel.cpp
+++ b/GUI/coregui/Models/SessionModel.cpp
@@ -257,10 +257,9 @@ QModelIndex SessionModel::indexOfItem(SessionItem* item) const
     return createIndex(row, 0, item);
 }
 
-SessionItem* SessionModel::insertNewItem(QString model_type, const QModelIndex& parent, int row,
+SessionItem* SessionModel::insertNewItem(QString model_type, SessionItem* parent_item, int row,
                                          QString tag)
 {
-    SessionItem* parent_item = itemForIndex(parent);
     if (!parent_item)
         parent_item = m_root_item;
     if (row > parent_item->numberOfChildren())

--- a/GUI/coregui/Models/SessionModel.h
+++ b/GUI/coregui/Models/SessionModel.h
@@ -55,8 +55,16 @@ public:
     QModelIndex indexOfItem(SessionItem* item) const;
     SessionItem* insertNewItem(QString model_type, SessionItem* parent_item = nullptr, int row = -1,
                                QString tag = "");
+
+    // #migration Method is deprecated, index usage is discouraged.
+    SessionItem* insertNewItem(QString model_type, const QModelIndex& parent_item,
+                                  int row = -1, QString tag = "");
+
     template <typename T>
     T* insertItem(SessionItem* parent = nullptr, int row = -1, QString tag = "");
+
+    // #migration Method is deprecated, index usage is discouraged.
+    template <typename T> T* insertItem(const QModelIndex& parent, int row = -1, QString tag = "");
 
     QString getModelTag() const;
     QString getModelName() const;
@@ -108,6 +116,11 @@ private:
 template <typename T> T* SessionModel::insertItem(SessionItem* parent, int row, QString tag)
 {
     return static_cast<T*>(insertNewItem(T().modelType(), parent, row, tag));
+}
+
+template <typename T> T* SessionModel::insertItem(const QModelIndex& parent, int row, QString tag)
+{
+    return insertItem<T>(itemForIndex(parent), row, tag);
 }
 
 template <typename T> T* SessionModel::topItem() const

--- a/GUI/coregui/Models/SessionModel.h
+++ b/GUI/coregui/Models/SessionModel.h
@@ -53,7 +53,7 @@ public:
     // End overridden methods from QAbstractItemModel
 
     QModelIndex indexOfItem(SessionItem* item) const;
-    SessionItem* insertNewItem(QString model_type, const QModelIndex& parent = {}, int row = -1,
+    SessionItem* insertNewItem(QString model_type, SessionItem* parent_item = nullptr, int row = -1,
                                QString tag = "");
     template <typename T>
     T* insertItem(SessionItem* parent = nullptr, int row = -1, QString tag = "");
@@ -107,8 +107,7 @@ private:
 
 template <typename T> T* SessionModel::insertItem(SessionItem* parent, int row, QString tag)
 {
-    return static_cast<T*>(
-        insertNewItem(T().modelType(), parent ? parent->index() : QModelIndex(), row, tag));
+    return static_cast<T*>(insertNewItem(T().modelType(), parent, row, tag));
 }
 
 template <typename T> T* SessionModel::topItem() const

--- a/GUI/coregui/Models/SessionModel.h
+++ b/GUI/coregui/Models/SessionModel.h
@@ -56,7 +56,7 @@ public:
     SessionItem* insertNewItem(QString model_type, const QModelIndex& parent = {}, int row = -1,
                                QString tag = "");
     template <typename T>
-    T* insertItem(const QModelIndex& parent = {}, int row = -1, QString tag = "");
+    T* insertItem(SessionItem* parent = nullptr, int row = -1, QString tag = "");
 
     QString getModelTag() const;
     QString getModelName() const;
@@ -105,9 +105,10 @@ private:
     QString m_model_tag; //!< model tag (SampleModel, InstrumentModel)
 };
 
-template <typename T> T* SessionModel::insertItem(const QModelIndex& parent, int row, QString tag)
+template <typename T> T* SessionModel::insertItem(SessionItem* parent, int row, QString tag)
 {
-    return static_cast<T*>(insertNewItem(T().modelType(), parent, row, tag));
+    return static_cast<T*>(
+        insertNewItem(T().modelType(), parent ? parent->index() : QModelIndex(), row, tag));
 }
 
 template <typename T> T* SessionModel::topItem() const

--- a/GUI/coregui/Models/SessionXML.cpp
+++ b/GUI/coregui/Models/SessionXML.cpp
@@ -249,7 +249,7 @@ SessionItem* createItem(SessionItem* item, const QString& modelType, const QStri
             result = item->getItem(tag);
         } else {
             try {
-                result = item->model()->insertNewItem(modelType, item->index(), -1, tag);
+                result = item->model()->insertNewItem(modelType, item, -1, tag);
             } catch (const std::exception&) {
                 result = nullptr; // error will be reported later
             }

--- a/GUI/coregui/Views/FitWidgets/FitComparisonViewController.cpp
+++ b/GUI/coregui/Views/FitWidgets/FitComparisonViewController.cpp
@@ -91,7 +91,7 @@ void FitComparison1DViewController::createDiffViewItem(JobItem* job_item)
 {
     m_diff_view_item = m_diff_item_controller->model()->insertItem<Data1DViewItem>();
     auto container = m_diff_view_item->model()->insertItem<DataPropertyContainer>(
-        m_diff_view_item->index(), -1, Data1DViewItem::T_DATA_PROPERTIES);
+        m_diff_view_item, -1, Data1DViewItem::T_DATA_PROPERTIES);
     container->addItem(m_diff_item_controller->diffItem());
 
     m_diff_view_item->setJobItem(job_item);

--- a/GUI/coregui/Views/ImportDataWidgets/RealDataMaskWidget.cpp
+++ b/GUI/coregui/Views/ImportDataWidgets/RealDataMaskWidget.cpp
@@ -69,8 +69,7 @@ MaskContainerItem* RealDataMaskWidget::maskContainer(IntensityDataItem* intensit
 {
     auto containerItem = intensityData->getItem(IntensityDataItem::T_MASKS);
     if (!containerItem)
-        containerItem =
-            intensityData->model()->insertNewItem("MaskContainer", intensityData->index());
+        containerItem = intensityData->model()->insertNewItem("MaskContainer", intensityData);
 
     MaskContainerItem* result = dynamic_cast<MaskContainerItem*>(containerItem);
     return result;

--- a/GUI/coregui/Views/InstrumentWidgets/InstrumentViewActions.cpp
+++ b/GUI/coregui/Views/InstrumentWidgets/InstrumentViewActions.cpp
@@ -13,6 +13,7 @@
 //  ************************************************************************************************
 
 #include "GUI/coregui/Views/InstrumentWidgets/InstrumentViewActions.h"
+#include "GUI/coregui/Models/DepthProbeInstrumentItem.h"
 #include "GUI/coregui/Models/GroupItem.h"
 #include "GUI/coregui/Models/InstrumentItems.h"
 #include "GUI/coregui/Models/ModelUtils.h"
@@ -79,16 +80,16 @@ void InstrumentViewActions::onAddInstrument()
     QString instrumentType = action->data().toString();
 
     if (instrumentType == "GISASInstrument") {
-        auto instrument = m_model->insertNewItem(instrumentType);
+        auto instrument = m_model->insertItem<GISASInstrumentItem>();
         instrument->setItemName(suggestInstrumentName("GISAS"));
     } else if (instrumentType == "OffSpecularInstrument") {
-        auto instrument = m_model->insertNewItem(instrumentType);
+        auto instrument = m_model->insertItem<OffSpecularInstrumentItem>();
         instrument->setItemName(suggestInstrumentName("OffSpecular"));
     } else if (instrumentType == "SpecularInstrument") {
-        auto instrument = m_model->insertNewItem(instrumentType);
+        auto instrument = m_model->insertItem<SpecularInstrumentItem>();
         instrument->setItemName(suggestInstrumentName("Specular"));
     } else if (instrumentType == "DepthProbeInstrument") {
-        auto instrument = m_model->insertNewItem(instrumentType);
+        auto instrument = m_model->insertItem<DepthProbeInstrumentItem>();
         instrument->setItemName(suggestInstrumentName("DepthProbe"));
     } else {
         qInfo() << "InstrumentViewActions::onAddInstrument() -> Not supported instrument type"

--- a/GUI/coregui/Views/IntensityDataWidgets/IntensityDataProjectionsWidget.cpp
+++ b/GUI/coregui/Views/IntensityDataWidgets/IntensityDataProjectionsWidget.cpp
@@ -62,8 +62,8 @@ IntensityDataProjectionsWidget::projectionContainer(IntensityDataItem* intensity
 
     auto containerItem = intensityItem->getItem(IntensityDataItem::T_PROJECTIONS);
     if (!containerItem)
-        containerItem = intensityItem->model()->insertNewItem(
-            "ProjectionContainer", intensityItem->index(), -1, IntensityDataItem::T_PROJECTIONS);
+        containerItem = intensityItem->model()->insertNewItem("ProjectionContainer", intensityItem,
+                                                              -1, IntensityDataItem::T_PROJECTIONS);
 
     return dynamic_cast<ProjectionContainerItem*>(containerItem);
 }

--- a/GUI/coregui/Views/JobWidgets/ProjectionsEditorCanvas.cpp
+++ b/GUI/coregui/Views/JobWidgets/ProjectionsEditorCanvas.cpp
@@ -90,9 +90,11 @@ void ProjectionsEditorCanvas::onEnteringColorMap()
     m_block_update = true;
 
     if (m_currentActivity == MaskEditorFlags::HORIZONTAL_LINE_MODE)
-        m_liveProjection = m_model->insertItem<HorizontalLineItem>(m_containerIndex);
+        m_liveProjection =
+            m_model->insertItem<HorizontalLineItem>(m_model->itemForIndex(m_containerIndex));
     else if (m_currentActivity == MaskEditorFlags::VERTICAL_LINE_MODE)
-        m_liveProjection = m_model->insertItem<VerticalLineItem>(m_containerIndex);
+        m_liveProjection =
+            m_model->insertItem<VerticalLineItem>(m_model->itemForIndex(m_containerIndex));
 
     if (m_liveProjection)
         m_liveProjection->setItemValue(MaskItem::P_IS_VISIBLE, false);

--- a/GUI/coregui/Views/JobWidgets/ProjectionsEditorCanvas.cpp
+++ b/GUI/coregui/Views/JobWidgets/ProjectionsEditorCanvas.cpp
@@ -91,10 +91,10 @@ void ProjectionsEditorCanvas::onEnteringColorMap()
 
     if (m_currentActivity == MaskEditorFlags::HORIZONTAL_LINE_MODE)
         m_liveProjection =
-            m_model->insertItem<HorizontalLineItem>(m_model->itemForIndex(m_containerIndex));
+            m_model->insertItem<HorizontalLineItem>(m_containerIndex);
     else if (m_currentActivity == MaskEditorFlags::VERTICAL_LINE_MODE)
         m_liveProjection =
-            m_model->insertItem<VerticalLineItem>(m_model->itemForIndex(m_containerIndex));
+            m_model->insertItem<VerticalLineItem>(m_containerIndex);
 
     if (m_liveProjection)
         m_liveProjection->setItemValue(MaskItem::P_IS_VISIBLE, false);

--- a/GUI/coregui/Views/MaskWidgets/MaskGraphicsScene.cpp
+++ b/GUI/coregui/Views/MaskWidgets/MaskGraphicsScene.cpp
@@ -639,7 +639,8 @@ void MaskGraphicsScene::processPolygonItem(QGraphicsSceneMouseEvent* event)
 
     if (!m_currentItem) {
         setDrawingInProgress(true);
-        m_currentItem = m_maskModel->insertItem<PolygonItem>(m_maskContainerIndex, 0);
+        m_currentItem = m_maskModel->insertItem<PolygonItem>(
+            m_maskModel->itemForIndex(m_maskContainerIndex), 0);
         m_currentItem->setItemValue(MaskItem::P_MASK_VALUE, m_context.getMaskValue());
         m_selectionModel->clearSelection();
         m_selectionModel->select(m_maskModel->indexOfItem(m_currentItem),
@@ -655,7 +656,7 @@ void MaskGraphicsScene::processPolygonItem(QGraphicsSceneMouseEvent* event)
             return;
         }
     }
-    auto point = m_maskModel->insertItem<PolygonPointItem>(m_maskModel->indexOfItem(m_currentItem));
+    auto point = m_maskModel->insertItem<PolygonPointItem>(m_currentItem);
     QPointF click_pos = event->buttonDownScenePos(Qt::LeftButton);
 
     point->setItemValue(PolygonPointItem::P_POSX, m_adaptor->fromSceneX(click_pos.x()));
@@ -683,13 +684,15 @@ void MaskGraphicsScene::processLineItem(QGraphicsSceneMouseEvent* event)
 
 void MaskGraphicsScene::processVerticalLineItem(const QPointF& pos)
 {
-    m_currentItem = m_maskModel->insertItem<VerticalLineItem>(m_maskContainerIndex, 0);
+    m_currentItem = m_maskModel->insertItem<VerticalLineItem>(
+        m_maskModel->itemForIndex(m_maskContainerIndex), 0);
     m_currentItem->setItemValue(VerticalLineItem::P_POSX, m_adaptor->fromSceneX(pos.x()));
 }
 
 void MaskGraphicsScene::processHorizontalLineItem(const QPointF& pos)
 {
-    m_currentItem = m_maskModel->insertItem<HorizontalLineItem>(m_maskContainerIndex, 0);
+    m_currentItem = m_maskModel->insertItem<HorizontalLineItem>(
+        m_maskModel->itemForIndex(m_maskContainerIndex), 0);
     m_currentItem->setItemValue(HorizontalLineItem::P_POSY, m_adaptor->fromSceneY(pos.y()));
 }
 
@@ -697,7 +700,8 @@ void MaskGraphicsScene::processMaskAllItem(QGraphicsSceneMouseEvent* event)
 {
     Q_UNUSED(event);
     setDrawingInProgress(true);
-    m_currentItem = m_maskModel->insertItem<MaskAllItem>(m_maskContainerIndex);
+    m_currentItem =
+        m_maskModel->insertItem<MaskAllItem>(m_maskModel->itemForIndex(m_maskContainerIndex));
     m_selectionModel->clearSelection();
     setDrawingInProgress(false);
 }

--- a/GUI/coregui/Views/MaskWidgets/MaskGraphicsScene.cpp
+++ b/GUI/coregui/Views/MaskWidgets/MaskGraphicsScene.cpp
@@ -600,7 +600,8 @@ void MaskGraphicsScene::processRectangleShapeItem(QGraphicsSceneMouseEvent* even
 
     if (!m_currentItem && line.length() > min_distance_to_create_rect) {
         m_currentItem = m_maskModel->insertNewItem(m_context.activityToModelType(),
-                                                   m_maskContainerIndex, m_context.activityToRow());
+                                                   m_maskModel->itemForIndex(m_maskContainerIndex),
+                                                   m_context.activityToRow());
         if (!m_context.isROIMode())
             m_currentItem->setItemValue(MaskItem::P_MASK_VALUE, m_context.getMaskValue());
         setItemName(m_currentItem);

--- a/GUI/coregui/Views/MaskWidgets/MaskGraphicsScene.cpp
+++ b/GUI/coregui/Views/MaskWidgets/MaskGraphicsScene.cpp
@@ -600,8 +600,7 @@ void MaskGraphicsScene::processRectangleShapeItem(QGraphicsSceneMouseEvent* even
 
     if (!m_currentItem && line.length() > min_distance_to_create_rect) {
         m_currentItem = m_maskModel->insertNewItem(m_context.activityToModelType(),
-                                                   m_maskModel->itemForIndex(m_maskContainerIndex),
-                                                   m_context.activityToRow());
+                                                   m_maskContainerIndex, m_context.activityToRow());
         if (!m_context.isROIMode())
             m_currentItem->setItemValue(MaskItem::P_MASK_VALUE, m_context.getMaskValue());
         setItemName(m_currentItem);
@@ -640,8 +639,7 @@ void MaskGraphicsScene::processPolygonItem(QGraphicsSceneMouseEvent* event)
 
     if (!m_currentItem) {
         setDrawingInProgress(true);
-        m_currentItem = m_maskModel->insertItem<PolygonItem>(
-            m_maskModel->itemForIndex(m_maskContainerIndex), 0);
+        m_currentItem = m_maskModel->insertItem<PolygonItem>(m_maskContainerIndex, 0);
         m_currentItem->setItemValue(MaskItem::P_MASK_VALUE, m_context.getMaskValue());
         m_selectionModel->clearSelection();
         m_selectionModel->select(m_maskModel->indexOfItem(m_currentItem),
@@ -685,15 +683,13 @@ void MaskGraphicsScene::processLineItem(QGraphicsSceneMouseEvent* event)
 
 void MaskGraphicsScene::processVerticalLineItem(const QPointF& pos)
 {
-    m_currentItem = m_maskModel->insertItem<VerticalLineItem>(
-        m_maskModel->itemForIndex(m_maskContainerIndex), 0);
+    m_currentItem = m_maskModel->insertItem<VerticalLineItem>(m_maskContainerIndex, 0);
     m_currentItem->setItemValue(VerticalLineItem::P_POSX, m_adaptor->fromSceneX(pos.x()));
 }
 
 void MaskGraphicsScene::processHorizontalLineItem(const QPointF& pos)
 {
-    m_currentItem = m_maskModel->insertItem<HorizontalLineItem>(
-        m_maskModel->itemForIndex(m_maskContainerIndex), 0);
+    m_currentItem = m_maskModel->insertItem<HorizontalLineItem>(m_maskContainerIndex, 0);
     m_currentItem->setItemValue(HorizontalLineItem::P_POSY, m_adaptor->fromSceneY(pos.y()));
 }
 
@@ -701,8 +697,7 @@ void MaskGraphicsScene::processMaskAllItem(QGraphicsSceneMouseEvent* event)
 {
     Q_UNUSED(event);
     setDrawingInProgress(true);
-    m_currentItem =
-        m_maskModel->insertItem<MaskAllItem>(m_maskModel->itemForIndex(m_maskContainerIndex));
+    m_currentItem = m_maskModel->insertItem<MaskAllItem>(m_maskContainerIndex);
     m_selectionModel->clearSelection();
     setDrawingInProgress(false);
 }

--- a/GUI/coregui/Views/SampleDesigner/MultiLayerView.cpp
+++ b/GUI/coregui/Views/SampleDesigner/MultiLayerView.cpp
@@ -224,8 +224,7 @@ void MultiLayerView::dropEvent(QGraphicsSceneDragDropEvent* event)
         if (designerScene) {
             SampleModel* sampleModel = designerScene->getSampleModel();
 
-            sampleModel->insertNewItem(mimeData->getClassName(),
-                                       sampleModel->indexOfItem(this->getItem()),
+            sampleModel->insertNewItem(mimeData->getClassName(), this->getItem(),
                                        getDropArea(event->pos()));
         }
     }

--- a/GUI/coregui/Views/SampleDesigner/SampleTreeWidget.cpp
+++ b/GUI/coregui/Views/SampleDesigner/SampleTreeWidget.cpp
@@ -95,8 +95,7 @@ void SampleTreeWidget::addItem(const QString& item_name)
     QModelIndex currentIndex = FilterPropertyProxy::toSourceIndex(treeView()->currentIndex());
 
     QModelIndex currentIndexAtColumnZero = getIndexAtColumnZero(currentIndex);
-    SessionItem* new_item = m_sampleModel->insertNewItem(
-        item_name, m_sampleModel->itemForIndex(currentIndexAtColumnZero));
+    SessionItem* new_item = m_sampleModel->insertNewItem(item_name, currentIndexAtColumnZero);
     if (new_item) {
         QModelIndex new_index = m_sampleModel->indexOfItem(new_item);
         scrollToIndex(new_index);

--- a/GUI/coregui/Views/SampleDesigner/SampleTreeWidget.cpp
+++ b/GUI/coregui/Views/SampleDesigner/SampleTreeWidget.cpp
@@ -95,7 +95,8 @@ void SampleTreeWidget::addItem(const QString& item_name)
     QModelIndex currentIndex = FilterPropertyProxy::toSourceIndex(treeView()->currentIndex());
 
     QModelIndex currentIndexAtColumnZero = getIndexAtColumnZero(currentIndex);
-    SessionItem* new_item = m_sampleModel->insertNewItem(item_name, currentIndexAtColumnZero);
+    SessionItem* new_item = m_sampleModel->insertNewItem(
+        item_name, m_sampleModel->itemForIndex(currentIndexAtColumnZero));
     if (new_item) {
         QModelIndex new_index = m_sampleModel->indexOfItem(new_item);
         scrollToIndex(new_index);

--- a/Tests/UnitTests/GUI/TestComponentProxyModel.cpp
+++ b/Tests/UnitTests/GUI/TestComponentProxyModel.cpp
@@ -362,9 +362,9 @@ TEST_F(TestComponentProxyModel, test_setRootIndexLayer)
 
     // inserting multilayer with two layers
     auto multilayer = model.insertItem<MultiLayerItem>();
-    auto layer1 = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
-    auto layout = model.insertItem<ParticleLayoutItem>(model.indexOfItem(layer1));
-    model.insertItem<LayerItem>(model.indexOfItem(multilayer));
+    auto layer1 = model.insertItem<LayerItem>(multilayer);
+    auto layout = model.insertItem<ParticleLayoutItem>(layer1);
+    model.insertItem<LayerItem>(multilayer);
 
     proxy.setRootIndex(model.indexOfItem(layer1));
     EXPECT_EQ(proxy.rowCount(QModelIndex()), 1);

--- a/Tests/UnitTests/GUI/TestFitParameterModel.cpp
+++ b/Tests/UnitTests/GUI/TestFitParameterModel.cpp
@@ -12,7 +12,7 @@ TEST_F(TestFitParameterModel, test_InitialState)
     JobModel source;
     auto fitSuiteItem = source.insertItem<FitSuiteItem>();
     auto container = source.insertItem<FitParameterContainerItem>(
-        fitSuiteItem->index(), -1, FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
+        fitSuiteItem, -1, FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
     FitParameterProxyModel proxy(dynamic_cast<FitParameterContainerItem*>(container));
 
     EXPECT_EQ(0, proxy.rowCount(QModelIndex()));
@@ -26,11 +26,11 @@ TEST_F(TestFitParameterModel, test_addFitParameter)
     JobModel source;
     auto fitSuiteItem = source.insertItem<FitSuiteItem>();
     auto container = source.insertItem<FitParameterContainerItem>(
-        fitSuiteItem->index(), -1, FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
+        fitSuiteItem, -1, FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
     FitParameterProxyModel proxy(dynamic_cast<FitParameterContainerItem*>(container));
 
     // adding fit parameter
-    auto fitPar0 = source.insertItem<FitParameterItem>(container->index());
+    auto fitPar0 = source.insertItem<FitParameterItem>(container);
     fitPar0->setDisplayName("par");
     fitPar0->setItemValue(FitParameterItem::P_MIN, 1.0);
     fitPar0->setItemValue(FitParameterItem::P_MAX, 2.0);
@@ -90,7 +90,7 @@ TEST_F(TestFitParameterModel, test_addFitParameter)
     // ----------------------------------------------------
     // adding second fit parameter
     // ----------------------------------------------------
-    auto fitPar1 = source.insertItem<FitParameterItem>(container->index());
+    auto fitPar1 = source.insertItem<FitParameterItem>(container);
     fitPar0->setDisplayName("par");
     fitPar0->setItemValue(FitParameterItem::P_MIN, 10.0);
     fitPar0->setItemValue(FitParameterItem::P_MAX, 20.0);
@@ -130,18 +130,18 @@ TEST_F(TestFitParameterModel, test_addFitParameterAndLink)
     JobModel source;
     auto fitSuiteItem = source.insertItem<FitSuiteItem>();
     auto container = source.insertItem<FitParameterContainerItem>(
-        fitSuiteItem->index(), -1, FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
+        fitSuiteItem, -1, FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
     FitParameterProxyModel proxy(dynamic_cast<FitParameterContainerItem*>(container));
 
     // adding fit parameter
-    auto fitPar0 = source.insertItem<FitParameterItem>(container->index());
+    auto fitPar0 = source.insertItem<FitParameterItem>(container);
     fitPar0->setDisplayName("par");
     fitPar0->setItemValue(FitParameterItem::P_MIN, 1.0);
     fitPar0->setItemValue(FitParameterItem::P_MAX, 2.0);
     fitPar0->setItemValue(FitParameterItem::P_START_VALUE, 3.0);
 
     // adding link
-    auto link0 = source.insertItem<FitParameterLinkItem>(fitPar0->index());
+    auto link0 = source.insertItem<FitParameterLinkItem>(fitPar0);
     link0->setItemValue(FitParameterLinkItem::P_LINK, "link0");
 
     // checking index of root
@@ -171,7 +171,7 @@ TEST_F(TestFitParameterModel, test_addFitParameterAndLink)
     EXPECT_EQ(linkIndex, proxy.indexOfItem(link0->getItem(FitParameterLinkItem::P_LINK)));
 
     // adding second link
-    auto link1 = source.insertItem<FitParameterLinkItem>(fitPar0->index());
+    auto link1 = source.insertItem<FitParameterLinkItem>(fitPar0);
     link1->setItemValue(FitParameterLinkItem::P_LINK, "link1");
     EXPECT_EQ(proxy.rowCount(index), 2);
     EXPECT_EQ(proxy.columnCount(index), 1); // linkItem
@@ -193,16 +193,16 @@ TEST_F(TestFitParameterModel, test_addTwoFitParameterAndLinks)
     JobModel source;
     auto fitSuiteItem = source.insertItem<FitSuiteItem>();
     auto container = source.insertItem<FitParameterContainerItem>(
-        fitSuiteItem->index(), -1, FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
+        fitSuiteItem, -1, FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
     FitParameterProxyModel proxy(dynamic_cast<FitParameterContainerItem*>(container));
 
     // adding fit parameters
-    auto fitPar0 = source.insertItem<FitParameterItem>(container->index());
-    auto link0 = source.insertItem<FitParameterLinkItem>(fitPar0->index());
+    auto fitPar0 = source.insertItem<FitParameterItem>(container);
+    auto link0 = source.insertItem<FitParameterLinkItem>(fitPar0);
     Q_UNUSED(link0);
 
-    auto fitPar1 = source.insertItem<FitParameterItem>(container->index());
-    auto link1 = source.insertItem<FitParameterLinkItem>(fitPar1->index());
+    auto fitPar1 = source.insertItem<FitParameterItem>(container);
+    auto link1 = source.insertItem<FitParameterLinkItem>(fitPar1);
     Q_UNUSED(link1);
 
     // checking index of root

--- a/Tests/UnitTests/GUI/TestMapperCases.cpp
+++ b/Tests/UnitTests/GUI/TestMapperCases.cpp
@@ -21,16 +21,16 @@ TEST_F(TestMapperCases, test_ParticeleCompositionUpdate)
 {
     SampleModel model;
     auto multilayer = model.insertItem<MultiLayerItem>();
-    auto layer = model.insertItem<LayerItem>(multilayer->index());
-    auto layout = model.insertItem<ParticleLayoutItem>(layer->index());
+    auto layer = model.insertItem<LayerItem>(multilayer);
+    auto layout = model.insertItem<ParticleLayoutItem>(layer);
 
     // composition added to layout should have abundance enabled
-    auto compositionFree = model.insertItem<ParticleCompositionItem>(layout->index());
+    auto compositionFree = model.insertItem<ParticleCompositionItem>(layout);
     EXPECT_TRUE(compositionFree->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
 
     // composition added to distribution should have abundance disabled
-    auto distribution = model.insertItem<ParticleDistributionItem>(layout->index());
-    auto composition = model.insertItem<ParticleCompositionItem>(distribution->index());
+    auto distribution = model.insertItem<ParticleDistributionItem>(layout);
+    auto composition = model.insertItem<ParticleCompositionItem>(distribution);
     EXPECT_FALSE(composition->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
 
     auto taken = distribution->takeRow(ParentRow(*composition));

--- a/Tests/UnitTests/GUI/TestMapperForItem.cpp
+++ b/Tests/UnitTests/GUI/TestMapperForItem.cpp
@@ -132,7 +132,7 @@ TEST_F(TestMapperForItem, test_onPropertyChange)
     Widget w;
     SampleModel model;
     auto multilayer = model.insertItem<MultiLayerItem>();
-    auto layer = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
+    auto layer = model.insertItem<LayerItem>(multilayer);
 
     // Mapper is looking on child; set property of child
     setItem(layer, &w);
@@ -192,7 +192,7 @@ TEST_F(TestMapperForItem, test_onParentChange)
     Widget w;
     SampleModel model;
     auto multilayer = model.insertItem<MultiLayerItem>();
-    auto layer = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
+    auto layer = model.insertItem<LayerItem>(multilayer);
 
     // Mapper is looking on child; changing child's parent
     setItem(layer, &w);
@@ -214,7 +214,7 @@ TEST_F(TestMapperForItem, test_onChildrenChange)
     // Mapper is looking on parent; adding new child to parent
     setItem(multilayer, &w);
     EXPECT_TRUE(m_mapped_item == multilayer);
-    model.insertItem<LayerItem>(model.indexOfItem(multilayer));
+    model.insertItem<LayerItem>(multilayer);
 
     EXPECT_EQ(w.m_onPropertyChangeCount, 0);
     EXPECT_EQ(w.m_onChildPropertyChangeCount, 2);
@@ -230,12 +230,12 @@ TEST_F(TestMapperForItem, test_onSiblingsChange)
     Widget w;
     SampleModel model;
     auto multilayer = model.insertItem<MultiLayerItem>();
-    auto layer = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
+    auto layer = model.insertItem<LayerItem>(multilayer);
 
     // Mapper is looking on child; adding another child to parent
     setItem(layer, &w);
     EXPECT_TRUE(m_mapped_item == layer);
-    model.insertItem<LayerItem>(model.indexOfItem(multilayer));
+    model.insertItem<LayerItem>(multilayer);
 
     EXPECT_EQ(w.m_onPropertyChangeCount, 0);
     EXPECT_EQ(w.m_onChildPropertyChangeCount, 0);
@@ -254,7 +254,7 @@ TEST_F(TestMapperForItem, test_Subscription)
     Widget w;
     SampleModel model;
     auto multilayer = model.insertItem<MultiLayerItem>();
-    auto layer = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
+    auto layer = model.insertItem<LayerItem>(multilayer);
 
     // Mapper is looking on child; set property of child
     setItem(layer, &w, true);
@@ -283,7 +283,7 @@ TEST_F(TestMapperForItem, test_TwoWidgetsSubscription)
     Widget w1, w2;
     SampleModel model;
     auto multilayer = model.insertItem<MultiLayerItem>();
-    auto layer = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
+    auto layer = model.insertItem<LayerItem>(multilayer);
 
     // Mapper is looking on child; set property of child
     setItem(layer);
@@ -307,7 +307,7 @@ TEST_F(TestMapperForItem, test_AboutToRemoveChild)
     Widget w;
     SampleModel model;
     auto container = model.insertItem<ProjectionContainerItem>();
-    auto line = model.insertItem<HorizontalLineItem>(container->index());
+    auto line = model.insertItem<HorizontalLineItem>(container);
 
     setItem(container, &w);
     EXPECT_EQ(w.m_onAboutToRemoveChild, 0);

--- a/Tests/UnitTests/GUI/TestModelUtils.cpp
+++ b/Tests/UnitTests/GUI/TestModelUtils.cpp
@@ -94,7 +94,7 @@ TEST_F(TestModelUtils, test_iterateIf)
 {
     SessionModel model("TestModel");
     auto multilayer = model.insertItem<MultiLayerItem>();
-    SessionItem* layer = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
+    SessionItem* layer = model.insertItem<LayerItem>(multilayer);
     SessionItem* thicknessItem = layer->getItem(LayerItem::P_THICKNESS);
 
     layer->setVisible(true);

--- a/Tests/UnitTests/GUI/TestMultiLayerItem.cpp
+++ b/Tests/UnitTests/GUI/TestMultiLayerItem.cpp
@@ -15,8 +15,8 @@ TEST_F(TestMultiLayerItem, test_twoLayerSystem)
     SampleModel model;
 
     auto multilayer = model.insertItem<MultiLayerItem>();
-    auto top = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
-    auto bottom = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
+    auto top = model.insertItem<LayerItem>(multilayer);
+    auto bottom = model.insertItem<LayerItem>(multilayer);
 
     // Thickness property should be disabled for top and bottom layers
     EXPECT_FALSE(top->getItem(LayerItem::P_THICKNESS)->isEnabled());
@@ -44,9 +44,9 @@ TEST_F(TestMultiLayerItem, test_threeLayerSystem)
     SampleModel model;
 
     auto multilayer = model.insertItem<MultiLayerItem>();
-    auto top = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
-    auto middle = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
-    auto bottom = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
+    auto top = model.insertItem<LayerItem>(multilayer);
+    auto middle = model.insertItem<LayerItem>(multilayer);
+    auto bottom = model.insertItem<LayerItem>(multilayer);
 
     // Thickness property should be disabled for top and bottom layers and enabled for middle
     EXPECT_FALSE(top->getItem(LayerItem::P_THICKNESS)->isEnabled());
@@ -79,9 +79,9 @@ TEST_F(TestMultiLayerItem, test_movingMiddleLayerOnTop)
     SampleModel model;
 
     auto multilayer = model.insertItem<MultiLayerItem>();
-    auto top = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
-    auto middle = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
-    auto bottom = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
+    auto top = model.insertItem<LayerItem>(multilayer);
+    auto middle = model.insertItem<LayerItem>(multilayer);
+    auto bottom = model.insertItem<LayerItem>(multilayer);
 
     const double thickness = 10.0;
     middle->setItemValue(LayerItem::P_THICKNESS, thickness);
@@ -127,8 +127,8 @@ TEST_F(TestMultiLayerItem, test_movingLayerOnCanvas)
     SampleModel model;
 
     auto multilayer = model.insertItem<MultiLayerItem>();
-    auto top = model.insertItem<LayerItem>(model.indexOfItem(multilayer));
-    model.insertItem<LayerItem>(model.indexOfItem(multilayer));
+    auto top = model.insertItem<LayerItem>(multilayer);
+    model.insertItem<LayerItem>(multilayer);
 
     // Moving top layer to canvas
     model.moveItem(top, nullptr);

--- a/Tests/UnitTests/GUI/TestOutputDataIOService.cpp
+++ b/Tests/UnitTests/GUI/TestOutputDataIOService.cpp
@@ -50,12 +50,12 @@ TEST_F(TestOutputDataIOService, test_nonXMLData)
     // adding JobItem
     auto jobItem = models.jobModel()->insertItem<JobItem>();
     auto dataItem =
-        models.jobModel()->insertItem<IntensityDataItem>(jobItem->index(), -1, JobItem::T_OUTPUT);
+        models.jobModel()->insertItem<IntensityDataItem>(jobItem, -1, JobItem::T_OUTPUT);
     EXPECT_EQ(models.jobModel()->nonXMLData().size(), 1);
 
     // adding RealDataItem to jobItem
     RealDataItem* realData2 =
-        models.jobModel()->insertItem<RealDataItem>(jobItem->index(), -1, JobItem::T_REALDATA);
+        models.jobModel()->insertItem<RealDataItem>(jobItem, -1, JobItem::T_REALDATA);
     EXPECT_EQ(models.jobModel()->nonXMLData().size(), 1);
     realData2->setOutputData(
         GuiUnittestUtils::createData(0.0, GuiUnittestUtils::DIM::D1).release());
@@ -261,7 +261,7 @@ TEST_F(TestOutputDataIOService, test_RealDataItemWithNativeData)
     // adding JobItem
     auto jobItem = models.jobModel()->insertItem<JobItem>();
     jobItem->setIdentifier(GUIHelpers::createUuid());
-    models.jobModel()->insertItem<IntensityDataItem>(jobItem->index(), -1, JobItem::T_OUTPUT);
+    models.jobModel()->insertItem<IntensityDataItem>(jobItem, -1, JobItem::T_OUTPUT);
     EXPECT_EQ(models.jobModel()->nonXMLData().size(), 1);
 
     // copying RealDataItem to JobItem

--- a/Tests/UnitTests/GUI/TestParaCrystalItems.cpp
+++ b/Tests/UnitTests/GUI/TestParaCrystalItems.cpp
@@ -77,11 +77,11 @@ TEST_F(TestParaCrystalItems, test_Inference2DRotationAngleToggle)
 {
     SampleModel model;
     auto multilayer = model.insertItem<MultiLayerItem>();
-    auto layer = model.insertItem<LayerItem>(multilayer->index());
-    auto layout = model.insertItem<ParticleLayoutItem>(layer->index());
+    auto layer = model.insertItem<LayerItem>(multilayer);
+    auto layout = model.insertItem<ParticleLayoutItem>(layer);
 
     auto interference = model.insertItem<InterferenceFunction2DParaCrystalItem>(
-        layout->index(), -1, ParticleLayoutItem::T_INTERFERENCE);
+        layout, -1, ParticleLayoutItem::T_INTERFERENCE);
 
     // rotation (xi) should be disabled if integration is on
     interference->setItemValue(InterferenceFunction2DParaCrystalItem::P_XI_INTEGRATION, true);

--- a/Tests/UnitTests/GUI/TestParaCrystalItems.cpp
+++ b/Tests/UnitTests/GUI/TestParaCrystalItems.cpp
@@ -2,6 +2,8 @@
 #include "GUI/coregui/Models/FTDistributionItems.h"
 #include "GUI/coregui/Models/InterferenceFunctionItems.h"
 #include "GUI/coregui/Models/Lattice2DItems.h"
+#include "GUI/coregui/Models/LayerItem.h"
+#include "GUI/coregui/Models/MultiLayerItem.h"
 #include "GUI/coregui/Models/ParticleLayoutItem.h"
 #include "GUI/coregui/Models/SampleModel.h"
 #include "GUI/coregui/Models/TransformFromDomain.h"
@@ -74,12 +76,12 @@ TEST_F(TestParaCrystalItems, test_Para2D_fromToDomain)
 TEST_F(TestParaCrystalItems, test_Inference2DRotationAngleToggle)
 {
     SampleModel model;
-    SessionItem* multilayer = model.insertNewItem("MultiLayer");
-    SessionItem* layer = model.insertNewItem("Layer", multilayer->index());
-    SessionItem* layout = model.insertNewItem("ParticleLayout", layer->index());
+    auto multilayer = model.insertItem<MultiLayerItem>();
+    auto layer = model.insertItem<LayerItem>(multilayer->index());
+    auto layout = model.insertItem<ParticleLayoutItem>(layer->index());
 
-    SessionItem* interference = model.insertNewItem("Interference2DParaCrystal", layout->index(),
-                                                    -1, ParticleLayoutItem::T_INTERFERENCE);
+    auto interference = model.insertItem<InterferenceFunction2DParaCrystalItem>(
+        layout->index(), -1, ParticleLayoutItem::T_INTERFERENCE);
 
     // rotation (xi) should be disabled if integration is on
     interference->setItemValue(InterferenceFunction2DParaCrystalItem::P_XI_INTEGRATION, true);

--- a/Tests/UnitTests/GUI/TestParameterTreeUtils.cpp
+++ b/Tests/UnitTests/GUI/TestParameterTreeUtils.cpp
@@ -27,10 +27,10 @@ TEST_F(TestParameterTreeUtils, test_parameterTreeNames)
 {
     SampleModel model;
 
-    SessionItem* layer = model.insertNewItem("Layer");
+    auto layer = model.insertItem<LayerItem>();
     EXPECT_EQ(ParameterTreeUtils::parameterTreeNames(layer), QStringList() << "Layer/Thickness");
 
-    SessionItem* particle = model.insertNewItem("Particle");
+    auto particle = model.insertItem<ParticleItem>();
     EXPECT_EQ(ParameterTreeUtils::parameterTreeNames(particle), expectedParticleParameterNames);
 }
 
@@ -40,7 +40,7 @@ TEST_F(TestParameterTreeUtils, test_parameterTranslatedNames)
 {
     SampleModel model;
 
-    SessionItem* particle = model.insertNewItem("Particle");
+    auto particle = model.insertItem<ParticleItem>();
 
     EXPECT_EQ(ParameterTreeUtils::translatedParameterTreeNames(particle),
               expectedParticleParameterTranslations);

--- a/Tests/UnitTests/GUI/TestParticleCoreShell.cpp
+++ b/Tests/UnitTests/GUI/TestParticleCoreShell.cpp
@@ -16,10 +16,10 @@ class TestParticleCoreShell : public ::testing::Test {
 TEST_F(TestParticleCoreShell, test_moveCoreAndShell)
 {
     SampleModel model;
-    SessionItem* coreshell = model.insertNewItem("ParticleCoreShell");
-    SessionItem* particle1 = model.insertNewItem("Particle");
-    SessionItem* particle2 = model.insertNewItem("Particle");
-    SessionItem* particle3 = model.insertNewItem("Particle");
+    auto coreshell = model.insertItem<ParticleCoreShellItem>();
+    auto particle1 = model.insertItem<ParticleItem>();
+    auto particle2 = model.insertItem<ParticleItem>();
+    auto particle3 = model.insertItem<ParticleItem>();
 
     // empty coreshell particle
     EXPECT_EQ(particle1->parent(), model.rootItem());
@@ -102,13 +102,13 @@ TEST_F(TestParticleCoreShell, test_distributionContext)
     SampleModel model;
 
     // coreshell particle
-    SessionItem* coreshell = model.insertNewItem("ParticleCoreShell");
+    auto coreshell = model.insertItem<ParticleCoreShellItem>();
     coreshell->setItemValue(ParticleItem::P_ABUNDANCE, 0.2);
     EXPECT_TRUE(coreshell->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
     EXPECT_EQ(coreshell->getItemValue(ParticleItem::P_ABUNDANCE).toDouble(), 0.2);
 
     // create distribution, adding coreshell to it
-    SessionItem* distribution = model.insertNewItem("ParticleDistribution");
+    auto distribution = model.insertItem<ParticleDistributionItem>();
     model.moveItem(coreshell, distribution, -1, ParticleDistributionItem::T_PARTICLES);
     // checking abundance has switched to defaults
     EXPECT_FALSE(coreshell->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
@@ -127,13 +127,13 @@ TEST_F(TestParticleCoreShell, test_compositionContext)
     SampleModel model;
 
     // coreshell particle
-    SessionItem* coreshell = model.insertNewItem("ParticleCoreShell");
+    auto coreshell = model.insertItem<ParticleCoreShellItem>();
     coreshell->setItemValue(ParticleItem::P_ABUNDANCE, 0.2);
     EXPECT_TRUE(coreshell->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
     EXPECT_EQ(coreshell->getItemValue(ParticleItem::P_ABUNDANCE).toDouble(), 0.2);
 
     // create composition, adding coreshell to it
-    SessionItem* composition = model.insertNewItem("ParticleComposition");
+    auto composition = model.insertItem<ParticleCompositionItem>();
     model.moveItem(coreshell, composition, -1, ParticleCompositionItem::T_PARTICLES);
     // checking abundance has switched to defaults
     EXPECT_FALSE(coreshell->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());

--- a/Tests/UnitTests/GUI/TestParticleCoreShell.cpp
+++ b/Tests/UnitTests/GUI/TestParticleCoreShell.cpp
@@ -64,7 +64,7 @@ TEST_F(TestParticleCoreShell, test_propertyAppearance)
 
     // adding core, and checking that abundance is disabled
     auto core =
-        model.insertItem<ParticleItem>(coreshell->index(), -1, ParticleCoreShellItem::T_CORE);
+        model.insertItem<ParticleItem>(coreshell, -1, ParticleCoreShellItem::T_CORE);
     EXPECT_FALSE(core->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
     EXPECT_TRUE(core->positionItem()->isEnabled());
 

--- a/Tests/UnitTests/GUI/TestParticleDistributionItem.cpp
+++ b/Tests/UnitTests/GUI/TestParticleDistributionItem.cpp
@@ -71,7 +71,7 @@ TEST_F(TestParticleDistributionItem, test_AddParticle)
     auto dist = model.insertItem<ParticleDistributionItem>();
 
     // adding default particle and checking list of available parameters
-    auto particle = model.insertItem<ParticleItem>(dist->index());
+    auto particle = model.insertItem<ParticleItem>(dist);
 
     EXPECT_EQ(dist->getItems().size(), 1);
 
@@ -114,7 +114,7 @@ TEST_F(TestParticleDistributionItem, test_MainLinkedCorrelation)
 {
     SampleModel model;
     auto dist = model.insertItem<ParticleDistributionItem>();
-    model.insertItem<ParticleItem>(dist->index());
+    model.insertItem<ParticleItem>(dist);
 
     ComboProperty mainCombo = dist->getItemValue(ParticleDistributionItem::P_DISTRIBUTED_PARAMETER)
                                   .value<ComboProperty>();
@@ -186,7 +186,7 @@ TEST_F(TestParticleDistributionItem, test_FromDomain)
     // creating GUI distribution
     SampleModel model;
     auto distItem = model.insertItem<ParticleDistributionItem>();
-    auto particleItem = model.insertItem<ParticleItem>(distItem->index());
+    auto particleItem = model.insertItem<ParticleItem>(distItem);
 
     particleItem->setGroupProperty(ParticleItem::P_FORM_FACTOR, "AnisoPyramid");
 
@@ -225,7 +225,7 @@ TEST_F(TestParticleDistributionItem, test_FromDomainLinked)
     // creating GUI distribution
     SampleModel model;
     auto distItem = model.insertItem<ParticleDistributionItem>();
-    auto particleItem = model.insertItem<ParticleItem>(distItem->index());
+    auto particleItem = model.insertItem<ParticleItem>(distItem);
 
     particleItem->setGroupProperty(ParticleItem::P_FORM_FACTOR, "AnisoPyramid");
 
@@ -271,7 +271,7 @@ TEST_F(TestParticleDistributionItem, test_FromDomainWithLimits)
     // creating GUI distribution
     SampleModel model;
     auto partDistItem = model.insertItem<ParticleDistributionItem>();
-    model.insertItem<ParticleItem>(partDistItem->index());
+    model.insertItem<ParticleItem>(partDistItem);
 
     // Sets it from domain
     TransformFromDomain::setParticleDistributionItem(partDistItem, particle_collection);
@@ -291,7 +291,7 @@ TEST_F(TestParticleDistributionItem, test_Clone)
 
     SampleModel model1;
     auto dist = model1.insertItem<ParticleDistributionItem>();
-    model1.insertItem<ParticleItem>(dist->index());
+    model1.insertItem<ParticleItem>(dist);
 
     QString buffer1;
     QXmlStreamWriter writer1(&buffer1);

--- a/Tests/UnitTests/GUI/TestParticleDistributionItem.cpp
+++ b/Tests/UnitTests/GUI/TestParticleDistributionItem.cpp
@@ -37,7 +37,7 @@ class TestParticleDistributionItem : public ::testing::Test {
 TEST_F(TestParticleDistributionItem, test_InitialState)
 {
     SampleModel model;
-    SessionItem* distItem = model.insertNewItem("ParticleDistribution");
+    auto distItem = model.insertItem<ParticleDistributionItem>();
 
     EXPECT_EQ(distItem->displayName(), "ParticleDistribution");
     EXPECT_EQ(distItem->displayName(), distItem->itemName());
@@ -68,10 +68,10 @@ TEST_F(TestParticleDistributionItem, test_InitialState)
 TEST_F(TestParticleDistributionItem, test_AddParticle)
 {
     SampleModel model;
-    SessionItem* dist = model.insertNewItem("ParticleDistribution");
+    auto dist = model.insertItem<ParticleDistributionItem>();
 
     // adding default particle and checking list of available parameters
-    SessionItem* particle = model.insertNewItem("Particle", dist->index());
+    auto particle = model.insertItem<ParticleItem>(dist->index());
 
     EXPECT_EQ(dist->getItems().size(), 1);
 
@@ -113,8 +113,8 @@ TEST_F(TestParticleDistributionItem, test_AddParticle)
 TEST_F(TestParticleDistributionItem, test_MainLinkedCorrelation)
 {
     SampleModel model;
-    SessionItem* dist = model.insertNewItem("ParticleDistribution");
-    model.insertNewItem("Particle", dist->index());
+    auto dist = model.insertItem<ParticleDistributionItem>();
+    model.insertItem<ParticleItem>(dist->index());
 
     ComboProperty mainCombo = dist->getItemValue(ParticleDistributionItem::P_DISTRIBUTED_PARAMETER)
                                   .value<ComboProperty>();
@@ -185,8 +185,8 @@ TEST_F(TestParticleDistributionItem, test_FromDomain)
 
     // creating GUI distribution
     SampleModel model;
-    SessionItem* distItem = model.insertNewItem("ParticleDistribution");
-    SessionItem* particleItem = model.insertNewItem("Particle", distItem->index());
+    auto distItem = model.insertItem<ParticleDistributionItem>();
+    auto particleItem = model.insertItem<ParticleItem>(distItem->index());
 
     particleItem->setGroupProperty(ParticleItem::P_FORM_FACTOR, "AnisoPyramid");
 
@@ -224,8 +224,8 @@ TEST_F(TestParticleDistributionItem, test_FromDomainLinked)
 
     // creating GUI distribution
     SampleModel model;
-    SessionItem* distItem = model.insertNewItem("ParticleDistribution");
-    SessionItem* particleItem = model.insertNewItem("Particle", distItem->index());
+    auto distItem = model.insertItem<ParticleDistributionItem>();
+    auto particleItem = model.insertItem<ParticleItem>(distItem->index());
 
     particleItem->setGroupProperty(ParticleItem::P_FORM_FACTOR, "AnisoPyramid");
 
@@ -270,8 +270,8 @@ TEST_F(TestParticleDistributionItem, test_FromDomainWithLimits)
 
     // creating GUI distribution
     SampleModel model;
-    SessionItem* partDistItem = model.insertNewItem("ParticleDistribution");
-    model.insertNewItem("Particle", partDistItem->index());
+    auto partDistItem = model.insertItem<ParticleDistributionItem>();
+    model.insertItem<ParticleItem>(partDistItem->index());
 
     // Sets it from domain
     TransformFromDomain::setParticleDistributionItem(partDistItem, particle_collection);
@@ -290,8 +290,8 @@ TEST_F(TestParticleDistributionItem, test_Clone)
     std::unique_ptr<MaterialModel> P_materialModel(new MaterialModel());
 
     SampleModel model1;
-    SessionItem* dist = model1.insertNewItem("ParticleDistribution");
-    model1.insertNewItem("Particle", dist->index());
+    auto dist = model1.insertItem<ParticleDistributionItem>();
+    model1.insertItem<ParticleItem>(dist->index());
 
     QString buffer1;
     QXmlStreamWriter writer1(&buffer1);

--- a/Tests/UnitTests/GUI/TestParticleItem.cpp
+++ b/Tests/UnitTests/GUI/TestParticleItem.cpp
@@ -14,7 +14,7 @@ class TestParticleItem : public ::testing::Test {
 TEST_F(TestParticleItem, test_InitialState)
 {
     SampleModel model;
-    SessionItem* item = model.insertNewItem("Particle");
+    auto item = model.insertItem<ParticleItem>();
 
     EXPECT_EQ(item->displayName(), "Particle");
     EXPECT_EQ(item->displayName(), item->itemName());
@@ -30,13 +30,13 @@ TEST_F(TestParticleItem, test_InitialState)
 TEST_F(TestParticleItem, test_compositionContext)
 {
     SampleModel model;
-    SessionItem* particle = model.insertNewItem("Particle");
+    auto particle = model.insertItem<ParticleItem>();
     particle->setItemValue(ParticleItem::P_ABUNDANCE, 0.2);
     EXPECT_TRUE(particle->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
     EXPECT_EQ(particle->getItemValue(ParticleItem::P_ABUNDANCE).toDouble(), 0.2);
 
     // adding particle to composition, checking that abundance is default
-    SessionItem* composition = model.insertNewItem("ParticleComposition");
+    auto composition = model.insertItem<ParticleCompositionItem>();
     model.moveItem(particle, composition, -1, ParticleCompositionItem::T_PARTICLES);
     EXPECT_FALSE(particle->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
     EXPECT_EQ(particle->getItemValue(ParticleItem::P_ABUNDANCE).toDouble(), 1.0);
@@ -50,13 +50,13 @@ TEST_F(TestParticleItem, test_compositionContext)
 TEST_F(TestParticleItem, test_distributionContext)
 {
     SampleModel model;
-    SessionItem* particle = model.insertNewItem("Particle");
+    auto particle = model.insertItem<ParticleItem>();
     particle->setItemValue(ParticleItem::P_ABUNDANCE, 0.2);
     EXPECT_TRUE(particle->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
     EXPECT_EQ(particle->getItemValue(ParticleItem::P_ABUNDANCE).toDouble(), 0.2);
 
     // adding particle to distribution, checking that abundance is default
-    SessionItem* distribution = model.insertNewItem("ParticleDistribution");
+    auto distribution = model.insertItem<ParticleDistributionItem>();
     model.moveItem(particle, distribution, -1, ParticleDistributionItem::T_PARTICLES);
     EXPECT_FALSE(particle->getItem(ParticleItem::P_ABUNDANCE)->isEnabled());
     EXPECT_EQ(particle->getItemValue(ParticleItem::P_ABUNDANCE).toDouble(), 1.0);

--- a/Tests/UnitTests/GUI/TestPropertyRepeater.cpp
+++ b/Tests/UnitTests/GUI/TestPropertyRepeater.cpp
@@ -8,12 +8,12 @@ namespace {
 
 IntensityDataItem* createData(SessionModel& model)
 {
-    return dynamic_cast<IntensityDataItem*>(model.insertNewItem("IntensityData"));
+    return model.insertItem<IntensityDataItem>();
 }
 
 BasicAxisItem* createAxis(SessionModel& model)
 {
-    return dynamic_cast<BasicAxisItem*>(model.insertNewItem("BasicAxis"));
+    return model.insertItem<BasicAxisItem>();
 }
 } // namespace
 

--- a/Tests/UnitTests/GUI/TestProxyModelStrategy.cpp
+++ b/Tests/UnitTests/GUI/TestProxyModelStrategy.cpp
@@ -4,6 +4,7 @@
 #include "GUI/coregui/Models/ModelUtils.h"
 #include "GUI/coregui/Models/ParticleItem.h"
 #include "GUI/coregui/Models/SessionModel.h"
+#include "GUI/coregui/Models/PropertyItem.h"
 #include "GUI/coregui/Models/VectorItem.h"
 #include "Tests/GTestWrapper/google_test.h"
 
@@ -27,7 +28,7 @@ TEST_F(TestProxyModelStrategy, test_identityStrategy)
     EXPECT_EQ(strategy.proxySourceParent().size(), 0);
 
     // building map when simple item
-    SessionItem* item = model.insertNewItem("Property");
+    auto item = model.insertItem<PropertyItem>();
     strategy.buildModelMap(&model, &proxy);
     EXPECT_EQ(strategy.sourceToProxy().size(), 2);
     EXPECT_EQ(strategy.proxySourceParent().size(), 2);
@@ -68,7 +69,7 @@ TEST_F(TestProxyModelStrategy, test_identityStrategyParticle)
     ComponentProxyModel proxy;
     IndentityProxyStrategy strategy;
 
-    SessionItem* item = model.insertNewItem("Particle");
+    auto item = model.insertItem<ParticleItem>();
 
     // building the map of source
     strategy.buildModelMap(&model, &proxy);
@@ -99,7 +100,7 @@ TEST_F(TestProxyModelStrategy, test_componentStrategyParticle)
     ComponentProxyModel proxy;
     ComponentProxyStrategy strategy;
 
-    SessionItem* item = model.insertNewItem("Particle");
+    auto item = model.insertItem<ParticleItem>();
 
     // building the map of  source
     strategy.buildModelMap(&model, &proxy);
@@ -139,7 +140,7 @@ TEST_F(TestProxyModelStrategy, test_setRootIndex)
     ComponentProxyModel proxy;
     ComponentProxyStrategy strategy;
 
-    SessionItem* item = model.insertNewItem("Particle");
+    auto item = model.insertItem<ParticleItem>();
     SessionItem* group = item->getItem(ParticleItem::P_FORM_FACTOR);
     SessionItem* ffItem = item->getGroupItem(ParticleItem::P_FORM_FACTOR);
 

--- a/Tests/UnitTests/GUI/TestRealSpaceBuilderUtils.cpp
+++ b/Tests/UnitTests/GUI/TestRealSpaceBuilderUtils.cpp
@@ -34,8 +34,8 @@ TEST_F(TestRealSpaceBuilderUtils, test_computeCumulativeAbundances)
     SampleModel sampleModel;
     auto layout = sampleModel.insertItem<ParticleLayoutItem>();
 
-    auto particle1 = sampleModel.insertItem<ParticleItem>(sampleModel.indexOfItem(layout), -1,
-                                                          ParticleLayoutItem::T_PARTICLES);
+    auto particle1 =
+        sampleModel.insertItem<ParticleItem>(layout, -1, ParticleLayoutItem::T_PARTICLES);
     EXPECT_EQ(particle1->parent(), layout);
 
     auto particle2 = sampleModel.insertItem<ParticleItem>();

--- a/Tests/UnitTests/GUI/TestRealSpaceBuilderUtils.cpp
+++ b/Tests/UnitTests/GUI/TestRealSpaceBuilderUtils.cpp
@@ -32,13 +32,13 @@ TEST_F(TestRealSpaceBuilderUtils, test_RealSpaceModelandParticle)
 TEST_F(TestRealSpaceBuilderUtils, test_computeCumulativeAbundances)
 {
     SampleModel sampleModel;
-    auto layout = dynamic_cast<ParticleLayoutItem*>(sampleModel.insertNewItem("ParticleLayout"));
+    auto layout = sampleModel.insertItem<ParticleLayoutItem>();
 
-    auto particle1 = sampleModel.insertNewItem("Particle", sampleModel.indexOfItem(layout), -1,
-                                               ParticleLayoutItem::T_PARTICLES);
+    auto particle1 = sampleModel.insertItem<ParticleItem>(sampleModel.indexOfItem(layout), -1,
+                                                          ParticleLayoutItem::T_PARTICLES);
     EXPECT_EQ(particle1->parent(), layout);
 
-    SessionItem* particle2 = sampleModel.insertNewItem("Particle");
+    auto particle2 = sampleModel.insertItem<ParticleItem>();
     EXPECT_EQ(particle2->parent(), sampleModel.rootItem());
 
     sampleModel.moveItem(particle2, layout, -1, ParticleLayoutItem::T_PARTICLES);
@@ -168,7 +168,7 @@ TEST_F(TestRealSpaceBuilderUtils, test_singleParticle3DContainer)
     ApplicationModels models;
     SampleModel* sampleModel = models.sampleModel();
 
-    auto particleItem = sampleModel->insertNewItem("Particle");
+    auto particleItem = sampleModel->insertItem<ParticleItem>();
     EXPECT_EQ(particleItem->getItemValue(ParticleItem::P_ABUNDANCE).toDouble(), 1.0);
     EXPECT_EQ(particleItem->getGroupItem(ParticleItem::P_FORM_FACTOR)->modelType(), "Cylinder");
 
@@ -193,11 +193,10 @@ TEST_F(TestRealSpaceBuilderUtils, test_particle3DContainerVector)
     ApplicationModels models;
     SampleModel* sampleModel = models.sampleModel();
 
-    auto layout = dynamic_cast<ParticleLayoutItem*>(sampleModel->insertNewItem("ParticleLayout"));
-
-    auto particle1 = sampleModel->insertNewItem("Particle");
-    auto particle2 = sampleModel->insertNewItem("Particle");
-    auto particle3 = sampleModel->insertNewItem("Particle");
+    auto layout = sampleModel->insertItem<ParticleLayoutItem>();
+    auto particle1 = sampleModel->insertItem<ParticleItem>();
+    auto particle2 = sampleModel->insertItem<ParticleItem>();
+    auto particle3 = sampleModel->insertItem<ParticleItem>();
 
     sampleModel->moveItem(particle1, layout, -1, ParticleLayoutItem::T_PARTICLES);
     sampleModel->moveItem(particle2, layout, -1, ParticleLayoutItem::T_PARTICLES);

--- a/Tests/UnitTests/GUI/TestSavingSpecularData.cpp
+++ b/Tests/UnitTests/GUI/TestSavingSpecularData.cpp
@@ -105,11 +105,11 @@ TEST_F(TestSavingSpecularData, test_InstrumentInJobItem)
     // adding JobItem
     auto jobItem = models.jobModel()->insertItem<JobItem>();
     auto dataItem =
-        models.jobModel()->insertItem<IntensityDataItem>(jobItem->index(), -1, JobItem::T_OUTPUT);
+        models.jobModel()->insertItem<IntensityDataItem>(jobItem, -1, JobItem::T_OUTPUT);
     EXPECT_EQ(models.jobModel()->nonXMLData().size(), 1);
 
     // adding instrument
-    auto instrument = models.jobModel()->insertItem<SpecularInstrumentItem>(jobItem->index(), -1,
+    auto instrument = models.jobModel()->insertItem<SpecularInstrumentItem>(jobItem, -1,
                                                                             JobItem::T_INSTRUMENT);
     // instrument contains hidden pointwise axis item
     EXPECT_EQ(models.jobModel()->nonXMLData().size(), 2);

--- a/Tests/UnitTests/GUI/TestSavingSpecularData.cpp
+++ b/Tests/UnitTests/GUI/TestSavingSpecularData.cpp
@@ -265,7 +265,7 @@ TEST_F(TestSavingSpecularData, test_CopyInstrumentToJobItem)
     pointwise_axis_item->init(*m_axis, "q-space");
 
     // adding JobItem and copying instrument
-    auto jobItem = dynamic_cast<JobItem*>(models.jobModel()->insertNewItem("JobItem"));
+    auto jobItem = models.jobModel()->insertItem<JobItem>();
     JobModelFunctions::setupJobItemInstrument(jobItem, instrument);
     auto job_instrument =
         dynamic_cast<SpecularInstrumentItem*>(jobItem->getItem(JobItem::T_INSTRUMENT));

--- a/Tests/UnitTests/GUI/TestSessionModel.cpp
+++ b/Tests/UnitTests/GUI/TestSessionModel.cpp
@@ -52,7 +52,7 @@ TEST_F(TestSessionModel, SampleModelCopy)
     SampleModel model1;
     auto multilayer = model1.insertItem<MultiLayerItem>();
     multilayer->setItemName("multilayer");
-    model1.insertItem<LayerItem>(model1.indexOfItem(multilayer));
+    model1.insertItem<LayerItem>(multilayer);
     auto multilayer2 = model1.insertItem<MultiLayerItem>();
     multilayer2->setItemName("multilayer2");
 
@@ -75,7 +75,7 @@ TEST_F(TestSessionModel, SampleModelPartialCopy)
     SampleModel model1;
     auto multilayer1 = model1.insertItem<MultiLayerItem>();
     multilayer1->setItemName("multilayer1");
-    model1.insertItem<LayerItem>(model1.indexOfItem(multilayer1));
+    model1.insertItem<LayerItem>(multilayer1);
 
     auto multilayer2 = model1.insertItem<MultiLayerItem>();
     multilayer2->setItemName("multilayer2");
@@ -132,7 +132,7 @@ TEST_F(TestSessionModel, copyItem)
     SampleModel sampleModel;
     auto multilayer1 = sampleModel.insertItem<MultiLayerItem>();
     multilayer1->setItemName("multilayer1");
-    sampleModel.insertItem<LayerItem>(sampleModel.indexOfItem(multilayer1));
+    sampleModel.insertItem<LayerItem>(multilayer1);
 
     InstrumentModel instrumentModel;
     auto instrument1 = instrumentModel.insertItem<GISASInstrumentItem>();
@@ -177,8 +177,8 @@ TEST_F(TestSessionModel, moveBetweenParents)
 {
     SessionModel model("TestModel");
     auto poly1 = model.insertItem<PolygonItem>();
-    auto point11 = model.insertItem<PolygonPointItem>(model.indexOfItem(poly1));
-    auto point12 = model.insertItem<PolygonPointItem>(model.indexOfItem(poly1));
+    auto point11 = model.insertItem<PolygonPointItem>(poly1);
+    auto point12 = model.insertItem<PolygonPointItem>(poly1);
     auto poly2 = model.insertItem<PolygonItem>();
 
     EXPECT_EQ(point11->parent(), poly1);
@@ -195,11 +195,11 @@ TEST_F(TestSessionModel, moveWithinSameParent)
 {
     SessionModel model("TestModel");
     auto poly = model.insertItem<PolygonItem>();
-    auto pA = model.insertItem<PolygonPointItem>(model.indexOfItem(poly));
-    auto pB = model.insertItem<PolygonPointItem>(model.indexOfItem(poly));
-    auto pC = model.insertItem<PolygonPointItem>(model.indexOfItem(poly));
-    auto pD = model.insertItem<PolygonPointItem>(model.indexOfItem(poly));
-    auto pE = model.insertItem<PolygonPointItem>(model.indexOfItem(poly));
+    auto pA = model.insertItem<PolygonPointItem>(poly);
+    auto pB = model.insertItem<PolygonPointItem>(poly);
+    auto pC = model.insertItem<PolygonPointItem>(poly);
+    auto pD = model.insertItem<PolygonPointItem>(poly);
+    auto pE = model.insertItem<PolygonPointItem>(poly);
 
     // 0  pA -> pA
     // 1  pB -> pC

--- a/Tests/UnitTests/GUI/TestTranslations.cpp
+++ b/Tests/UnitTests/GUI/TestTranslations.cpp
@@ -18,9 +18,9 @@ TEST_F(TestTranslations, test_TranslatePosition)
 {
     SampleModel model;
     auto multilayer = model.insertItem<MultiLayerItem>();
-    auto layer = model.insertItem<LayerItem>(multilayer->index());
-    auto layout = model.insertItem<ParticleLayoutItem>(layer->index());
-    auto particle = model.insertItem<ParticleItem>(layout->index());
+    auto layer = model.insertItem<LayerItem>(multilayer);
+    auto layout = model.insertItem<ParticleLayoutItem>(layer);
+    auto particle = model.insertItem<ParticleItem>(layout);
 
     auto xItem = particle->positionItem()->getItem(VectorItem::P_X);
 
@@ -32,12 +32,12 @@ TEST_F(TestTranslations, test_TranslateRotation)
 {
     SampleModel model;
     auto multilayer = model.insertItem<MultiLayerItem>();
-    auto layer = model.insertItem<LayerItem>(multilayer->index());
-    auto layout = model.insertItem<ParticleLayoutItem>(layer->index());
-    auto particle = model.insertItem<ParticleItem>(layout->index());
+    auto layer = model.insertItem<LayerItem>(multilayer);
+    auto layout = model.insertItem<ParticleLayoutItem>(layer);
+    auto particle = model.insertItem<ParticleItem>(layout);
 
     auto transformation =
-        model.insertItem<TransformationItem>(particle->index(), -1, ParticleItem::T_TRANSFORMATION);
+        model.insertItem<TransformationItem>(particle, -1, ParticleItem::T_TRANSFORMATION);
 
     SessionItem* rotationItem =
         transformation->setGroupProperty(TransformationItem::P_ROT, "XRotation");


### PR DESCRIPTION
- Replace most of remaining methods `insertNewItem` toward more type safe `insertItem<>`
- Change signature of `insertItem(QModelIndex parent)` to insertItem(SessionItem* parent)`

This is done to make an interface more uniform with other methods of `SessionModel` (`copyItem`, `moveItem`, etc), and avoid repeating code like

```
model.insertItem<Child>(parent->index())
or
model.insertItem<Child>(model.indexOfItem(parent))
```

in the favor of

```
model.insertItem<Child>(parent)
```
