### PR TITLE
Decrease get item usage

### DIFF
--- a/GUI/coregui/Models/AxesItems.cpp
+++ b/GUI/coregui/Models/AxesItems.cpp
@@ -29,11 +29,50 @@ BasicAxisItem::BasicAxisItem(const QString& type) : SessionItem(type)
     register_basic_properties();
 }
 
+int BasicAxisItem::binCount() const
+{
+    return getItemValue(P_NBINS).toInt();
+}
+
+void BasicAxisItem::setBinCount(int value)
+{
+    setItemValue(P_NBINS, value);
+}
+
+double BasicAxisItem::lowerBound() const
+{
+    return getItemValue(P_MIN_DEG).toDouble();
+}
+
+void BasicAxisItem::setLowerBound(double value)
+{
+    setItemValue(P_MIN_DEG, value);
+}
+
+double BasicAxisItem::upperBound() const
+{
+    return getItemValue(P_MAX_DEG).toDouble();
+}
+
+void BasicAxisItem::setUpperBound(double value)
+{
+    setItemValue(P_MAX_DEG, value);
+}
+
+QString BasicAxisItem::title() const
+{
+    return getItemValue(P_TITLE).toString();
+}
+
+void BasicAxisItem::setTitle(const QString& title)
+{
+    setItemValue(P_TITLE, title);
+}
+
 std::unique_ptr<IAxis> BasicAxisItem::createAxis(double scale) const
 {
-    return std::make_unique<FixedBinAxis>(
-        getItemValue(P_TITLE).toString().toStdString(), getItemValue(P_NBINS).toInt(),
-        getItemValue(P_MIN_DEG).toDouble() * scale, getItemValue(P_MAX_DEG).toDouble() * scale);
+    return std::make_unique<FixedBinAxis>(title().toStdString(), binCount(), lowerBound() * scale,
+                                          upperBound() * scale);
 }
 
 BasicAxisItem::~BasicAxisItem() = default;
@@ -42,10 +81,8 @@ void BasicAxisItem::register_basic_properties()
 {
     addProperty(P_IS_VISIBLE, true)->setVisible(false);
     addProperty(P_NBINS, 100)->setLimits(RealLimits::limited(1, max_detector_pixels));
-    addProperty(P_MIN_DEG, 0.0)->setDecimals(3);
-    getItem(P_MIN_DEG)->setLimits(RealLimits::limitless());
-    addProperty(P_MAX_DEG, -1.0)->setDecimals(3);
-    getItem(P_MAX_DEG)->setLimits(RealLimits::limitless());
+    addProperty(P_MIN_DEG, 0.0)->setDecimals(3).setLimits(RealLimits::limitless());
+    addProperty(P_MAX_DEG, -1.0)->setDecimals(3).setLimits(RealLimits::limitless());
     addProperty(P_TITLE, QString());
     addProperty(P_TITLE_IS_VISIBLE, true)->setVisible(false);
 }
@@ -71,6 +108,16 @@ AmplitudeAxisItem::AmplitudeAxisItem() : BasicAxisItem("AmplitudeAxis")
                 setMinMaxEditor("Default");
         }
     });
+}
+
+bool AmplitudeAxisItem::isLogScale() const
+{
+    return getItemValue(P_IS_LOGSCALE).toBool();
+}
+
+void AmplitudeAxisItem::setLogScale(bool value)
+{
+    setItemValue(P_IS_LOGSCALE, value);
 }
 
 //! Sets editor for min, max values of axes

--- a/GUI/coregui/Models/AxesItems.h
+++ b/GUI/coregui/Models/AxesItems.h
@@ -32,6 +32,18 @@ public:
     explicit BasicAxisItem(const QString& type = "BasicAxis");
     virtual ~BasicAxisItem();
 
+    int binCount() const;
+    void setBinCount(int value);
+
+    double lowerBound() const;
+    void setLowerBound(double value);
+
+    double upperBound() const;
+    void setUpperBound(double value);
+
+    QString title() const;
+    void setTitle(const QString& title);
+
     virtual std::unique_ptr<IAxis> createAxis(double scale) const;
 
 protected:
@@ -43,6 +55,9 @@ public:
     static const QString P_IS_LOGSCALE;
     static const QString P_LOCK_MIN_MAX;
     AmplitudeAxisItem();
+
+    bool isLogScale() const;
+    void setLogScale(bool value);
 
 private:
     void setMinMaxEditor(const QString& editorType);

--- a/GUI/coregui/Models/BeamDistributionItem.cpp
+++ b/GUI/coregui/Models/BeamDistributionItem.cpp
@@ -66,8 +66,7 @@ BeamDistributionItem::getParameterDistributionForName(const std::string& paramet
 
 void BeamDistributionItem::initDistributionItem(bool show_mean)
 {
-    GroupItem* groupItem = dynamic_cast<GroupItem*>(getItem(P_DISTRIBUTION));
-    ASSERT(groupItem);
+    auto groupItem = item<GroupItem>(P_DISTRIBUTION);
 
     SessionItem* distributionNone = nullptr;
     for (auto item : groupItem->getItems(GroupItem::T_ITEMS)) {

--- a/GUI/coregui/Models/BeamItems.cpp
+++ b/GUI/coregui/Models/BeamItems.cpp
@@ -188,7 +188,7 @@ void SpecularBeamItem::updateToData(const IAxis& axis, QString units)
     if (units == "nbins") {
         inclinationAxisGroup()->setCurrentType("BasicAxis");
         auto axis_item = currentInclinationAxisItem();
-        axis_item->setItemValue(BasicAxisItem::P_NBINS, static_cast<int>(axis.size()));
+        axis_item->setBinCount(static_cast<int>(axis.size()));
         return;
     }
 

--- a/GUI/coregui/Models/BeamItems.cpp
+++ b/GUI/coregui/Models/BeamItems.cpp
@@ -24,10 +24,9 @@
 #include "GUI/coregui/Models/PointwiseAxisItem.h"
 #include "GUI/coregui/Models/SessionItemUtils.h"
 #include "GUI/coregui/Models/SpecularBeamInclinationItem.h"
-#include "GUI/coregui/utils/GUIHelpers.h"
 #include "GUI/coregui/Models/VectorItem.h"
+#include "GUI/coregui/utils/GUIHelpers.h"
 #include <cmath>
-
 
 namespace {
 const QString polarization_tooltip = "Polarization of the beam, given as the Bloch vector";
@@ -69,36 +68,27 @@ void BeamItem::setIntensity(double value)
 
 double BeamItem::wavelength() const
 {
-    BeamWavelengthItem* beamWavelength = dynamic_cast<BeamWavelengthItem*>(getItem(P_WAVELENGTH));
-    return beamWavelength->wavelength();
+    return item<BeamWavelengthItem>(P_WAVELENGTH)->wavelength();
 }
 
 void BeamItem::setWavelength(double value)
 {
-    auto beam_wavelength = dynamic_cast<BeamWavelengthItem*>(getItem(P_WAVELENGTH));
-    ASSERT(beam_wavelength);
-    beam_wavelength->resetToValue(value);
+    item<BeamWavelengthItem>(P_WAVELENGTH)->resetToValue(value);
 }
 
 void BeamItem::setInclinationAngle(double value)
 {
-    auto angleItem = dynamic_cast<BeamDistributionItem*>(getItem(P_INCLINATION_ANGLE));
-    ASSERT(angleItem);
-    angleItem->resetToValue(value);
+    item<BeamDistributionItem>(P_INCLINATION_ANGLE)->resetToValue(value);
 }
 
 double BeamItem::getAzimuthalAngle() const
 {
-    const auto inclination = dynamic_cast<BeamAzimuthalAngleItem*>(getItem(P_AZIMUTHAL_ANGLE));
-    ASSERT(inclination);
-    return inclination->azimuthalAngle();
+    return item<BeamAzimuthalAngleItem>(P_AZIMUTHAL_ANGLE)->azimuthalAngle();
 }
 
 void BeamItem::setAzimuthalAngle(double value)
 {
-    auto angleItem = dynamic_cast<BeamDistributionItem*>(getItem(P_AZIMUTHAL_ANGLE));
-    ASSERT(angleItem);
-    angleItem->resetToValue(value);
+    item<BeamDistributionItem>(P_AZIMUTHAL_ANGLE)->resetToValue(value);
 }
 
 std::unique_ptr<Beam> BeamItem::createBeam() const
@@ -234,9 +224,7 @@ GISASBeamItem::~GISASBeamItem() = default;
 
 double GISASBeamItem::getInclinationAngle() const
 {
-    const auto inclination = dynamic_cast<BeamInclinationAngleItem*>(getItem(P_INCLINATION_ANGLE));
-    ASSERT(inclination);
-    return inclination->inclinationAngle();
+    return item<BeamInclinationAngleItem>(P_INCLINATION_ANGLE)->inclinationAngle();
 }
 
 namespace {

--- a/GUI/coregui/Models/Data1DViewItem.cpp
+++ b/GUI/coregui/Models/Data1DViewItem.cpp
@@ -217,7 +217,7 @@ const BasicAxisItem* Data1DViewItem::xAxisItem() const
 
 BasicAxisItem* Data1DViewItem::xAxisItem()
 {
-    return const_cast<BasicAxisItem*>(static_cast<const Data1DViewItem*>(this)->xAxisItem());
+    return item<BasicAxisItem>(P_XAXIS);
 }
 
 const AmplitudeAxisItem* Data1DViewItem::yAxisItem() const
@@ -227,7 +227,7 @@ const AmplitudeAxisItem* Data1DViewItem::yAxisItem() const
 
 AmplitudeAxisItem* Data1DViewItem::yAxisItem()
 {
-    return const_cast<AmplitudeAxisItem*>(static_cast<const Data1DViewItem*>(this)->yAxisItem());
+    return item<AmplitudeAxisItem>(P_YAXIS);
 }
 
 //! Set axes viewport to original data.

--- a/GUI/coregui/Models/Data1DViewItem.cpp
+++ b/GUI/coregui/Models/Data1DViewItem.cpp
@@ -73,52 +73,53 @@ Data1DViewItem::Data1DViewItem() : SessionItem("Data1DViewItem"), m_job_item(nul
 
 int Data1DViewItem::getNbins() const
 {
-    return xAxisItem()->getItemValue(BasicAxisItem::P_NBINS).toInt();
+
+    return xAxisItem()->binCount();
 }
 
 double Data1DViewItem::getLowerX() const
 {
-    return getItem(P_XAXIS)->getItemValue(BasicAxisItem::P_MIN_DEG).toDouble();
+    return xAxisItem()->lowerBound();
 }
 
 double Data1DViewItem::getUpperX() const
 {
-    return getItem(P_XAXIS)->getItemValue(BasicAxisItem::P_MAX_DEG).toDouble();
+    return xAxisItem()->upperBound();
 }
 
 double Data1DViewItem::getLowerY() const
 {
-    return getItem(P_YAXIS)->getItemValue(BasicAxisItem::P_MIN_DEG).toDouble();
+    return yAxisItem()->lowerBound();
 }
 
 double Data1DViewItem::getUpperY() const
 {
-    return getItem(P_YAXIS)->getItemValue(BasicAxisItem::P_MAX_DEG).toDouble();
+    return yAxisItem()->upperBound();
 }
 
 bool Data1DViewItem::isLog() const
 {
-    return getItem(P_YAXIS)->getItemValue(AmplitudeAxisItem::P_IS_LOGSCALE).toBool();
+    return yAxisItem()->isLogScale();
 }
 
 QString Data1DViewItem::getXaxisTitle() const
 {
-    return getItem(P_XAXIS)->getItemValue(BasicAxisItem::P_TITLE).toString();
+    return xAxisItem()->title();
 }
 
 QString Data1DViewItem::getYaxisTitle() const
 {
-    return getItem(P_YAXIS)->getItemValue(BasicAxisItem::P_TITLE).toString();
+    return yAxisItem()->title();
 }
 
-void Data1DViewItem::setXaxisTitle(QString xtitle)
+void Data1DViewItem::setXaxisTitle(const QString& title)
 {
-    getItem(P_XAXIS)->setItemValue(BasicAxisItem::P_TITLE, xtitle);
+    xAxisItem()->setTitle(title);
 }
 
-void Data1DViewItem::setYaxisTitle(QString ytitle)
+void Data1DViewItem::setYaxisTitle(const QString& title)
 {
-    getItem(P_YAXIS)->setItemValue(AmplitudeAxisItem::P_TITLE, ytitle);
+    yAxisItem()->setTitle(title);
 }
 
 //! set zoom range of x,y axes to axes of input data
@@ -179,39 +180,39 @@ JobItem* Data1DViewItem::jobItem()
         "Error in DataItem1DView::jobItem: passed item is not owned by any job item");
 }
 
-void Data1DViewItem::setLowerX(double xmin)
+void Data1DViewItem::setLowerX(double value)
 {
-    getItem(P_XAXIS)->setItemValue(BasicAxisItem::P_MIN_DEG, xmin);
+    xAxisItem()->setLowerBound(value);
 }
 
-void Data1DViewItem::setUpperX(double xmax)
+void Data1DViewItem::setUpperX(double value)
 {
-    getItem(P_XAXIS)->setItemValue(BasicAxisItem::P_MAX_DEG, xmax);
+    xAxisItem()->setUpperBound(value);
 }
 
-void Data1DViewItem::setLowerY(double ymin)
+void Data1DViewItem::setLowerY(double value)
 {
-    getItem(P_YAXIS)->setItemValue(AmplitudeAxisItem::P_MIN_DEG, ymin);
+    yAxisItem()->setLowerBound(value);
 }
 
-void Data1DViewItem::setUpperY(double ymax)
+void Data1DViewItem::setUpperY(double value)
 {
-    getItem(P_YAXIS)->setItemValue(AmplitudeAxisItem::P_MAX_DEG, ymax);
+    yAxisItem()->setUpperBound(value);
 }
 
 void Data1DViewItem::setLog(bool log_flag)
 {
-    getItem(P_YAXIS)->setItemValue(AmplitudeAxisItem::P_IS_LOGSCALE, log_flag);
+    yAxisItem()->setLogScale(log_flag);
 }
 
 DataPropertyContainer* Data1DViewItem::propertyContainerItem()
 {
-    return dynamic_cast<DataPropertyContainer*>(getItem(T_DATA_PROPERTIES));
+    return item<DataPropertyContainer>(T_DATA_PROPERTIES);
 }
 
 const BasicAxisItem* Data1DViewItem::xAxisItem() const
 {
-    return dynamic_cast<const BasicAxisItem*>(getItem(P_XAXIS));
+    return item<BasicAxisItem>(P_XAXIS);
 }
 
 BasicAxisItem* Data1DViewItem::xAxisItem()
@@ -221,9 +222,12 @@ BasicAxisItem* Data1DViewItem::xAxisItem()
 
 const AmplitudeAxisItem* Data1DViewItem::yAxisItem() const
 {
-    auto result = dynamic_cast<const AmplitudeAxisItem*>(getItem(P_YAXIS));
-    ASSERT(result);
-    return result;
+    return item<AmplitudeAxisItem>(P_YAXIS);
+}
+
+AmplitudeAxisItem* Data1DViewItem::yAxisItem()
+{
+    return const_cast<AmplitudeAxisItem*>(static_cast<const Data1DViewItem*>(this)->yAxisItem());
 }
 
 //! Set axes viewport to original data.

--- a/GUI/coregui/Models/Data1DViewItem.h
+++ b/GUI/coregui/Models/Data1DViewItem.h
@@ -57,11 +57,12 @@ public:
     const BasicAxisItem* xAxisItem() const;
     BasicAxisItem* xAxisItem();
     const AmplitudeAxisItem* yAxisItem() const;
+    AmplitudeAxisItem* yAxisItem();
 
     void resetView();
 
-    void setXaxisTitle(QString xtitle);
-    void setYaxisTitle(QString ytitle);
+    void setXaxisTitle(const QString& title);
+    void setYaxisTitle(const QString& title);
     void setAxesRangeToData();
 
     //! Returns data view to default state (no dimensional units, default axes' names)
@@ -78,10 +79,10 @@ public:
     //! job item set with DataItem1DView::setJobItem.
     JobItem* jobItem();
 
-    void setLowerX(double xmin);
-    void setUpperX(double xmax);
-    void setLowerY(double ymin);
-    void setUpperY(double ymax);
+    void setLowerX(double value);
+    void setUpperX(double value);
+    void setLowerY(double value);
+    void setUpperY(double value);
     void setLog(bool log_flag);
 
     DataPropertyContainer* propertyContainerItem();

--- a/GUI/coregui/Models/DataItem.h
+++ b/GUI/coregui/Models/DataItem.h
@@ -51,8 +51,8 @@ public:
 
     QString selectedAxesUnits() const;
 
-    virtual void setXaxisTitle(QString xtitle) = 0;
-    virtual void setYaxisTitle(QString ytitle) = 0;
+    virtual void setXaxisTitle(const QString& title) = 0;
+    virtual void setYaxisTitle(const QString& title) = 0;
     virtual void setAxesRangeToData() = 0;
     virtual void updateAxesUnits(const InstrumentItem* instrument) = 0;
     virtual std::vector<int> shape() const = 0;

--- a/GUI/coregui/Models/DepthProbeInstrumentItem.cpp
+++ b/GUI/coregui/Models/DepthProbeInstrumentItem.cpp
@@ -31,9 +31,9 @@ DepthProbeInstrumentItem::DepthProbeInstrumentItem() : InstrumentItem("DepthProb
     addGroupProperty(P_BEAM, "SpecularBeam");
 
     auto axisItem = beamItem()->currentInclinationAxisItem();
-    axisItem->setItemValue(BasicAxisItem::P_MIN_DEG, 0.0);
-    axisItem->setItemValue(BasicAxisItem::P_MAX_DEG, 1.0);
-    axisItem->setItemValue(BasicAxisItem::P_NBINS, 500);
+    axisItem->setLowerBound(0.0);
+    axisItem->setUpperBound(1.0);
+    axisItem->setBinCount(500);
 
     auto axis = addGroupProperty(P_Z_AXIS, "BasicAxis");
     axis->getItem(BasicAxisItem::P_TITLE)->setVisible(false);

--- a/GUI/coregui/Models/DomainObjectBuilder.cpp
+++ b/GUI/coregui/Models/DomainObjectBuilder.cpp
@@ -145,8 +145,8 @@ DomainObjectBuilder::createUnitConverter(const InstrumentItem* instrumentItem)
         return UnitConverterUtils::createConverterForGISAS(*instrument);
 
     if (instrumentItem->modelType() == "OffSpecularInstrument") {
-        auto axis_item = dynamic_cast<BasicAxisItem*>(
-            instrumentItem->getItem(OffSpecularInstrumentItem::P_ALPHA_AXIS));
+        auto axis_item =
+            instrumentItem->item<BasicAxisItem>(OffSpecularInstrumentItem::P_ALPHA_AXIS);
         const auto detector2d = dynamic_cast<const IDetector2D*>(instrument->getDetector());
         return std::make_unique<OffSpecularConverter>(*detector2d, instrument->beam(),
                                                       *axis_item->createAxis(Units::deg));

--- a/GUI/coregui/Models/DomainSimulationBuilder.cpp
+++ b/GUI/coregui/Models/DomainSimulationBuilder.cpp
@@ -122,8 +122,7 @@ createOffSpecularSimulation(std::unique_ptr<MultiLayer> P_multilayer,
     ret->setInstrument(*P_instrument);
 
     auto beamItem = instrument->beamItem();
-    auto axisItem =
-        dynamic_cast<BasicAxisItem*>(instrument->getItem(OffSpecularInstrumentItem::P_ALPHA_AXIS));
+    auto axisItem = instrument->item<BasicAxisItem>(OffSpecularInstrumentItem::P_ALPHA_AXIS);
     ret->setBeamParameters(beamItem->wavelength(), *axisItem->createAxis(Units::deg),
                            beamItem->getAzimuthalAngle());
 

--- a/GUI/coregui/Models/FitSuiteItem.cpp
+++ b/GUI/coregui/Models/FitSuiteItem.cpp
@@ -34,11 +34,10 @@ FitSuiteItem::FitSuiteItem() : SessionItem("FitSuite")
 
 FitParameterContainerItem* FitSuiteItem::fitParameterContainerItem()
 {
-    return dynamic_cast<FitParameterContainerItem*>(
-        getItem(FitSuiteItem::T_FIT_PARAMETERS_CONTAINER));
+    return item<FitParameterContainerItem>(FitSuiteItem::T_FIT_PARAMETERS_CONTAINER);
 }
 
 MinimizerContainerItem* FitSuiteItem::minimizerContainerItem()
 {
-    return dynamic_cast<MinimizerContainerItem*>(getItem(FitSuiteItem::T_MINIMIZER));
+    return item<MinimizerContainerItem>(FitSuiteItem::T_MINIMIZER);
 }

--- a/GUI/coregui/Models/InstrumentItems.cpp
+++ b/GUI/coregui/Models/InstrumentItems.cpp
@@ -125,7 +125,7 @@ std::unique_ptr<Instrument> SpecularInstrumentItem::createInstrument() const
 std::vector<int> SpecularInstrumentItem::shape() const
 {
     const auto axis_item = beamItem()->currentInclinationAxisItem();
-    return {axis_item->getItemValue(BasicAxisItem::P_NBINS).toInt()};
+    return {axis_item->binCount()};
 }
 
 void SpecularInstrumentItem::updateToRealData(const RealDataItem* item)
@@ -262,22 +262,22 @@ OffSpecularInstrumentItem::OffSpecularInstrumentItem() : Instrument2DItem("OffSp
 
 std::vector<int> OffSpecularInstrumentItem::shape() const
 {
-    const int x_size = getItem(P_ALPHA_AXIS)->getItemValue(BasicAxisItem::P_NBINS).toInt();
+    const int x_size = item<BasicAxisItem>(P_ALPHA_AXIS)->binCount();
     auto detector_item = detectorItem();
     return {x_size, detector_item->ySize()};
 }
 
-void OffSpecularInstrumentItem::updateToRealData(const RealDataItem* item)
+void OffSpecularInstrumentItem::updateToRealData(const RealDataItem* dataItem)
 {
-    if (!item)
+    if (!dataItem)
         return;
 
-    const auto data_shape = item->shape();
+    const auto data_shape = dataItem->shape();
     if (shape().size() != data_shape.size())
         throw GUIHelpers::Error("Error in OffSpecularInstrumentItem::updateToRealData: The type of "
                                 "instrument is incompatible with passed data shape.");
-    getItem(OffSpecularInstrumentItem::P_ALPHA_AXIS)
-        ->setItemValue(BasicAxisItem::P_NBINS, data_shape[0]);
+
+    item<BasicAxisItem>(P_ALPHA_AXIS)->setBinCount(data_shape[0]);
     detectorItem()->setYSize(data_shape[1]);
 }
 

--- a/GUI/coregui/Models/IntensityDataItem.cpp
+++ b/GUI/coregui/Models/IntensityDataItem.cpp
@@ -152,12 +152,12 @@ double IntensityDataItem::getYmax() const
 
 double IntensityDataItem::getLowerZ() const
 {
-    return getItem(P_ZAXIS)->getItemValue(BasicAxisItem::P_MIN_DEG).toDouble();
+    return zAxisItem()->lowerBound();
 }
 
 double IntensityDataItem::getUpperZ() const
 {
-    return getItem(P_ZAXIS)->getItemValue(BasicAxisItem::P_MAX_DEG).toDouble();
+    return zAxisItem()->upperBound();
 }
 
 QString IntensityDataItem::getGradient() const
@@ -168,7 +168,7 @@ QString IntensityDataItem::getGradient() const
 
 bool IntensityDataItem::isLogz() const
 {
-    return getItem(P_ZAXIS)->getItemValue(AmplitudeAxisItem::P_IS_LOGSCALE).toBool();
+    return zAxisItem()->isLogScale();
 }
 
 bool IntensityDataItem::isInterpolated() const
@@ -178,12 +178,12 @@ bool IntensityDataItem::isInterpolated() const
 
 QString IntensityDataItem::getXaxisTitle() const
 {
-    return getItem(P_XAXIS)->getItemValue(BasicAxisItem::P_TITLE).toString();
+    return xAxisItem()->title();
 }
 
 QString IntensityDataItem::getYaxisTitle() const
 {
-    return getItem(P_YAXIS)->getItemValue(BasicAxisItem::P_TITLE).toString();
+    return yAxisItem()->title();
 }
 
 bool IntensityDataItem::isZAxisLocked() const
@@ -198,12 +198,12 @@ void IntensityDataItem::setZAxisLocked(bool state)
 
 void IntensityDataItem::setXaxisTitle(QString xtitle)
 {
-    getItem(P_XAXIS)->setItemValue(BasicAxisItem::P_TITLE, xtitle);
+    xAxisItem()->setTitle(xtitle);
 }
 
 void IntensityDataItem::setYaxisTitle(QString ytitle)
 {
-    getItem(P_YAXIS)->setItemValue(BasicAxisItem::P_TITLE, ytitle);
+    yAxisItem()->setTitle(ytitle);
 }
 
 //! set zoom range of x,y axes to axes of input data
@@ -248,46 +248,46 @@ void IntensityDataItem::reset(ImportDataInfo data)
 
 void IntensityDataItem::setLowerX(double xmin)
 {
-    getItem(P_XAXIS)->setItemValue(BasicAxisItem::P_MIN_DEG, xmin);
+    xAxisItem()->setLowerBound(xmin);
 }
 
 void IntensityDataItem::setUpperX(double xmax)
 {
-    getItem(P_XAXIS)->setItemValue(BasicAxisItem::P_MAX_DEG, xmax);
+    xAxisItem()->setUpperBound(xmax);
 }
 
 void IntensityDataItem::setLowerY(double ymin)
 {
-    getItem(P_YAXIS)->setItemValue(BasicAxisItem::P_MIN_DEG, ymin);
+    yAxisItem()->setLowerBound(ymin);
 }
 
 void IntensityDataItem::setUpperY(double ymax)
 {
-    getItem(P_YAXIS)->setItemValue(BasicAxisItem::P_MAX_DEG, ymax);
+    yAxisItem()->setUpperBound(ymax);
 }
 
 void IntensityDataItem::setLowerAndUpperZ(double zmin, double zmax)
 {
     if (getLowerZ() != zmin)
-        getItem(P_ZAXIS)->setItemValue(BasicAxisItem::P_MIN_DEG, zmin);
+        setLowerZ(zmin);
 
     if (getUpperZ() != zmax)
-        getItem(P_ZAXIS)->setItemValue(BasicAxisItem::P_MAX_DEG, zmax);
+        setUpperZ(zmax);
 }
 
 void IntensityDataItem::setLowerZ(double zmin)
 {
-    getItem(P_ZAXIS)->setItemValue(BasicAxisItem::P_MIN_DEG, zmin);
+    zAxisItem()->setLowerBound(zmin);
 }
 
 void IntensityDataItem::setUpperZ(double zmax)
 {
-    getItem(P_ZAXIS)->setItemValue(BasicAxisItem::P_MAX_DEG, zmax);
+    zAxisItem()->setUpperBound(zmax);
 }
 
 void IntensityDataItem::setLogz(bool logz)
 {
-    getItem(P_ZAXIS)->setItemValue(AmplitudeAxisItem::P_IS_LOGSCALE, logz);
+    zAxisItem()->setLogScale(logz);
 }
 
 void IntensityDataItem::setInterpolated(bool interp)
@@ -367,7 +367,7 @@ QPair<double, double> IntensityDataItem::dataRange() const
 
 const BasicAxisItem* IntensityDataItem::xAxisItem() const
 {
-    return dynamic_cast<const BasicAxisItem*>(getItem(P_XAXIS));
+    return item<BasicAxisItem>(P_XAXIS);
 }
 
 BasicAxisItem* IntensityDataItem::xAxisItem()
@@ -377,7 +377,7 @@ BasicAxisItem* IntensityDataItem::xAxisItem()
 
 const BasicAxisItem* IntensityDataItem::yAxisItem() const
 {
-    return dynamic_cast<const BasicAxisItem*>(getItem(P_YAXIS));
+    return item<BasicAxisItem>(P_YAXIS);
 }
 
 BasicAxisItem* IntensityDataItem::yAxisItem()
@@ -385,14 +385,14 @@ BasicAxisItem* IntensityDataItem::yAxisItem()
     return const_cast<BasicAxisItem*>(static_cast<const IntensityDataItem*>(this)->yAxisItem());
 }
 
-const BasicAxisItem* IntensityDataItem::zAxisItem() const
+const AmplitudeAxisItem* IntensityDataItem::zAxisItem() const
 {
-    return dynamic_cast<const BasicAxisItem*>(getItem(P_ZAXIS));
+    return item<AmplitudeAxisItem>(P_ZAXIS);
 }
 
-BasicAxisItem* IntensityDataItem::zAxisItem()
+AmplitudeAxisItem* IntensityDataItem::zAxisItem()
 {
-    return const_cast<BasicAxisItem*>(static_cast<const IntensityDataItem*>(this)->zAxisItem());
+    return const_cast<AmplitudeAxisItem*>(static_cast<const IntensityDataItem*>(this)->zAxisItem());
 }
 
 //! Set axes viewport to original data.

--- a/GUI/coregui/Models/IntensityDataItem.cpp
+++ b/GUI/coregui/Models/IntensityDataItem.cpp
@@ -196,14 +196,14 @@ void IntensityDataItem::setZAxisLocked(bool state)
     return getItem(P_ZAXIS)->setItemValue(AmplitudeAxisItem::P_LOCK_MIN_MAX, state);
 }
 
-void IntensityDataItem::setXaxisTitle(QString xtitle)
+void IntensityDataItem::setXaxisTitle(const QString& title)
 {
-    xAxisItem()->setTitle(xtitle);
+    xAxisItem()->setTitle(title);
 }
 
-void IntensityDataItem::setYaxisTitle(QString ytitle)
+void IntensityDataItem::setYaxisTitle(const QString& title)
 {
-    yAxisItem()->setTitle(ytitle);
+    yAxisItem()->setTitle(title);
 }
 
 //! set zoom range of x,y axes to axes of input data
@@ -246,24 +246,24 @@ void IntensityDataItem::reset(ImportDataInfo data)
     converter.convertFromNbins(this);
 }
 
-void IntensityDataItem::setLowerX(double xmin)
+void IntensityDataItem::setLowerX(double value)
 {
-    xAxisItem()->setLowerBound(xmin);
+    xAxisItem()->setLowerBound(value);
 }
 
-void IntensityDataItem::setUpperX(double xmax)
+void IntensityDataItem::setUpperX(double value)
 {
-    xAxisItem()->setUpperBound(xmax);
+    xAxisItem()->setUpperBound(value);
 }
 
-void IntensityDataItem::setLowerY(double ymin)
+void IntensityDataItem::setLowerY(double value)
 {
-    yAxisItem()->setLowerBound(ymin);
+    yAxisItem()->setLowerBound(value);
 }
 
-void IntensityDataItem::setUpperY(double ymax)
+void IntensityDataItem::setUpperY(double value)
 {
-    yAxisItem()->setUpperBound(ymax);
+    yAxisItem()->setUpperBound(value);
 }
 
 void IntensityDataItem::setLowerAndUpperZ(double zmin, double zmax)

--- a/GUI/coregui/Models/IntensityDataItem.cpp
+++ b/GUI/coregui/Models/IntensityDataItem.cpp
@@ -372,7 +372,7 @@ const BasicAxisItem* IntensityDataItem::xAxisItem() const
 
 BasicAxisItem* IntensityDataItem::xAxisItem()
 {
-    return const_cast<BasicAxisItem*>(static_cast<const IntensityDataItem*>(this)->xAxisItem());
+    return item<BasicAxisItem>(P_XAXIS);
 }
 
 const BasicAxisItem* IntensityDataItem::yAxisItem() const
@@ -382,7 +382,7 @@ const BasicAxisItem* IntensityDataItem::yAxisItem() const
 
 BasicAxisItem* IntensityDataItem::yAxisItem()
 {
-    return const_cast<BasicAxisItem*>(static_cast<const IntensityDataItem*>(this)->yAxisItem());
+    return item<BasicAxisItem>(P_YAXIS);
 }
 
 const AmplitudeAxisItem* IntensityDataItem::zAxisItem() const
@@ -392,7 +392,7 @@ const AmplitudeAxisItem* IntensityDataItem::zAxisItem() const
 
 AmplitudeAxisItem* IntensityDataItem::zAxisItem()
 {
-    return const_cast<AmplitudeAxisItem*>(static_cast<const IntensityDataItem*>(this)->zAxisItem());
+    return item<AmplitudeAxisItem>(P_ZAXIS);
 }
 
 //! Set axes viewport to original data.

--- a/GUI/coregui/Models/IntensityDataItem.cpp
+++ b/GUI/coregui/Models/IntensityDataItem.cpp
@@ -98,22 +98,22 @@ void IntensityDataItem::setOutputData(OutputData<double>* data)
 
 int IntensityDataItem::getNbinsX() const
 {
-    return xAxisItem()->getItemValue(BasicAxisItem::P_NBINS).toInt();
+    return xAxisItem()->binCount();
 }
 
 int IntensityDataItem::getNbinsY() const
 {
-    return yAxisItem()->getItemValue(BasicAxisItem::P_NBINS).toInt();
+    return yAxisItem()->binCount();
 }
 
 double IntensityDataItem::getLowerX() const
 {
-    return getItem(P_XAXIS)->getItemValue(BasicAxisItem::P_MIN_DEG).toDouble();
+    return xAxisItem()->lowerBound();
 }
 
 double IntensityDataItem::getUpperX() const
 {
-    return getItem(P_XAXIS)->getItemValue(BasicAxisItem::P_MAX_DEG).toDouble();
+    return xAxisItem()->upperBound();
 }
 
 double IntensityDataItem::getXmin() const
@@ -130,12 +130,12 @@ double IntensityDataItem::getXmax() const
 
 double IntensityDataItem::getLowerY() const
 {
-    return getItem(P_YAXIS)->getItemValue(BasicAxisItem::P_MIN_DEG).toDouble();
+    return yAxisItem()->lowerBound();
 }
 
 double IntensityDataItem::getUpperY() const
 {
-    return getItem(P_YAXIS)->getItemValue(BasicAxisItem::P_MAX_DEG).toDouble();
+    return yAxisItem()->upperBound();
 }
 
 double IntensityDataItem::getYmin() const
@@ -312,9 +312,9 @@ void IntensityDataItem::updateAxesZoomLevel()
     }
 
     const int nx = static_cast<int>(m_data->axis(0).size());
-    xAxisItem()->setItemValue(BasicAxisItem::P_NBINS, nx);
+    xAxisItem()->setBinCount(nx);
     const int ny = static_cast<int>(m_data->axis(1).size());
-    yAxisItem()->setItemValue(BasicAxisItem::P_NBINS, ny);
+    yAxisItem()->setBinCount(ny);
 }
 
 //! Init axes labels, if it was not done already.

--- a/GUI/coregui/Models/IntensityDataItem.h
+++ b/GUI/coregui/Models/IntensityDataItem.h
@@ -89,8 +89,8 @@ public:
     MaskContainerItem* maskContainerItem();
     ProjectionContainerItem* projectionContainerItem();
 
-    void setXaxisTitle(QString xtitle) override;
-    void setYaxisTitle(QString ytitle) override;
+    void setXaxisTitle(const QString& title) override;
+    void setYaxisTitle(const QString& title) override;
     void setAxesRangeToData() override;
     void updateAxesUnits(const InstrumentItem* instrument) override;
     std::vector<int> shape() const override;
@@ -100,10 +100,10 @@ public:
     void reset(ImportDataInfo data) override;
 
 public slots:
-    void setLowerX(double xmin);
-    void setUpperX(double xmax);
-    void setLowerY(double ymin);
-    void setUpperY(double ymax);
+    void setLowerX(double value);
+    void setUpperX(double value);
+    void setLowerY(double value);
+    void setUpperY(double value);
     void setLowerAndUpperZ(double zmin, double zmax);
     void setLowerZ(double zmin);
     void setUpperZ(double zmax);

--- a/GUI/coregui/Models/IntensityDataItem.h
+++ b/GUI/coregui/Models/IntensityDataItem.h
@@ -18,6 +18,7 @@
 #include "GUI/coregui/Models/DataItem.h"
 
 class BasicAxisItem;
+class AmplitudeAxisItem;
 class MaskContainerItem;
 class ProjectionContainerItem;
 
@@ -80,8 +81,8 @@ public:
     BasicAxisItem* xAxisItem();
     const BasicAxisItem* yAxisItem() const;
     BasicAxisItem* yAxisItem();
-    const BasicAxisItem* zAxisItem() const;
-    BasicAxisItem* zAxisItem();
+    const AmplitudeAxisItem* zAxisItem() const;
+    AmplitudeAxisItem* zAxisItem();
 
     void resetView();
 

--- a/GUI/coregui/Models/ParticleItem.cpp
+++ b/GUI/coregui/Models/ParticleItem.cpp
@@ -104,7 +104,7 @@ void ParticleItem::updatePropertiesAppearance(SessionItem* newParent)
         }
     } else {
         getItem(ParticleItem::P_ABUNDANCE)->setEnabled(true);
-        getItem(ParticleItem::P_POSITION)->setEnabled(true);
+        positionItem()->setEnabled(true);
     }
 }
 

--- a/GUI/coregui/Models/PointwiseAxisItem.cpp
+++ b/GUI/coregui/Models/PointwiseAxisItem.cpp
@@ -138,9 +138,9 @@ void PointwiseAxisItem::updateIndicators()
         return;
 
     const auto converter = m_instrument->createUnitConverter();
-    getItem(P_MIN_DEG)->setValue(converter->calculateMin(0, Axes::Units::DEGREES));
-    getItem(P_MAX_DEG)->setValue(converter->calculateMax(0, Axes::Units::DEGREES));
-    getItem(P_NBINS)->setValue(static_cast<int>(m_axis->size()));
+    setLowerBound(converter->calculateMin(0, Axes::Units::DEGREES));
+    setUpperBound(converter->calculateMax(0, Axes::Units::DEGREES));
+    setBinCount(static_cast<int>(m_axis->size()));
 
     emitDataChanged();
 }

--- a/GUI/coregui/Models/RectangularDetectorItem.cpp
+++ b/GUI/coregui/Models/RectangularDetectorItem.cpp
@@ -159,7 +159,7 @@ void RectangularDetectorItem::setYSize(int ny)
 
 const BasicAxisItem* RectangularDetectorItem::xAxisItem() const
 {
-    return dynamic_cast<const BasicAxisItem*>(getItem(P_X_AXIS));
+    return item<BasicAxisItem>(P_X_AXIS);
 }
 
 BasicAxisItem* RectangularDetectorItem::xAxisItem()
@@ -170,7 +170,7 @@ BasicAxisItem* RectangularDetectorItem::xAxisItem()
 
 const BasicAxisItem* RectangularDetectorItem::yAxisItem() const
 {
-    return dynamic_cast<const BasicAxisItem*>(getItem(P_Y_AXIS));
+    return item<BasicAxisItem>(P_Y_AXIS);
 }
 
 BasicAxisItem* RectangularDetectorItem::yAxisItem()

--- a/GUI/coregui/Models/RectangularDetectorItem.cpp
+++ b/GUI/coregui/Models/RectangularDetectorItem.cpp
@@ -139,36 +139,56 @@ void RectangularDetectorItem::setDetectorAlignment(const QString& alignment)
 
 int RectangularDetectorItem::xSize() const
 {
-    return getItem(RectangularDetectorItem::P_X_AXIS)->getItemValue(BasicAxisItem::P_NBINS).toInt();
+    return xAxisItem()->binCount();
 }
 
 int RectangularDetectorItem::ySize() const
 {
-    return getItem(RectangularDetectorItem::P_Y_AXIS)->getItemValue(BasicAxisItem::P_NBINS).toInt();
+    return yAxisItem()->binCount();
 }
 
 void RectangularDetectorItem::setXSize(int nx)
 {
-    getItem(RectangularDetectorItem::P_X_AXIS)->setItemValue(BasicAxisItem::P_NBINS, nx);
+    xAxisItem()->setBinCount(nx);
 }
 
 void RectangularDetectorItem::setYSize(int ny)
 {
-    getItem(RectangularDetectorItem::P_Y_AXIS)->setItemValue(BasicAxisItem::P_NBINS, ny);
+    yAxisItem()->setBinCount(ny);
+}
+
+const BasicAxisItem* RectangularDetectorItem::xAxisItem() const
+{
+    return dynamic_cast<const BasicAxisItem*>(getItem(P_X_AXIS));
+}
+
+BasicAxisItem* RectangularDetectorItem::xAxisItem()
+{
+    return const_cast<BasicAxisItem*>(
+        static_cast<const RectangularDetectorItem*>(this)->xAxisItem());
+}
+
+const BasicAxisItem* RectangularDetectorItem::yAxisItem() const
+{
+    return dynamic_cast<const BasicAxisItem*>(getItem(P_Y_AXIS));
+}
+
+BasicAxisItem* RectangularDetectorItem::yAxisItem()
+{
+    return const_cast<BasicAxisItem*>(
+        static_cast<const RectangularDetectorItem*>(this)->yAxisItem());
 }
 
 std::unique_ptr<IDetector2D> RectangularDetectorItem::createDomainDetector() const
 {
     // basic axes parameters
-    auto x_axis = item<BasicAxisItem>(RectangularDetectorItem::P_X_AXIS);
-    size_t n_x = x_axis->getItemValue(BasicAxisItem::P_NBINS).toUInt();
-    double width = x_axis->getItemValue(BasicAxisItem::P_MAX_DEG).toDouble();
+    size_t n_x = xAxisItem()->binCount();
+    double width = xAxisItem()->upperBound();
 
-    auto y_axis = item<BasicAxisItem>(RectangularDetectorItem::P_Y_AXIS);
-    size_t n_y = y_axis->getItemValue(BasicAxisItem::P_NBINS).toUInt();
-    double height = y_axis->getItemValue(BasicAxisItem::P_MAX_DEG).toDouble();
+    size_t n_y = yAxisItem()->binCount();
+    double height = yAxisItem()->upperBound();
 
-    std::unique_ptr<RectangularDetector> result(new RectangularDetector(n_x, width, n_y, height));
+    auto result = std::make_unique<RectangularDetector>(n_x, width, n_y, height);
 
     // distance and alighnment
     double u0 = getItemValue(P_U0).toDouble();

--- a/GUI/coregui/Models/RectangularDetectorItem.h
+++ b/GUI/coregui/Models/RectangularDetectorItem.h
@@ -18,6 +18,8 @@
 #include "Base/Vector/Vectors3D.h"
 #include "GUI/coregui/Models/DetectorItems.h"
 
+class BasicAxisItem;
+
 class BA_CORE_API_ RectangularDetectorItem : public DetectorItem {
 public:
     static const QString P_X_AXIS;
@@ -39,6 +41,11 @@ public:
     int ySize() const override;
     void setXSize(int nx) override;
     void setYSize(int ny) override;
+
+    const BasicAxisItem* xAxisItem() const;
+    BasicAxisItem* xAxisItem();
+    const BasicAxisItem* yAxisItem() const;
+    BasicAxisItem* yAxisItem();
 
 private:
     std::unique_ptr<IDetector2D> createDomainDetector() const override;

--- a/GUI/coregui/Models/SpecularBeamInclinationItem.cpp
+++ b/GUI/coregui/Models/SpecularBeamInclinationItem.cpp
@@ -87,10 +87,13 @@ void setupDistributionMean(SessionItem* distribution)
     valueItem->setValue(0.0);
 }
 
-void setAxisPresentationDefaults(SessionItem* axis_item, const QString& type)
+void setAxisPresentationDefaults(SessionItem* item, const QString& type)
 {
+    auto axis_item = dynamic_cast<BasicAxisItem*>(item);
+    Q_ASSERT(axis_item);
+
     axis_item->getItem(BasicAxisItem::P_TITLE)->setVisible(false);
-    axis_item->setItemValue(BasicAxisItem::P_TITLE, "alpha_i");
+    axis_item->setTitle("alpha_i");
     axis_item->getItem(BasicAxisItem::P_NBINS)->setToolTip("Number of points in scan");
     axis_item->getItem(BasicAxisItem::P_MIN_DEG)->setToolTip("Starting value [deg]");
     axis_item->getItem(BasicAxisItem::P_MAX_DEG)->setToolTip("Ending value [deg]");
@@ -98,9 +101,9 @@ void setAxisPresentationDefaults(SessionItem* axis_item, const QString& type)
     axis_item->getItem(BasicAxisItem::P_MAX_DEG)->setLimits(RealLimits::limited(0., 90.));
 
     if (type == "BasicAxis") {
-        axis_item->setItemValue(BasicAxisItem::P_MIN_DEG, 0.0);
-        axis_item->setItemValue(BasicAxisItem::P_MAX_DEG, 3.0);
-        axis_item->setItemValue(BasicAxisItem::P_NBINS, 500);
+        axis_item->setLowerBound(0.0);
+        axis_item->setUpperBound(3.0);
+        axis_item->setBinCount(500);
     } else if (type == "PointwiseAxis") {
         axis_item->getItem(BasicAxisItem::P_MIN_DEG)->setEnabled(false);
         axis_item->getItem(BasicAxisItem::P_MAX_DEG)->setEnabled(false);

--- a/GUI/coregui/Models/SpecularDataItem.cpp
+++ b/GUI/coregui/Models/SpecularDataItem.cpp
@@ -56,17 +56,17 @@ void SpecularDataItem::setOutputData(OutputData<double>* data)
 
 int SpecularDataItem::getNbins() const
 {
-    return xAxisItem()->getItemValue(BasicAxisItem::P_NBINS).toInt();
+    return xAxisItem()->binCount();
 }
 
 double SpecularDataItem::getLowerX() const
 {
-    return getItem(P_XAXIS)->getItemValue(BasicAxisItem::P_MIN_DEG).toDouble();
+    return xAxisItem()->lowerBound();
 }
 
 double SpecularDataItem::getUpperX() const
 {
-    return getItem(P_XAXIS)->getItemValue(BasicAxisItem::P_MAX_DEG).toDouble();
+    return xAxisItem()->upperBound();
 }
 
 double SpecularDataItem::getXmin() const
@@ -83,12 +83,12 @@ double SpecularDataItem::getXmax() const
 
 double SpecularDataItem::getLowerY() const
 {
-    return getItem(P_YAXIS)->getItemValue(BasicAxisItem::P_MIN_DEG).toDouble();
+    return yAxisItem()->lowerBound();
 }
 
 double SpecularDataItem::getUpperY() const
 {
-    return getItem(P_YAXIS)->getItemValue(BasicAxisItem::P_MAX_DEG).toDouble();
+    return yAxisItem()->upperBound();
 }
 
 double SpecularDataItem::getYmin() const
@@ -103,27 +103,27 @@ double SpecularDataItem::getYmax() const
 
 bool SpecularDataItem::isLog() const
 {
-    return getItem(P_YAXIS)->getItemValue(AmplitudeAxisItem::P_IS_LOGSCALE).toBool();
+    return yAxisItem()->isLogScale();
 }
 
 QString SpecularDataItem::getXaxisTitle() const
 {
-    return getItem(P_XAXIS)->getItemValue(BasicAxisItem::P_TITLE).toString();
+    return xAxisItem()->title();
 }
 
 QString SpecularDataItem::getYaxisTitle() const
 {
-    return getItem(P_YAXIS)->getItemValue(BasicAxisItem::P_TITLE).toString();
+    return yAxisItem()->title();
 }
 
-void SpecularDataItem::setXaxisTitle(QString xtitle)
+void SpecularDataItem::setXaxisTitle(const QString& title)
 {
-    getItem(P_XAXIS)->setItemValue(BasicAxisItem::P_TITLE, xtitle);
+    xAxisItem()->setTitle(title);
 }
 
-void SpecularDataItem::setYaxisTitle(QString ytitle)
+void SpecularDataItem::setYaxisTitle(const QString& title)
 {
-    getItem(P_YAXIS)->setItemValue(AmplitudeAxisItem::P_TITLE, ytitle);
+    yAxisItem()->setTitle(title);
 }
 
 //! set zoom range of x,y axes to axes of input data
@@ -157,29 +157,29 @@ void SpecularDataItem::reset(ImportDataInfo data)
     setAxesRangeToData();
 }
 
-void SpecularDataItem::setLowerX(double xmin)
+void SpecularDataItem::setLowerX(double value)
 {
-    getItem(P_XAXIS)->setItemValue(BasicAxisItem::P_MIN_DEG, xmin);
+    xAxisItem()->setLowerBound(value);
 }
 
-void SpecularDataItem::setUpperX(double xmax)
+void SpecularDataItem::setUpperX(double value)
 {
-    getItem(P_XAXIS)->setItemValue(BasicAxisItem::P_MAX_DEG, xmax);
+    xAxisItem()->setUpperBound(value);
 }
 
-void SpecularDataItem::setLowerY(double ymin)
+void SpecularDataItem::setLowerY(double value)
 {
-    getItem(P_YAXIS)->setItemValue(AmplitudeAxisItem::P_MIN_DEG, ymin);
+    yAxisItem()->setLowerBound(value);
 }
 
-void SpecularDataItem::setUpperY(double ymax)
+void SpecularDataItem::setUpperY(double value)
 {
-    getItem(P_YAXIS)->setItemValue(AmplitudeAxisItem::P_MAX_DEG, ymax);
+    yAxisItem()->setUpperBound(value);
 }
 
 void SpecularDataItem::setLog(bool log_flag)
 {
-    getItem(P_YAXIS)->setItemValue(AmplitudeAxisItem::P_IS_LOGSCALE, log_flag);
+    yAxisItem()->setLogScale(log_flag);
 }
 
 //! Sets zoom range of X,Y axes, if it was not yet defined.
@@ -223,7 +223,7 @@ QPair<double, double> SpecularDataItem::dataRange() const
 
 const BasicAxisItem* SpecularDataItem::xAxisItem() const
 {
-    return dynamic_cast<const BasicAxisItem*>(getItem(P_XAXIS));
+    return item<BasicAxisItem>(P_XAXIS);
 }
 
 BasicAxisItem* SpecularDataItem::xAxisItem()
@@ -233,9 +233,12 @@ BasicAxisItem* SpecularDataItem::xAxisItem()
 
 const AmplitudeAxisItem* SpecularDataItem::yAxisItem() const
 {
-    auto result = dynamic_cast<const AmplitudeAxisItem*>(getItem(P_YAXIS));
-    ASSERT(result);
-    return result;
+    return item<AmplitudeAxisItem>(P_YAXIS);
+}
+
+AmplitudeAxisItem* SpecularDataItem::yAxisItem()
+{
+    return const_cast<AmplitudeAxisItem*>(static_cast<const SpecularDataItem*>(this)->yAxisItem());
 }
 
 //! Set axes viewport to original data.

--- a/GUI/coregui/Models/SpecularDataItem.cpp
+++ b/GUI/coregui/Models/SpecularDataItem.cpp
@@ -228,7 +228,7 @@ const BasicAxisItem* SpecularDataItem::xAxisItem() const
 
 BasicAxisItem* SpecularDataItem::xAxisItem()
 {
-    return const_cast<BasicAxisItem*>(static_cast<const SpecularDataItem*>(this)->xAxisItem());
+    return item<BasicAxisItem>(P_XAXIS);
 }
 
 const AmplitudeAxisItem* SpecularDataItem::yAxisItem() const
@@ -238,7 +238,7 @@ const AmplitudeAxisItem* SpecularDataItem::yAxisItem() const
 
 AmplitudeAxisItem* SpecularDataItem::yAxisItem()
 {
-    return const_cast<AmplitudeAxisItem*>(static_cast<const SpecularDataItem*>(this)->yAxisItem());
+    return item<AmplitudeAxisItem>(P_YAXIS);
 }
 
 //! Set axes viewport to original data.

--- a/GUI/coregui/Models/SpecularDataItem.h
+++ b/GUI/coregui/Models/SpecularDataItem.h
@@ -63,11 +63,12 @@ public:
     const BasicAxisItem* xAxisItem() const;
     BasicAxisItem* xAxisItem();
     const AmplitudeAxisItem* yAxisItem() const;
+    AmplitudeAxisItem* yAxisItem();
 
     void resetView();
 
-    void setXaxisTitle(QString xtitle) override;
-    void setYaxisTitle(QString ytitle) override;
+    void setXaxisTitle(const QString& title) override;
+    void setYaxisTitle(const QString& title) override;
     void setAxesRangeToData() override;
     void updateAxesUnits(const InstrumentItem* instrument) override;
     std::vector<int> shape() const override;
@@ -77,10 +78,10 @@ public:
     void reset(ImportDataInfo data) override;
 
 public slots:
-    void setLowerX(double xmin);
-    void setUpperX(double xmax);
-    void setLowerY(double ymin);
-    void setUpperY(double ymax);
+    void setLowerX(double value);
+    void setUpperX(double value);
+    void setLowerY(double value);
+    void setUpperY(double value);
     void setLog(bool log_flag);
 
 private:

--- a/GUI/coregui/Models/SphericalDetectorItem.cpp
+++ b/GUI/coregui/Models/SphericalDetectorItem.cpp
@@ -45,44 +45,35 @@ SphericalDetectorItem::SphericalDetectorItem() : DetectorItem("SphericalDetector
 
 std::unique_ptr<IDetector2D> SphericalDetectorItem::createDomainDetector() const
 {
-    auto x_axis = dynamic_cast<BasicAxisItem*>(getItem(SphericalDetectorItem::P_PHI_AXIS));
-    ASSERT(x_axis);
-    int n_x = x_axis->getItemValue(BasicAxisItem::P_NBINS).toInt();
-    double x_min = Units::deg2rad(x_axis->getItemValue(BasicAxisItem::P_MIN_DEG).toDouble());
-    double x_max = Units::deg2rad(x_axis->getItemValue(BasicAxisItem::P_MAX_DEG).toDouble());
+    int n_x = phiAxisItem()->binCount();
+    double x_min = Units::deg2rad(phiAxisItem()->lowerBound());
+    double x_max = Units::deg2rad(phiAxisItem()->upperBound());
 
-    auto y_axis = dynamic_cast<BasicAxisItem*>(getItem(SphericalDetectorItem::P_ALPHA_AXIS));
-    ASSERT(y_axis);
-    int n_y = y_axis->getItemValue(BasicAxisItem::P_NBINS).toInt();
-    double y_min = Units::deg2rad(y_axis->getItemValue(BasicAxisItem::P_MIN_DEG).toDouble());
-    double y_max = Units::deg2rad(y_axis->getItemValue(BasicAxisItem::P_MAX_DEG).toDouble());
+    int n_y = alphaAxisItem()->binCount();
+    double y_min = Units::deg2rad(alphaAxisItem()->lowerBound());
+    double y_max = Units::deg2rad(alphaAxisItem()->upperBound());
 
-    std::unique_ptr<SphericalDetector> result(
-        new SphericalDetector(n_x, x_min, x_max, n_y, y_min, y_max));
-
-    return std::unique_ptr<IDetector2D>(result.release());
+    return std::make_unique<SphericalDetector>(n_x, x_min, x_max, n_y, y_min, y_max);
 }
 
 int SphericalDetectorItem::xSize() const
 {
-    return getItem(SphericalDetectorItem::P_PHI_AXIS)->getItemValue(BasicAxisItem::P_NBINS).toInt();
+    return phiAxisItem()->binCount();
 }
 
 int SphericalDetectorItem::ySize() const
 {
-    return getItem(SphericalDetectorItem::P_ALPHA_AXIS)
-        ->getItemValue(BasicAxisItem::P_NBINS)
-        .toInt();
+    return alphaAxisItem()->binCount();
 }
 
 void SphericalDetectorItem::setXSize(int nx)
 {
-    getItem(SphericalDetectorItem::P_PHI_AXIS)->setItemValue(BasicAxisItem::P_NBINS, nx);
+    phiAxisItem()->setBinCount(nx);
 }
 
 void SphericalDetectorItem::setYSize(int ny)
 {
-    getItem(SphericalDetectorItem::P_ALPHA_AXIS)->setItemValue(BasicAxisItem::P_NBINS, ny);
+    alphaAxisItem()->setBinCount(ny);
 }
 
 const BasicAxisItem* SphericalDetectorItem::phiAxisItem() const

--- a/GUI/coregui/Models/SphericalDetectorItem.cpp
+++ b/GUI/coregui/Models/SphericalDetectorItem.cpp
@@ -83,8 +83,7 @@ const BasicAxisItem* SphericalDetectorItem::phiAxisItem() const
 
 BasicAxisItem* SphericalDetectorItem::phiAxisItem()
 {
-    return const_cast<BasicAxisItem*>(
-        static_cast<const SphericalDetectorItem*>(this)->phiAxisItem());
+    return item<BasicAxisItem>(P_PHI_AXIS);
 }
 
 const BasicAxisItem* SphericalDetectorItem::alphaAxisItem() const
@@ -94,8 +93,7 @@ const BasicAxisItem* SphericalDetectorItem::alphaAxisItem() const
 
 BasicAxisItem* SphericalDetectorItem::alphaAxisItem()
 {
-    return const_cast<BasicAxisItem*>(
-        static_cast<const SphericalDetectorItem*>(this)->alphaAxisItem());
+    return item<BasicAxisItem>(P_ALPHA_AXIS);
 }
 
 double SphericalDetectorItem::axesToDomainUnitsFactor() const

--- a/GUI/coregui/Models/SphericalDetectorItem.cpp
+++ b/GUI/coregui/Models/SphericalDetectorItem.cpp
@@ -85,6 +85,28 @@ void SphericalDetectorItem::setYSize(int ny)
     getItem(SphericalDetectorItem::P_ALPHA_AXIS)->setItemValue(BasicAxisItem::P_NBINS, ny);
 }
 
+const BasicAxisItem* SphericalDetectorItem::phiAxisItem() const
+{
+    return item<BasicAxisItem>(P_PHI_AXIS);
+}
+
+BasicAxisItem* SphericalDetectorItem::phiAxisItem()
+{
+    return const_cast<BasicAxisItem*>(
+        static_cast<const SphericalDetectorItem*>(this)->phiAxisItem());
+}
+
+const BasicAxisItem* SphericalDetectorItem::alphaAxisItem() const
+{
+    return item<BasicAxisItem>(P_ALPHA_AXIS);
+}
+
+BasicAxisItem* SphericalDetectorItem::alphaAxisItem()
+{
+    return const_cast<BasicAxisItem*>(
+        static_cast<const SphericalDetectorItem*>(this)->alphaAxisItem());
+}
+
 double SphericalDetectorItem::axesToDomainUnitsFactor() const
 {
     return Units::deg;

--- a/GUI/coregui/Models/SphericalDetectorItem.h
+++ b/GUI/coregui/Models/SphericalDetectorItem.h
@@ -17,6 +17,8 @@
 
 #include "GUI/coregui/Models/DetectorItems.h"
 
+class BasicAxisItem;
+
 class BA_CORE_API_ SphericalDetectorItem : public DetectorItem {
 public:
     static const QString P_PHI_AXIS;
@@ -27,6 +29,12 @@ public:
     int ySize() const override;
     void setXSize(int nx) override;
     void setYSize(int ny) override;
+
+    const BasicAxisItem* phiAxisItem() const;
+    BasicAxisItem* phiAxisItem();
+
+    const BasicAxisItem* alphaAxisItem() const;
+    BasicAxisItem* alphaAxisItem();
 
 protected:
     std::unique_ptr<IDetector2D> createDomainDetector() const override;

--- a/GUI/coregui/Models/TransformFromDomain.cpp
+++ b/GUI/coregui/Models/TransformFromDomain.cpp
@@ -408,17 +408,13 @@ void TransformFromDomain::setRectangularDetector(RectangularDetectorItem* detect
                                                  const RectangularDetector& detector)
 {
     // Axes
-    BasicAxisItem* xAxisItem =
-        dynamic_cast<BasicAxisItem*>(detector_item->getItem(RectangularDetectorItem::P_X_AXIS));
-    ASSERT(xAxisItem);
-    xAxisItem->setItemValue(BasicAxisItem::P_NBINS, (int)detector.getNbinsX());
-    xAxisItem->setItemValue(BasicAxisItem::P_MAX_DEG, detector.getWidth());
+    auto xAxisItem = detector_item->xAxisItem();
+    xAxisItem->setBinCount(detector.getNbinsX());
+    xAxisItem->setUpperBound(detector.getWidth());
 
-    BasicAxisItem* yAxisItem =
-        dynamic_cast<BasicAxisItem*>(detector_item->getItem(RectangularDetectorItem::P_Y_AXIS));
-    ASSERT(yAxisItem);
-    yAxisItem->setItemValue(BasicAxisItem::P_NBINS, (int)detector.getNbinsY());
-    yAxisItem->setItemValue(BasicAxisItem::P_MAX_DEG, detector.getHeight());
+    auto yAxisItem = detector_item->yAxisItem();
+    yAxisItem->setBinCount((int)detector.getNbinsY());
+    yAxisItem->setUpperBound(detector.getHeight());
 
     if (detector.getDetectorArrangment() == RectangularDetector::GENERIC) {
         detector_item->setDetectorAlignment("Generic");

--- a/GUI/coregui/Models/TransformFromDomain.cpp
+++ b/GUI/coregui/Models/TransformFromDomain.cpp
@@ -389,19 +389,15 @@ void TransformFromDomain::setSphericalDetector(SphericalDetectorItem* detector_i
     const IAxis& phi_axis = detector.axis(0);
     const IAxis& alpha_axis = detector.axis(1);
 
-    BasicAxisItem* phiAxisItem =
-        dynamic_cast<BasicAxisItem*>(detector_item->getItem(SphericalDetectorItem::P_PHI_AXIS));
-    ASSERT(phiAxisItem);
-    phiAxisItem->setItemValue(BasicAxisItem::P_NBINS, (int)phi_axis.size());
-    phiAxisItem->setItemValue(BasicAxisItem::P_MIN_DEG, Units::rad2deg(phi_axis.lowerBound()));
-    phiAxisItem->setItemValue(BasicAxisItem::P_MAX_DEG, Units::rad2deg(phi_axis.upperBound()));
+    auto phiAxisItem = detector_item->phiAxisItem();
+    phiAxisItem->setBinCount(phi_axis.size());
+    phiAxisItem->setLowerBound(Units::rad2deg(phi_axis.lowerBound()));
+    phiAxisItem->setUpperBound(Units::rad2deg(phi_axis.upperBound()));
 
-    BasicAxisItem* alphaAxisItem =
-        dynamic_cast<BasicAxisItem*>(detector_item->getItem(SphericalDetectorItem::P_ALPHA_AXIS));
-    ASSERT(alphaAxisItem);
-    alphaAxisItem->setItemValue(BasicAxisItem::P_NBINS, (int)alpha_axis.size());
-    alphaAxisItem->setItemValue(BasicAxisItem::P_MIN_DEG, Units::rad2deg(alpha_axis.lowerBound()));
-    alphaAxisItem->setItemValue(BasicAxisItem::P_MAX_DEG, Units::rad2deg(alpha_axis.upperBound()));
+    auto alphaAxisItem = detector_item->alphaAxisItem();
+    alphaAxisItem->setBinCount(alpha_axis.size());
+    alphaAxisItem->setLowerBound(Units::rad2deg(alpha_axis.lowerBound()));
+    alphaAxisItem->setUpperBound(Units::rad2deg(alpha_axis.upperBound()));
 }
 
 void TransformFromDomain::setRectangularDetector(RectangularDetectorItem* detector_item,

--- a/GUI/coregui/Views/InstrumentWidgets/DetectorMaskDelegate.cpp
+++ b/GUI/coregui/Views/InstrumentWidgets/DetectorMaskDelegate.cpp
@@ -60,11 +60,11 @@ void DetectorMaskDelegate::createIntensityDataItem()
     m_intensityItem->getItem(IntensityDataItem::P_PROJECTIONS_FLAG)->setEnabled(false);
     m_intensityItem->setItemValue(IntensityDataItem::P_IS_INTERPOLATED, false);
 
-    auto zAxisItem = m_intensityItem->item<AmplitudeAxisItem>(IntensityDataItem::P_ZAXIS);
+    auto zAxisItem = m_intensityItem->zAxisItem();
     zAxisItem->setItemValue(BasicAxisItem::P_IS_VISIBLE, false);
-    zAxisItem->setItemValue(BasicAxisItem::P_MIN_DEG, 0.0);
-    zAxisItem->setItemValue(BasicAxisItem::P_MAX_DEG, 2.0);
-    zAxisItem->setItemValue(AmplitudeAxisItem::P_IS_LOGSCALE, false);
+    zAxisItem->setLowerBound(0.0);
+    zAxisItem->setUpperBound(2.0);
+    zAxisItem->setLogScale(false);
     zAxisItem->setItemValue(AmplitudeAxisItem::P_LOCK_MIN_MAX, true);
 
     // creating output data corresponding to the detector

--- a/GUI/coregui/Views/InstrumentWidgets/RectangularDetectorEditor.cpp
+++ b/GUI/coregui/Views/InstrumentWidgets/RectangularDetectorEditor.cpp
@@ -15,6 +15,7 @@
 #include "GUI/coregui/Views/InstrumentWidgets/RectangularDetectorEditor.h"
 #include "GUI/coregui/Models/ComboProperty.h"
 #include "GUI/coregui/Models/RectangularDetectorItem.h"
+#include "GUI/coregui/Models/AxesItems.h"
 #include "GUI/coregui/Views/PropertyEditor/ComponentEditor.h"
 #include <QGridLayout>
 
@@ -101,12 +102,10 @@ void RectangularDetectorEditor::create_editors()
 void RectangularDetectorEditor::init_editors()
 {
     m_xAxisEditor->clearEditor();
-    auto xAxisItem = detectorItem()->getItem(RectangularDetectorItem::P_X_AXIS);
-    m_xAxisEditor->setItem(xAxisItem);
+    m_xAxisEditor->setItem(detectorItem()->xAxisItem());
 
     m_yAxisEditor->clearEditor();
-    auto yAxisItem = detectorItem()->getItem(RectangularDetectorItem::P_Y_AXIS);
-    m_yAxisEditor->setItem(yAxisItem);
+    m_yAxisEditor->setItem(detectorItem()->yAxisItem());
 
     m_resolutionFunctionEditor->clearEditor();
     auto resFuncGroup = detectorItem()->getItem(RectangularDetectorItem::P_RESOLUTION_FUNCTION);

--- a/GUI/coregui/Views/InstrumentWidgets/SphericalDetectorEditor.cpp
+++ b/GUI/coregui/Views/InstrumentWidgets/SphericalDetectorEditor.cpp
@@ -14,6 +14,7 @@
 
 #include "GUI/coregui/Views/InstrumentWidgets/SphericalDetectorEditor.h"
 #include "GUI/coregui/Models/SphericalDetectorItem.h"
+#include "GUI/coregui/Models/AxesItems.h"
 #include "GUI/coregui/Views/PropertyEditor/ComponentEditor.h"
 #include <QGridLayout>
 
@@ -45,10 +46,10 @@ SphericalDetectorEditor::SphericalDetectorEditor(QWidget* parent)
 
 void SphericalDetectorEditor::subscribeToItem()
 {
-    auto phiAxisItem = detectorItem()->getItem(SphericalDetectorItem::P_PHI_AXIS);
+    auto phiAxisItem = detectorItem()->phiAxisItem();
     m_phiAxisEditor->setItem(phiAxisItem);
 
-    auto alphaAxisItem = detectorItem()->getItem(SphericalDetectorItem::P_ALPHA_AXIS);
+    auto alphaAxisItem = detectorItem()->alphaAxisItem();
     m_alphaAxisEditor->setItem(alphaAxisItem);
 
     auto resFuncGroup = detectorItem()->getItem(SphericalDetectorItem::P_RESOLUTION_FUNCTION);

--- a/Tests/UnitTests/GUI/TestAxesItems.cpp
+++ b/Tests/UnitTests/GUI/TestAxesItems.cpp
@@ -10,6 +10,33 @@
 class TestAxesItems : public ::testing::Test {
 };
 
+TEST_F(TestAxesItems, gettersAndSettes)
+{
+    BasicAxisItem item;
+
+    item.setBinCount(42);
+    EXPECT_EQ(item.binCount(), 42);
+
+    item.setLowerBound(42.1);
+    EXPECT_EQ(item.lowerBound(), 42.1);
+
+    item.setUpperBound(42.2);
+    EXPECT_EQ(item.upperBound(), 42.2);
+
+    item.setTitle("abc");
+    EXPECT_EQ(item.title(), QString("abc"));
+}
+
+TEST_F(TestAxesItems, AmplitudeAxisGettersAndSetters)
+{
+    AmplitudeAxisItem item;
+
+    item.setLogScale(true);
+    EXPECT_TRUE(item.isLogScale());
+    item.setLogScale(false);
+    EXPECT_FALSE(item.isLogScale());
+}
+
 TEST_F(TestAxesItems, transformFromDomain)
 {
     BasicAxisItem item;


### PR DESCRIPTION
- Few getter/setters for axes related properties.
- Replace getItem with type-safe item<T> (where it was easy to do).
- Number of `getItem()` usages decreased from 385 to 292.
