### PR TITLE
Add single property items (i.e. VectorItem) via type safe mechanism

### DIFF
--- a/GUI/coregui/Models/BeamItems.cpp
+++ b/GUI/coregui/Models/BeamItems.cpp
@@ -48,8 +48,8 @@ BeamItem::BeamItem(const QString& beam_model) : SessionItem(beam_model)
         .setToolTip("Beam intensity in neutrons (or gammas) per sec.")
         .setEditorType("ScientificDouble");
 
-    addGroupProperty(P_AZIMUTHAL_ANGLE, "BeamAzimuthalAngle");
-    addGroupProperty(P_POLARIZATION, "Vector")->setToolTip(polarization_tooltip);
+    addProperty<BeamAzimuthalAngleItem>(P_AZIMUTHAL_ANGLE);
+    addProperty<VectorItem>(P_POLARIZATION)->setToolTip(polarization_tooltip);
 
     addTranslator(VectorParameterTranslator(P_POLARIZATION, "BlochVector"));
 }

--- a/GUI/coregui/Models/BeamItems.cpp
+++ b/GUI/coregui/Models/BeamItems.cpp
@@ -105,16 +105,6 @@ std::unique_ptr<Beam> BeamItem::createBeam() const
     return result;
 }
 
-void BeamItem::setInclinationProperty(const QString& inclination_type)
-{
-    addGroupProperty(P_INCLINATION_ANGLE, inclination_type);
-}
-
-void BeamItem::setWavelengthProperty(const QString& wavelength_type)
-{
-    addGroupProperty(P_WAVELENGTH, wavelength_type);
-}
-
 // Specular beam item
 /* ------------------------------------------------------------------------- */
 
@@ -124,8 +114,8 @@ const QString footprint_group_label("Type");
 
 SpecularBeamItem::SpecularBeamItem() : BeamItem("SpecularBeam")
 {
-    setInclinationProperty("SpecularBeamInclinationAxis");
-    setWavelengthProperty("SpecularBeamWavelength");
+    addProperty<SpecularBeamInclinationItem>(P_INCLINATION_ANGLE);
+    addProperty<SpecularBeamWavelengthItem>(P_WAVELENGTH);
 
     getItem(P_AZIMUTHAL_ANGLE)->setVisible(false);
     getItem(P_POLARIZATION)->setVisible(false);
@@ -216,8 +206,8 @@ void SpecularBeamItem::updateWavelength()
 
 GISASBeamItem::GISASBeamItem() : BeamItem("GISASBeam")
 {
-    setInclinationProperty("BeamInclinationAngle");
-    setWavelengthProperty("BeamWavelength");
+    addProperty<BeamInclinationAngleItem>(P_INCLINATION_ANGLE);
+    addProperty<BeamWavelengthItem>(P_WAVELENGTH);
 }
 
 GISASBeamItem::~GISASBeamItem() = default;

--- a/GUI/coregui/Models/BeamItems.h
+++ b/GUI/coregui/Models/BeamItems.h
@@ -49,9 +49,6 @@ public:
 
 protected:
     explicit BeamItem(const QString& beam_model);
-
-    void setInclinationProperty(const QString& inclination_type);
-    void setWavelengthProperty(const QString& wavelength_type);
 };
 
 class BA_CORE_API_ SpecularBeamItem : public BeamItem {

--- a/GUI/coregui/Models/Data1DViewItem.cpp
+++ b/GUI/coregui/Models/Data1DViewItem.cpp
@@ -40,16 +40,14 @@ Data1DViewItem::Data1DViewItem() : SessionItem("Data1DViewItem"), m_job_item(nul
 {
     addProperty(P_TITLE, QString())->setVisible(false);
 
-    SessionItem* item = addGroupProperty(P_XAXIS, "BasicAxis");
-    item->getItem(BasicAxisItem::P_NBINS)->setVisible(false);
+    auto basicAxis = addProperty<BasicAxisItem>(P_XAXIS);
+    basicAxis->getItem(BasicAxisItem::P_NBINS)->setVisible(false);
 
-    item = addGroupProperty(P_YAXIS, "AmplitudeAxis");
-    item->getItem(BasicAxisItem::P_NBINS)->setVisible(false);
-    item->getItem(BasicAxisItem::P_TITLE)->setVisible(true);
-
-    item = item->getItem(AmplitudeAxisItem::P_IS_VISIBLE);
-    item->setValue(true);
-    item->setVisible(false);
+    auto amplitudeAxis = addProperty<AmplitudeAxisItem>(P_YAXIS);
+    amplitudeAxis->getItem(BasicAxisItem::P_NBINS)->setVisible(false);
+    amplitudeAxis->getItem(BasicAxisItem::P_TITLE)->setVisible(true);
+    amplitudeAxis->getItem(AmplitudeAxisItem::P_IS_VISIBLE)->setValue(true);
+    amplitudeAxis->getItem(AmplitudeAxisItem::P_IS_VISIBLE)->setVisible(false);
 
     registerTag(T_DATA_PROPERTIES, 1, 1, QStringList() << "DataPropertyContainer");
 

--- a/GUI/coregui/Models/DepthProbeInstrumentItem.cpp
+++ b/GUI/coregui/Models/DepthProbeInstrumentItem.cpp
@@ -17,6 +17,7 @@
 #include "Core/Simulation/DepthProbeSimulation.h"
 #include "Device/Detector/SimpleUnitConverters.h"
 #include "GUI/coregui/Models/AxesItems.h"
+#include "GUI/coregui/Models/BeamItems.h"
 #include "GUI/coregui/Models/BeamWavelengthItem.h"
 #include "GUI/coregui/Models/SpecularBeamInclinationItem.h"
 #include "GUI/coregui/Models/TransformToDomain.h"
@@ -28,17 +29,17 @@ DepthProbeInstrumentItem::DepthProbeInstrumentItem() : InstrumentItem("DepthProb
 {
     setItemName("DepthProbeInstrument");
 
-    addGroupProperty(P_BEAM, "SpecularBeam");
+    addProperty<SpecularBeamItem>(P_BEAM);
 
     auto axisItem = beamItem()->currentInclinationAxisItem();
     axisItem->setLowerBound(0.0);
     axisItem->setUpperBound(1.0);
     axisItem->setBinCount(500);
 
-    auto axis = addGroupProperty(P_Z_AXIS, "BasicAxis");
+    auto axis = addProperty<BasicAxisItem>(P_Z_AXIS);
+    axis->setLowerBound(-100.0);
+    axis->setUpperBound(100.0);
     axis->getItem(BasicAxisItem::P_TITLE)->setVisible(false);
-    axis->setItemValue(BasicAxisItem::P_MIN_DEG, -100.0);
-    axis->setItemValue(BasicAxisItem::P_MAX_DEG, 100.0);
     axis->getItem(BasicAxisItem::P_NBINS)
         ->setToolTip("Number of points in scan across sample bulk");
     axis->getItem(BasicAxisItem::P_MIN_DEG)

--- a/GUI/coregui/Models/DetectorItems.cpp
+++ b/GUI/coregui/Models/DetectorItems.cpp
@@ -40,7 +40,7 @@ DetectorItem::DetectorItem(const QString& modelType) : SessionItem(modelType)
     registerTag(T_MASKS, 0, -1, QStringList() << "MaskContainer");
     setDefaultTag(T_MASKS);
 
-    addGroupProperty(P_ANALYZER_DIRECTION, "Vector")->setToolTip(analyzer_direction_tooltip);
+    addProperty<VectorItem>(P_ANALYZER_DIRECTION)->setToolTip(analyzer_direction_tooltip);
     addProperty(P_ANALYZER_EFFICIENCY, 0.0)
         ->setLimits(RealLimits::limitless())
         .setToolTip(analyzer_efficiency_tooltip);

--- a/GUI/coregui/Models/InstrumentItems.cpp
+++ b/GUI/coregui/Models/InstrumentItems.cpp
@@ -17,6 +17,7 @@
 #include "Device/Detector/IDetector2D.h"
 #include "Device/Instrument/Instrument.h"
 #include "GUI/coregui/Models/BackgroundItems.h"
+#include "GUI/coregui/Models/BeamItems.h"
 #include "GUI/coregui/Models/DataItem.h"
 #include "GUI/coregui/Models/DetectorItems.h"
 #include "GUI/coregui/Models/GroupItem.h"
@@ -90,11 +91,6 @@ InstrumentItem::InstrumentItem(const QString& modelType) : SessionItem(modelType
     addProperty(P_IDENTIFIER, GUIHelpers::createUuid())->setVisible(false);
 }
 
-void InstrumentItem::initBeamGroup(const QString& beam_model)
-{
-    addGroupProperty(P_BEAM, beam_model);
-}
-
 void InstrumentItem::initBackgroundGroup()
 {
     auto item = addGroupProperty(P_BACKGROUND, "Background group");
@@ -104,7 +100,8 @@ void InstrumentItem::initBackgroundGroup()
 
 SpecularInstrumentItem::SpecularInstrumentItem() : InstrumentItem("SpecularInstrument")
 {
-    initBeamGroup("SpecularBeam");
+    addProperty<SpecularBeamItem>(P_BEAM);
+
     initBackgroundGroup();
     item<SpecularBeamItem>(P_BEAM)->updateFileName(
         ItemFileNameUtils::instrumentDataFileName(*this));
@@ -181,7 +178,7 @@ const QString Instrument2DItem::P_DETECTOR = "Detector";
 
 Instrument2DItem::Instrument2DItem(const QString& modelType) : InstrumentItem(modelType)
 {
-    initBeamGroup("GISASBeam");
+    addProperty<GISASBeamItem>(P_BEAM);
     addGroupProperty(P_DETECTOR, "Detector group");
     initBackgroundGroup();
 

--- a/GUI/coregui/Models/InstrumentItems.cpp
+++ b/GUI/coregui/Models/InstrumentItems.cpp
@@ -284,15 +284,15 @@ void OffSpecularInstrumentItem::updateToRealData(const RealDataItem* dataItem)
 namespace {
 void addAxisGroupProperty(SessionItem* parent, const QString& tag)
 {
-    auto item = parent->addGroupProperty(tag, "BasicAxis");
-    item->setToolTip("Incoming alpha range [deg]");
-    item->getItem(BasicAxisItem::P_TITLE)->setVisible(false);
-    item->getItem(BasicAxisItem::P_NBINS)->setToolTip("Number of points in scan");
-    item->getItem(BasicAxisItem::P_MIN_DEG)->setToolTip("Starting value [deg]");
-    item->getItem(BasicAxisItem::P_MAX_DEG)->setToolTip("Ending value [deg]");
+    auto axisItem = parent->addProperty<BasicAxisItem>(tag);
+    axisItem->setToolTip("Incoming alpha range [deg]");
+    axisItem->getItem(BasicAxisItem::P_TITLE)->setVisible(false);
+    axisItem->getItem(BasicAxisItem::P_NBINS)->setToolTip("Number of points in scan");
+    axisItem->getItem(BasicAxisItem::P_MIN_DEG)->setToolTip("Starting value [deg]");
+    axisItem->getItem(BasicAxisItem::P_MAX_DEG)->setToolTip("Ending value [deg]");
 
-    item->setItemValue(BasicAxisItem::P_TITLE, "alpha_i");
-    item->setItemValue(BasicAxisItem::P_MIN_DEG, 0.0);
-    item->setItemValue(BasicAxisItem::P_MAX_DEG, 10.0);
+    axisItem->setTitle("alpha_i");
+    axisItem->setLowerBound(0.0);
+    axisItem->setUpperBound(10.0);
 }
 } // namespace

--- a/GUI/coregui/Models/InstrumentItems.h
+++ b/GUI/coregui/Models/InstrumentItems.h
@@ -48,7 +48,6 @@ public:
 protected:
     explicit InstrumentItem(const QString& modelType);
 
-    void initBeamGroup(const QString& beam_model);
     void initBackgroundGroup();
 };
 

--- a/GUI/coregui/Models/IntensityDataItem.cpp
+++ b/GUI/coregui/Models/IntensityDataItem.cpp
@@ -63,14 +63,14 @@ IntensityDataItem::IntensityDataItem() : DataItem("IntensityData")
     addProperty(P_IS_INTERPOLATED, true);
     addProperty(P_GRADIENT, gradientCombo().variant());
 
-    SessionItem* item = addGroupProperty(P_XAXIS, "BasicAxis");
-    item->getItem(BasicAxisItem::P_NBINS)->setVisible(false);
+    auto basicAxis = addProperty<BasicAxisItem>(P_XAXIS);
+    basicAxis->getItem(BasicAxisItem::P_NBINS)->setVisible(false);
 
-    item = addGroupProperty(P_YAXIS, "BasicAxis");
-    item->getItem(BasicAxisItem::P_NBINS)->setVisible(false);
+    basicAxis = addProperty<BasicAxisItem>(P_YAXIS);
+    basicAxis->getItem(BasicAxisItem::P_NBINS)->setVisible(false);
 
-    item = addGroupProperty(P_ZAXIS, "AmplitudeAxis");
-    item->getItem(BasicAxisItem::P_NBINS)->setVisible(false);
+    auto amplitudeAxis = addProperty<AmplitudeAxisItem>(P_ZAXIS);
+    amplitudeAxis->getItem(BasicAxisItem::P_NBINS)->setVisible(false);
 
     setXaxisTitle(x_axis_default_name);
     setYaxisTitle(y_axis_default_name);

--- a/GUI/coregui/Models/MaterialItem.cpp
+++ b/GUI/coregui/Models/MaterialItem.cpp
@@ -36,7 +36,7 @@ MaterialItem::MaterialItem() : SessionItem("Material")
     addProperty(P_COLOR, color.variant())->setEditorType("ExtColorEditor");
 
     addGroupProperty(P_MATERIAL_DATA, "Material data group");
-    addGroupProperty(P_MAGNETIZATION, "Vector")->setToolTip(magnetization_tooltip);
+    addProperty<VectorItem>(P_MAGNETIZATION)->setToolTip(magnetization_tooltip);
     addProperty(P_IDENTIFIER, GUIHelpers::createUuid());
     getItem(P_IDENTIFIER)->setVisible(false);
 }

--- a/GUI/coregui/Models/MesoCrystalItem.cpp
+++ b/GUI/coregui/Models/MesoCrystalItem.cpp
@@ -73,10 +73,10 @@ MesoCrystalItem::MesoCrystalItem() : SessionGraphicsItem("MesoCrystal")
         .setDecimals(3)
         .setToolTip(abundance_tooltip);
 
-    addGroupProperty(P_VECTOR_A, "Vector")->setToolTip(lattice_vector1_tooltip);
-    addGroupProperty(P_VECTOR_B, "Vector")->setToolTip(lattice_vector2_tooltip);
-    addGroupProperty(P_VECTOR_C, "Vector")->setToolTip(lattice_vector3_tooltip);
-    addGroupProperty(ParticleItem::P_POSITION, "Vector")->setToolTip(position_tooltip);
+    addProperty<VectorItem>(P_VECTOR_A)->setToolTip(lattice_vector1_tooltip);
+    addProperty<VectorItem>(P_VECTOR_B)->setToolTip(lattice_vector2_tooltip);
+    addProperty<VectorItem>(P_VECTOR_C)->setToolTip(lattice_vector3_tooltip);
+    addProperty<VectorItem>(ParticleItem::P_POSITION)->setToolTip(position_tooltip);
 
     registerTag(T_BASIS_PARTICLE, 0, 1,
                 QStringList() << "Particle"

--- a/GUI/coregui/Models/MultiLayerItem.cpp
+++ b/GUI/coregui/Models/MultiLayerItem.cpp
@@ -14,6 +14,7 @@
 
 #include "GUI/coregui/Models/MultiLayerItem.h"
 #include "GUI/coregui/Models/LayerItem.h"
+#include "GUI/coregui/Models/VectorItem.h"
 #include "GUI/coregui/Models/ParameterTranslators.h"
 
 namespace {
@@ -34,7 +35,7 @@ MultiLayerItem::MultiLayerItem() : SessionGraphicsItem("MultiLayer")
         ->setDecimals(5)
         .setToolTip("Cross correlation length of roughnesses \n"
                     "between interfaces in nanometers");
-    addGroupProperty(P_EXTERNAL_FIELD, "Vector")->setToolTip(external_field_tooltip);
+    addProperty<VectorItem>(P_EXTERNAL_FIELD)->setToolTip(external_field_tooltip);
 
     registerTag(T_LAYERS, 0, -1, QStringList() << "Layer");
     setDefaultTag(T_LAYERS);

--- a/GUI/coregui/Models/ParticleCompositionItem.cpp
+++ b/GUI/coregui/Models/ParticleCompositionItem.cpp
@@ -45,7 +45,7 @@ ParticleCompositionItem::ParticleCompositionItem() : SessionGraphicsItem("Partic
         .setDecimals(3)
         .setToolTip(abundance_tooltip);
 
-    addGroupProperty(ParticleItem::P_POSITION, "Vector")->setToolTip(position_tooltip);
+    addProperty<VectorItem>(ParticleItem::P_POSITION)->setToolTip(position_tooltip);
 
     registerTag(T_PARTICLES, 0, -1,
                 QStringList() << "Particle"

--- a/GUI/coregui/Models/ParticleCoreShellItem.cpp
+++ b/GUI/coregui/Models/ParticleCoreShellItem.cpp
@@ -45,7 +45,7 @@ ParticleCoreShellItem::ParticleCoreShellItem() : SessionGraphicsItem("ParticleCo
         .setDecimals(3)
         .setToolTip(abundance_tooltip);
 
-    addGroupProperty(ParticleItem::P_POSITION, "Vector")->setToolTip(position_tooltip);
+    addProperty<VectorItem>(ParticleItem::P_POSITION)->setToolTip(position_tooltip);
 
     registerTag(T_CORE, 0, 1, QStringList() << "Particle");
     registerTag(T_SHELL, 0, 1, QStringList() << "Particle");

--- a/GUI/coregui/Models/ParticleItem.cpp
+++ b/GUI/coregui/Models/ParticleItem.cpp
@@ -50,7 +50,7 @@ ParticleItem::ParticleItem() : SessionGraphicsItem("Particle")
         ->setLimits(RealLimits::limited(0.0, 1.0))
         .setDecimals(3)
         .setToolTip(abundance_tooltip);
-    addGroupProperty(P_POSITION, "Vector")->setToolTip(position_tooltip);
+    addProperty<VectorItem>(P_POSITION)->setToolTip(position_tooltip);
 
     registerTag(T_TRANSFORMATION, 0, 1, QStringList() << "Rotation");
     setDefaultTag(T_TRANSFORMATION);
@@ -61,7 +61,6 @@ ParticleItem::ParticleItem() : SessionGraphicsItem("Particle")
     mapper()->setOnParentChange(
         [this](SessionItem* newParent) { updatePropertiesAppearance(newParent); });
 }
-
 
 VectorItem* ParticleItem::positionItem() const
 {

--- a/GUI/coregui/Models/RectangularDetectorItem.cpp
+++ b/GUI/coregui/Models/RectangularDetectorItem.cpp
@@ -76,30 +76,30 @@ RectangularDetectorItem::RectangularDetectorItem()
     : DetectorItem("RectangularDetector"), m_is_constructed(false)
 {
     // axes parameters
-    SessionItem* item = addGroupProperty(P_X_AXIS, "BasicAxis");
-    item->getItem(BasicAxisItem::P_TITLE)->setVisible(false);
-    item->getItem(BasicAxisItem::P_MIN_DEG)->setVisible(false);
-    item->setItemValue(BasicAxisItem::P_MAX_DEG, default_detector_width);
-    item->getItem(BasicAxisItem::P_MAX_DEG)->setDisplayName("Width [mm]");
-    item->getItem(BasicAxisItem::P_MAX_DEG)->setToolTip("Width of the detector in mm");
+    auto axisItem = addProperty<BasicAxisItem>(P_X_AXIS);
+    axisItem->getItem(BasicAxisItem::P_TITLE)->setVisible(false);
+    axisItem->getItem(BasicAxisItem::P_MIN_DEG)->setVisible(false);
+    axisItem->setUpperBound(default_detector_width);
+    axisItem->getItem(BasicAxisItem::P_MAX_DEG)->setDisplayName("Width [mm]");
+    axisItem->getItem(BasicAxisItem::P_MAX_DEG)->setToolTip("Width of the detector in mm");
 
-    item = addGroupProperty(P_Y_AXIS, "BasicAxis");
-    item->getItem(BasicAxisItem::P_TITLE)->setVisible(false);
-    item->getItem(BasicAxisItem::P_MIN_DEG)->setVisible(false);
-    item->setItemValue(BasicAxisItem::P_MAX_DEG, default_detector_height);
-    item->getItem(BasicAxisItem::P_MAX_DEG)->setDisplayName("Height [mm]");
-    item->getItem(BasicAxisItem::P_MAX_DEG)->setToolTip("Height of the detector in mm");
+    axisItem = addProperty<BasicAxisItem>(P_Y_AXIS);
+    axisItem->getItem(BasicAxisItem::P_TITLE)->setVisible(false);
+    axisItem->getItem(BasicAxisItem::P_MIN_DEG)->setVisible(false);
+    axisItem->setUpperBound(default_detector_height);
+    axisItem->getItem(BasicAxisItem::P_MAX_DEG)->setDisplayName("Height [mm]");
+    axisItem->getItem(BasicAxisItem::P_MAX_DEG)->setToolTip("Height of the detector in mm");
 
     // alignment selector
     addProperty(P_ALIGNMENT, alignmentCombo().variant());
 
     // alignment parameters
-    item = addGroupProperty(P_NORMAL, "Vector");
-    item->setItemValue(VectorItem::P_X, default_detector_distance);
+    auto normalItem = addProperty<VectorItem>(P_NORMAL);
+    normalItem->setX(default_detector_distance);
 
     // direction
-    item = addGroupProperty(P_DIRECTION, "Vector");
-    item->setItemValue(VectorItem::P_Y, -1.0);
+    auto directionItem = addProperty<VectorItem>(P_DIRECTION);
+    directionItem->setY(-1.0);
 
     addProperty(P_U0, default_detector_width / 2.)
         ->setToolTip(tooltip_u0)

--- a/GUI/coregui/Models/SessionItem.cpp
+++ b/GUI/coregui/Models/SessionItem.cpp
@@ -20,6 +20,7 @@
 #include "GUI/coregui/Models/SessionItemUtils.h"
 #include "GUI/coregui/Models/SessionModel.h"
 #include "GUI/coregui/utils/GUIHelpers.h"
+#include <QDebug>
 
 const QString SessionItem::P_NAME = "Name";
 
@@ -320,6 +321,10 @@ SessionItem* SessionItem::addGroupProperty(const QString& groupTag, const QStrin
         registerTag(groupTag, 1, 1, QStringList() << "GroupProperty");
         result = groupItem;
     } else {
+        // # migration Remove this branch at any convenient occasion. It is not used anymore.
+        // # migration Suggestion is to throw if not SessionItemUtils::IsValidGroup(groupType)
+        qWarning() << "SessionItem::addGroupProperty() is obsolete for single property items. Use "
+                      "::addProperty<> instead.";
         // create single item
         registerTag(groupTag, 1, 1, QStringList() << groupType);
         result = ItemFactory::CreateItem(groupType);

--- a/GUI/coregui/Models/SessionItem.h
+++ b/GUI/coregui/Models/SessionItem.h
@@ -67,6 +67,10 @@ public:
 
     // convenience functions for properties
     SessionItem* addProperty(const QString& name, const QVariant& variant);
+
+    // #migration: templated addProperty will eventually replace addGroupProperty
+    template <typename T> T* addProperty(const QString& name);
+
     QVariant getItemValue(const QString& tag) const;
     void setItemValue(const QString& tag, const QVariant& variant);
 
@@ -143,6 +147,16 @@ template <typename T> T* SessionItem::item(const QString& tag) const
     T* t = dynamic_cast<T*>(getItem(tag));
     ASSERT(t);
     return t;
+}
+
+template <typename T> T* SessionItem::addProperty(const QString& tagname)
+{
+    auto property = new T;
+    property->setDisplayName(tagname);
+    registerTag(tagname, 1, 1, QStringList() << property->modelType());
+    bool success = insertItem(0, property, tagname);
+    ASSERT(success);
+    return property;
 }
 
 template <typename T> T& SessionItem::groupItem(const QString& groupName) const

--- a/GUI/coregui/Models/SpecularDataItem.cpp
+++ b/GUI/coregui/Models/SpecularDataItem.cpp
@@ -26,16 +26,15 @@ SpecularDataItem::SpecularDataItem() : DataItem("SpecularData")
 {
     addProperty(P_TITLE, QString())->setVisible(false);
 
-    SessionItem* item = addGroupProperty(P_XAXIS, "BasicAxis");
-    item->getItem(BasicAxisItem::P_NBINS)->setVisible(false);
+    auto basicAxis = addProperty<BasicAxisItem>(P_XAXIS);
+    basicAxis->getItem(BasicAxisItem::P_NBINS)->setVisible(false);
 
-    item = addGroupProperty(P_YAXIS, "AmplitudeAxis");
-    item->getItem(BasicAxisItem::P_NBINS)->setVisible(false);
-    item->getItem(BasicAxisItem::P_TITLE)->setVisible(true);
+    auto amplitudeAxis = addProperty<AmplitudeAxisItem>(P_YAXIS);
+    amplitudeAxis->getItem(BasicAxisItem::P_NBINS)->setVisible(false);
+    amplitudeAxis->getItem(BasicAxisItem::P_TITLE)->setVisible(true);
 
-    item = item->getItem(AmplitudeAxisItem::P_IS_VISIBLE);
-    item->setValue(true);
-    item->setVisible(false);
+    amplitudeAxis->getItem(AmplitudeAxisItem::P_IS_VISIBLE)->setValue(true);
+    amplitudeAxis->getItem(AmplitudeAxisItem::P_IS_VISIBLE)->setVisible(false);
 
     setXaxisTitle(SpecularDataAxesNames::x_axis_default_name);
     setYaxisTitle(SpecularDataAxesNames::y_axis_default_name);

--- a/GUI/coregui/Models/SphericalDetectorItem.cpp
+++ b/GUI/coregui/Models/SphericalDetectorItem.cpp
@@ -22,23 +22,25 @@ const QString SphericalDetectorItem::P_ALPHA_AXIS = "Alpha axis";
 
 SphericalDetectorItem::SphericalDetectorItem() : DetectorItem("SphericalDetector")
 {
-    SessionItem* item = addGroupProperty(P_PHI_AXIS, "BasicAxis");
-    item->getItem(BasicAxisItem::P_TITLE)->setVisible(false);
-    item->setItemValue(BasicAxisItem::P_MIN_DEG, -1.0);
-    item->setItemValue(BasicAxisItem::P_MAX_DEG, 1.0);
+    auto phiAxis = addProperty<BasicAxisItem>(P_PHI_AXIS);
+    phiAxis->getItem(BasicAxisItem::P_TITLE)->setVisible(false);
+    phiAxis->setLowerBound(-1.0);
+    phiAxis->setUpperBound(1.0);
 
-    item->getItem(BasicAxisItem::P_NBINS)->setToolTip("Number of phi-axis bins");
-    item->getItem(BasicAxisItem::P_MIN_DEG)->setToolTip("Low edge of first phi-bin (in deg)");
-    item->getItem(BasicAxisItem::P_MAX_DEG)->setToolTip("Upper edge of last phi-bin (in deg)");
+    phiAxis->getItem(BasicAxisItem::P_NBINS)->setToolTip("Number of phi-axis bins");
+    phiAxis->getItem(BasicAxisItem::P_MIN_DEG)->setToolTip("Low edge of first phi-bin (in deg)");
+    phiAxis->getItem(BasicAxisItem::P_MAX_DEG)->setToolTip("Upper edge of last phi-bin (in deg)");
 
-    item = addGroupProperty(P_ALPHA_AXIS, "BasicAxis");
-    item->getItem(BasicAxisItem::P_TITLE)->setVisible(false);
-    item->setItemValue(BasicAxisItem::P_MIN_DEG, 0.0);
-    item->setItemValue(BasicAxisItem::P_MAX_DEG, 2.0);
+    auto alphaAxis = addProperty<BasicAxisItem>(P_ALPHA_AXIS);
+    alphaAxis->getItem(BasicAxisItem::P_TITLE)->setVisible(false);
+    alphaAxis->setLowerBound(0.0);
+    alphaAxis->setUpperBound(2.0);
 
-    item->getItem(BasicAxisItem::P_NBINS)->setToolTip("Number of alpha-axis bins");
-    item->getItem(BasicAxisItem::P_MIN_DEG)->setToolTip("Low edge of first alpha-bin (in deg)");
-    item->getItem(BasicAxisItem::P_MAX_DEG)->setToolTip("Upper edge of last alpha-bin (in deg)");
+    alphaAxis->getItem(BasicAxisItem::P_NBINS)->setToolTip("Number of alpha-axis bins");
+    alphaAxis->getItem(BasicAxisItem::P_MIN_DEG)
+        ->setToolTip("Low edge of first alpha-bin (in deg)");
+    alphaAxis->getItem(BasicAxisItem::P_MAX_DEG)
+        ->setToolTip("Upper edge of last alpha-bin (in deg)");
 
     register_resolution_function();
 }


### PR DESCRIPTION
Provides the possibility to add a single property item via the type-safe addProperty<> method.
The final task is to replace addGroupProperty completely with a type-safe mechanism.

- [x] Number off addGroupProperty usages 55 -> 27.
- [x] Number off getItem usages 292 -> 257.
