### PR TITLE
Fix some memory issues

### DIFF
--- a/Sample/Multilayer/MultiLayer.cpp
+++ b/Sample/Multilayer/MultiLayer.cpp
@@ -40,11 +40,10 @@ MultiLayer* MultiLayer::clone() const
     ret->setRoughnessModel(roughnessModel());
     for (size_t i = 0; i < numberOfLayers(); ++i) {
         const auto* interface = i > 0 ? m_interfaces[i - 1] : nullptr;
-        Layer* layer = m_layers[i]->clone();
         if (i > 0 && interface->getRoughness())
-            ret->addLayerWithTopRoughness(*layer, *interface->getRoughness());
+            ret->addLayerWithTopRoughness(std::as_const(*m_layers[i]), *interface->getRoughness());
         else
-            ret->addLayer(*layer);
+            ret->addLayer(std::as_const(*m_layers[i]));
     }
     return ret;
 }

--- a/Tests/UnitTests/Core/Data/LLDataTest.cpp
+++ b/Tests/UnitTests/Core/Data/LLDataTest.cpp
@@ -6,6 +6,7 @@
 class LLDataTest : public ::testing::Test {
 protected:
     LLDataTest();
+    ~LLDataTest();
 
     LLData<int>* int_data_0d;
     LLData<float>* fl_data_1d;
@@ -35,6 +36,26 @@ LLDataTest::LLDataTest()
     db_data_3d = new LLData<double>(3u, dim3);
 
     matrix_data_2d = new LLData<Eigen::Matrix2d>(2u, dim2);
+
+    delete[] dim0;
+    delete[] dim1;
+    delete[] dim2;
+    delete[] dim3;
+}
+
+LLDataTest::~LLDataTest()
+{
+    if(int_data_0d)
+        delete int_data_0d;
+
+    if(fl_data_1d)
+        delete fl_data_1d;
+
+    if(db_data_3d)
+        delete db_data_3d;
+
+    if(matrix_data_2d)
+        delete matrix_data_2d;
 }
 
 TEST_F(LLDataTest, TotalSize)

--- a/Tests/UnitTests/Core/Data/OutputDataIteratorTest.cpp
+++ b/Tests/UnitTests/Core/Data/OutputDataIteratorTest.cpp
@@ -21,6 +21,7 @@ OutputDataIteratorTest::OutputDataIteratorTest()
         value += 1.0;
         ++it;
     }
+    delete[] dims;
 }
 
 TEST_F(OutputDataIteratorTest, Iterate)

--- a/Tests/UnitTests/Core/Fresnel/DepthProbeSimulationTest.cpp
+++ b/Tests/UnitTests/Core/Fresnel/DepthProbeSimulationTest.cpp
@@ -93,6 +93,7 @@ TEST_F(DepthProbeSimulationTest, CheckAxesOfDefaultSimulation)
     const auto sim_clone = sim->clone();
     EXPECT_FALSE(alpha_axis == sim_clone->getAlphaAxis());
     EXPECT_FALSE(z_axis == sim_clone->getZAxis());
+    delete sim_clone;
 }
 
 TEST_F(DepthProbeSimulationTest, SetBeamParameters)

--- a/Tests/UnitTests/Core/Sample/FormFactorBasicTest.cpp
+++ b/Tests/UnitTests/Core/Sample/FormFactorBasicTest.cpp
@@ -58,6 +58,7 @@ protected:
         EXPECT_EQ(clone->volume(), V);
         cvector_t q(.1, .2, complex_t(.3, .004));
         EXPECT_EQ(clone->evaluate_for_q(q), p->evaluate_for_q(q));
+        delete clone;
     }
     double V, R;
 };

--- a/Tests/UnitTests/Core/Sample/ParticleCoreShellTest.cpp
+++ b/Tests/UnitTests/Core/Sample/ParticleCoreShellTest.cpp
@@ -65,6 +65,7 @@ TEST_F(ParticleCoreShellTest, ComplexCoreShellClone)
     ParticleCoreShell* clone = coreshell.clone();
     EXPECT_EQ(coreshell.coreParticle()->position(), relative_pos);
     EXPECT_EQ(clone->coreParticle()->position(), relative_pos);
+    delete clone;
 }
 
 TEST_F(ParticleCoreShellTest, getChildren)

--- a/Tests/UnitTests/Core/Sample/ParticleLayoutTest.cpp
+++ b/Tests/UnitTests/Core/Sample/ParticleLayoutTest.cpp
@@ -147,6 +147,7 @@ TEST_F(ParticleLayoutTest, ParticleLayoutClone)
     auto p_iff = node_progeny::OnlyChildOfType<IInterferenceFunction>(*clone);
 
     EXPECT_TRUE(nullptr != p_iff);
+    delete clone;
 }
 
 TEST_F(ParticleLayoutTest, ParticleLayoutInterferenceFunction)

--- a/Tests/UnitTests/Core/Sample/ParticleTest.cpp
+++ b/Tests/UnitTests/Core/Sample/ParticleTest.cpp
@@ -35,13 +35,15 @@ TEST_F(ParticleTest, Constructors)
     // construction with form factor
     std::unique_ptr<Particle> p2(new Particle(mat, sphere));
     EXPECT_EQ(mat, *p2->material());
-    EXPECT_TRUE(dynamic_cast<FormFactorDecoratorMaterial*>(p2->createFormFactor()));
+    auto p2_formfactor = std::unique_ptr<IFormFactor>(p2->createFormFactor());
+    EXPECT_TRUE(dynamic_cast<FormFactorDecoratorMaterial*>(p2_formfactor.get()));
     EXPECT_EQ(nullptr, p2->rotation());
 
     // construction with transformation
     std::unique_ptr<Particle> p3(new Particle(mat, sphere, transform));
     EXPECT_EQ(mat, *p3->material());
-    EXPECT_TRUE(dynamic_cast<FormFactorDecoratorMaterial*>(p3->createFormFactor()));
+    auto p3_formfactor = std::unique_ptr<IFormFactor>(p3->createFormFactor());
+    EXPECT_TRUE(dynamic_cast<FormFactorDecoratorMaterial*>(p3_formfactor.get()));
 }
 
 TEST_F(ParticleTest, setters)


### PR DESCRIPTION
This fixes a memory leak in the multilayer. Furthermore in the unit tests correct release of acquired memory is ensured.