### PR TITLE
Remove dependency from MVVM lib

### DIFF
--- a/GUI/coregui/CMakeLists.txt
+++ b/GUI/coregui/CMakeLists.txt
@@ -104,7 +104,6 @@ target_link_libraries(${library_name}
     Qt5::PrintSupport
     Qt5::Network
     qcustomplot
-    MVVM::View
 )
 
 # --- Installation ---------

--- a/GUI/coregui/Views/SampleDesigner/LayerView.cpp
+++ b/GUI/coregui/Views/SampleDesigner/LayerView.cpp
@@ -18,13 +18,12 @@
 #include "GUI/coregui/Views/SampleDesigner/MultiLayerView.h"
 #include "GUI/coregui/Views/SampleDesigner/ParticleLayoutView.h"
 #include "GUI/coregui/mainwindow/tooltipdatabase.h"
-#include "mvvm/widgets/widgetutils.h"
 #include <QPainter>
 #include <QStyleOptionGraphicsItem>
 
 LayerView::LayerView(QGraphicsItem* parent) : ILayerView(parent)
 {
-    setColor(ModelView::Utils::RandomColor());
+    setColor(QColor(qrand() % 256, qrand() % 256, qrand() % 256));
     setName("Layer");
     setRectangle(DesignerHelper::getDefaultBoundingRect("Layer"));
     setAcceptDrops(false);


### PR DESCRIPTION
MVVM dependency with current MAC pipeline causes runtime error on MAC (missing library when installing with one of the artifacts). This may be the case as well on Windows/Linux, but I didn't test it.

Since so far only one minor call is used from MVVM, this dependency has been removed.

Seems important for upcoming release 1.19.0
