### PR TITLE
add support for .dat file

### DIFF
--- a/gui2/dataloader/importfilewidget.cpp
+++ b/gui2/dataloader/importfilewidget.cpp
@@ -65,7 +65,7 @@ void ImportFileWidget::onAddFilesRequest()
 {
     QFileDialog dialog(this, "Select one or more files to load", m_currentWorkdir);
     dialog.setFileMode(QFileDialog::ExistingFiles);
-    dialog.setNameFilter("Text (*.txt *.csv);; Other (*.*)");
+    dialog.setNameFilter("Text (*.txt *.csv *.dat);; Other (*.*)");
     dialog.setOption(QFileDialog::DontUseNativeDialog);
     QStringList file_names = dialog.exec() ? dialog.selectedFiles() : QStringList();
 


### PR DESCRIPTION
Often reflectometry files are given the extension `.dat`. I have added this to the gui2 import menu as a quality of life improvement. 